### PR TITLE
fix(building): add missing choice building ECB methods

### DIFF
--- a/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
+++ b/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
@@ -55,6 +55,9 @@ namespace TheWaningBorder.Entities
                 "Barracks" => Barracks.Create(ecb, position, faction),
                 "Hut" => Hut.Create(ecb, position, faction),
                 "GatherersHut" => GatherersHut.Create(ecb, position, faction),
+                "TempleOfRidan" => CreateTempleOfRidanECB(ecb, position, faction),
+                "VaultOfAlmierra" => CreateVaultOfAlmierraECB(ecb, position, faction),
+                "FiendstoneKeep" => CreateFiendstoneKeepECB(ecb, position, faction),
                 "Alanthor_Smelter" => Smelter.Create(ecb, position, faction),
                 _ => CreateDefault(ecb, buildingId, position, faction)
             };


### PR DESCRIPTION
## Summary

- Add `CreateTempleOfRidanECB`, `CreateVaultOfAlmierraECB`, and `CreateFiendstoneKeepECB` private methods to `BuildingFactory` with full component parity to the existing EntityManager versions
- Wire all 3 new cases into the `EntityCommandBuffer` overload switch statement so choice buildings no longer fall through to `CreateDefault`

## Details

The ECB overload of `BuildingFactory.Create` was missing switch cases for the 3 choice buildings (`TempleOfRidan`, `VaultOfAlmierra`, `FiendstoneKeep`). When created via the ECB path, they fell through to `CreateDefault` and became generic buildings, losing all their special components:

| Building | Special Components Restored |
|----------|----------------------------|
| TempleOfRidan | `TempleTag`, `ChoiceBuildingTag`, `TrainingState`, `TrainQueueItem` buffer, `RallyPoint` |
| VaultOfAlmierra | `VaultTag`, `ChoiceBuildingTag`, `VaultStorage` (interest rate, lock duration) |
| FiendstoneKeep | `FiendstoneKeepTag`, `ChoiceBuildingTag`, `BuildingRangedAttack`, `PopulationProvider`, `BuildingTag.IsBase=1` |

Each ECB method mirrors the corresponding EM method exactly: same TechTreeDB stat loading, same default values, same component set.

## Test plan

- [ ] Verify `BuildingFactory.Create(ecb, "TempleOfRidan", ...)` produces an entity with `TempleTag`, `ChoiceBuildingTag`, `TrainingState`, `TrainQueueItem` buffer, and `RallyPoint`
- [ ] Verify `BuildingFactory.Create(ecb, "VaultOfAlmierra", ...)` produces an entity with `VaultTag`, `ChoiceBuildingTag`, and `VaultStorage`
- [ ] Verify `BuildingFactory.Create(ecb, "FiendstoneKeep", ...)` produces an entity with `FiendstoneKeepTag`, `ChoiceBuildingTag`, `BuildingRangedAttack`, `PopulationProvider`, and `IsBase=1`
- [ ] Confirm no compile errors in Unity
- [ ] Existing EM-based building creation (player placement) is unaffected

Fixes #4

?? Generated with [Claude Code](https://claude.com/claude-code)