### PR TITLE
feat(mining): implement GatherCommand nearest deposit search

### DIFF
--- a/Assets/Scripts/Core/Commands/CommandTypes/GatherCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/GatherCommand.cs
@@ -2,8 +2,11 @@
 // Gather/mining command component and execution logic
 // Location: Assets/Scripts/Core/Commands/CommandTypes/GatherCommand.cs
 
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.AI;
 
 namespace TheWaningBorder.Core.Commands.Types
 {
@@ -57,13 +60,141 @@ namespace TheWaningBorder.Core.Commands.Types
         }
 
         /// <summary>
-        /// Find nearest deposit location for a miner
+        /// Find nearest non-depleted resource deposit (iron mine or cadaver) within the
+        /// miner's LineOfSight radius. Returns Entity.Null if nothing is in range.
         /// </summary>
         public static Entity FindNearestDeposit(EntityManager em, Entity miner, Faction faction)
         {
-            // TODO: Implement proper nearest deposit search
-            // For now, return Entity.Null and let the gathering system handle it
-            return Entity.Null;
+            if (!em.Exists(miner)) return Entity.Null;
+            if (!em.HasComponent<LocalTransform>(miner)) return Entity.Null;
+
+            float3 minerPos = em.GetComponentData<LocalTransform>(miner).Position;
+
+            // Use LineOfSight radius if available, otherwise a sensible default
+            float searchRadius = em.HasComponent<LineOfSight>(miner)
+                ? em.GetComponentData<LineOfSight>(miner).Radius
+                : 30f;
+
+            Entity nearest = Entity.Null;
+            float nearestDist = float.MaxValue;
+
+            // Search iron deposits
+            var ironQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<IronMineTag>(),
+                ComponentType.ReadOnly<IronDepositState>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using (var ironEntities = ironQuery.ToEntityArray(Allocator.Temp))
+            using (var ironStates = ironQuery.ToComponentDataArray<IronDepositState>(Allocator.Temp))
+            using (var ironTransforms = ironQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp))
+            {
+                for (int i = 0; i < ironEntities.Length; i++)
+                {
+                    if (ironStates[i].Depleted == 1) continue;
+
+                    float dist = DistXZ(minerPos, ironTransforms[i].Position);
+                    if (dist <= searchRadius && dist < nearestDist)
+                    {
+                        nearest = ironEntities[i];
+                        nearestDist = dist;
+                    }
+                }
+            }
+
+            // Search cadavers (crystal sources)
+            var cadaverQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<CadaverTag>(),
+                ComponentType.ReadOnly<CadaverState>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using (var cadaverEntities = cadaverQuery.ToEntityArray(Allocator.Temp))
+            using (var cadaverStates = cadaverQuery.ToComponentDataArray<CadaverState>(Allocator.Temp))
+            using (var cadaverTransforms = cadaverQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp))
+            {
+                for (int i = 0; i < cadaverEntities.Length; i++)
+                {
+                    if (cadaverStates[i].Depleted == 1) continue;
+
+                    float dist = DistXZ(minerPos, cadaverTransforms[i].Position);
+                    if (dist <= searchRadius && dist < nearestDist)
+                    {
+                        nearest = cadaverEntities[i];
+                        nearestDist = dist;
+                    }
+                }
+            }
+
+            return nearest;
+        }
+
+        /// <summary>
+        /// Find the nearest non-depleted resource deposit (iron mine or cadaver) within
+        /// a radius of a given world position. Used by input system for click-near-deposit.
+        /// </summary>
+        public static Entity FindNearestDepositNearPosition(EntityManager em, float3 position, float searchRadius)
+        {
+            Entity nearest = Entity.Null;
+            float nearestDist = float.MaxValue;
+
+            // Search iron deposits
+            var ironQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<IronMineTag>(),
+                ComponentType.ReadOnly<IronDepositState>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using (var ironEntities = ironQuery.ToEntityArray(Allocator.Temp))
+            using (var ironStates = ironQuery.ToComponentDataArray<IronDepositState>(Allocator.Temp))
+            using (var ironTransforms = ironQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp))
+            {
+                for (int i = 0; i < ironEntities.Length; i++)
+                {
+                    if (ironStates[i].Depleted == 1) continue;
+
+                    float dist = DistXZ(position, ironTransforms[i].Position);
+                    if (dist <= searchRadius && dist < nearestDist)
+                    {
+                        nearest = ironEntities[i];
+                        nearestDist = dist;
+                    }
+                }
+            }
+
+            // Search cadavers (crystal sources)
+            var cadaverQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<CadaverTag>(),
+                ComponentType.ReadOnly<CadaverState>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using (var cadaverEntities = cadaverQuery.ToEntityArray(Allocator.Temp))
+            using (var cadaverStates = cadaverQuery.ToComponentDataArray<CadaverState>(Allocator.Temp))
+            using (var cadaverTransforms = cadaverQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp))
+            {
+                for (int i = 0; i < cadaverEntities.Length; i++)
+                {
+                    if (cadaverStates[i].Depleted == 1) continue;
+
+                    float dist = DistXZ(position, cadaverTransforms[i].Position);
+                    if (dist <= searchRadius && dist < nearestDist)
+                    {
+                        nearest = cadaverEntities[i];
+                        nearestDist = dist;
+                    }
+                }
+            }
+
+            return nearest;
+        }
+
+        /// <summary>
+        /// XZ-only (horizontal) distance -- ignores Y so terrain height doesn't break range checks.
+        /// </summary>
+        private static float DistXZ(float3 a, float3 b)
+        {
+            return math.distance(new float2(a.x, a.z), new float2(b.x, b.z));
         }
 
         private static void SetupGather(EntityManager em, Entity miner, Entity resourceNode, Entity depositLocation)

