### PR TITLE
fix(training): add missing Litharch case to UnitFactory

### DIFF
--- a/Assets/Scripts/Entities/Units/UnitFactory.cs
+++ b/Assets/Scripts/Entities/Units/UnitFactory.cs
@@ -21,7 +21,7 @@ namespace TheWaningBorder.Entities
         /// Automatically loads stats from TechTreeDB if available.
         /// </summary>
         /// <param name="em">EntityManager</param>
-        /// <param name="unitId">Unit type: "Builder", "Miner", "Swordsman", "Archer", "Scout"</param>
+        /// <param name="unitId">Unit type: "Builder", "Miner", "Swordsman", "Archer", "Scout", "Litharch"</param>
         /// <param name="position">World position to spawn at</param>
         /// <param name="faction">Faction the unit belongs to</param>
         /// <returns>Created entity</returns>
@@ -34,6 +34,7 @@ namespace TheWaningBorder.Entities
                 "Swordsman" => Swordsman.Create(em, position, faction),
                 "Archer" => Archer.Create(em, position, faction),
                 "Scout" => Scout.Create(em, position, faction),
+                "Litharch" => Litharch.Create(em, position, faction),
                 "Berserker" or "Feraldis_Berserker" => Berserker.Create(em, position, faction),
                 _ => CreateDefault(em, unitId, position, faction)
             };
@@ -52,6 +53,7 @@ namespace TheWaningBorder.Entities
                 "Swordsman" => Swordsman.Create(ecb, position, faction),
                 "Archer" => Archer.Create(ecb, position, faction),
                 "Scout" => Scout.Create(ecb, position, faction),
+                "Litharch" => Litharch.Create(ecb, position, faction),
                 "Berserker" or "Feraldis_Berserker" => Berserker.Create(ecb, position, faction),
                 _ => CreateDefault(ecb, unitId, position, faction)
             };
@@ -69,6 +71,7 @@ namespace TheWaningBorder.Entities
                 "Swordsman" => 1,
                 "Archer" => 1,
                 "Scout" => 1,
+                "Litharch" => 1,
                 "Berserker" or "Feraldis_Berserker" => 1,
                 _ => 1
             };
@@ -86,6 +89,7 @@ namespace TheWaningBorder.Entities
                 "Swordsman" => UnitClass.Melee,
                 "Archer" => UnitClass.Ranged,
                 "Scout" => UnitClass.Scout,
+                "Litharch" => UnitClass.Support,
                 "Berserker" or "Feraldis_Berserker" => UnitClass.Melee,
                 _ => UnitClass.Melee
             };
@@ -103,6 +107,7 @@ namespace TheWaningBorder.Entities
                 "Archer" => 202,
                 "Miner" => 203,
                 "Scout" => 206,
+                "Litharch" => 207,
                 "Berserker" or "Feraldis_Berserker" => 210,
                 _ => 201
             };


### PR DESCRIPTION
## Summary
Closes #3

Adds the missing `"Litharch"` case to all 5 switch statements in `UnitFactory.cs`, fixing the bug where passing `"Litharch"` to `UnitFactory.Create()` silently fell through to the default branch and spawned a Swordsman instead.

## Changes
- **`Create(EntityManager)`**: Added `"Litharch" => Litharch.Create(em, position, faction)`
- **`Create(EntityCommandBuffer)`**: Added `"Litharch" => Litharch.Create(ecb, position, faction)`
- **`GetPopulationCost`**: Added `"Litharch" => 1` (matches `FactionPopulation.cs`)
- **`GetUnitClass`**: Added `"Litharch" => UnitClass.Support` (matches `Litharch.Create()` component setup)
- **`GetPresentationId`**: Added `"Litharch" => 207` (matches `PresentationSpawnSystem` mapping)
- **XML doc**: Updated `unitId` param documentation to include `"Litharch"`

## Spec Reference
Implements spec from issue #3 comment.

## Verification Checklist
- [x] All 5 switch statements updated consistently
- [x] Population cost (1) matches `FactionPopulation.cs`
- [x] Unit class (`Support`) matches `Litharch.Create()` component
- [x] Presentation ID (207) matches `PresentationSpawnSystem`
- [x] No other files modified (per spec scope)
- [x] No namespace imports needed (`Litharch` is in same `TheWaningBorder.Entities` namespace)