--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -262,6 +262,16 @@ namespace TheWaningBorder.Input
 
                 case TargetType.Ground:
                 default:
+                    // If miners are selected and click is near a deposit, gather instead of move
+                    if (capabilities.CanGather)
+                    {
+                        Entity nearbyDeposit = FindNearestResourceNearClick(clickWorld);
+                        if (nearbyDeposit != Entity.Null)
+                        {
+                            IssueGatherCommands(nearbyDeposit);
+                            break;
+                        }
+                    }
                     IssueFormationMove(clickWorld);
                     break;
             }
@@ -864,7 +874,30 @@ namespace TheWaningBorder.Input
             ents.Dispose();
             return nearest;
         }
-        
+
+        /// <summary>
+        /// Searches for the nearest non-depleted resource deposit (iron mine or cadaver)
+        /// near the click position. Uses the first selected miner's LineOfSight radius
+        /// as the search range, or 30 units as a fallback.
+        /// </summary>
+        private Entity FindNearestResourceNearClick(float3 clickPos)
+        {
+            // Determine search radius from the first selected miner's LOS
+            float searchRadius = 30f;
+            foreach (var e in SelectionSystem.CurrentSelection)
+            {
+                if (!_em.Exists(e)) continue;
+                if (!IsOwnedByLocalPlayer(e)) continue;
+                if (!_em.HasComponent<MinerTag>(e)) continue;
+
+                if (_em.HasComponent<LineOfSight>(e))
+                    searchRadius = _em.GetComponentData<LineOfSight>(e).Radius;
+                break;
+            }
+
+            return GatherCommandHelper.FindNearestDepositNearPosition(_em, clickPos, searchRadius);
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // RAYCASTING
         // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Implement `GatherCommandHelper.FindNearestDeposit()` to search for nearest non-depleted iron mine or cadaver within LineOfSight range
- Add `FindNearestDepositNearPosition()` for position-based searches used by the input system
- Update `RTSInputManager.HandleRightClick()` to check for nearby deposits when miners right-click ground, issuing gather commands instead of formation moves

## Details
When a player right-clicks ground near a deposit with miners selected, the system now:
1. Gets the first selected miner's LineOfSight radius (default 30 units)
2. Searches for non-depleted IronMineTag or CadaverTag entities within that radius of the click point
3. If found, issues gather commands to the nearest deposit instead of a formation move
4. If no deposit is nearby, falls through to normal formation move behavior

## Files Changed
- `Assets/Scripts/Core/Commands/CommandTypes/GatherCommand.cs` - Implemented FindNearestDeposit + added FindNearestDepositNearPosition
- `Assets/Scripts/Input/RTSInputManager.cs` - Added deposit proximity check in ground-click handler + FindNearestResourceNearClick helper

## Test Plan
- [ ] Select miners, right-click ground near an iron deposit → miners auto-assign and start mining
- [ ] Select miners, right-click ground near a cadaver → miners gather crystal
- [ ] Select miners, right-click ground far from any deposit → miners move normally
- [ ] Select non-miner units, right-click ground near deposit → units move normally
- [ ] Mixed selection near deposit → miners gather, soldiers move

Closes #7