### PR TITLE
feat(combat): implement HealCommand nearest target search

### DIFF
--- a/Assets/Scripts/Core/Commands/CommandTypes/HealCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/HealCommand.cs
@@ -2,6 +2,7 @@
 // Heal command component and execution logic
 // Location: Assets/Scripts/Core/Commands/CommandTypes/HealCommand.cs
 
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
@@ -93,9 +94,58 @@ namespace TheWaningBorder.Core.Commands.Types
             var healerFaction = em.GetComponentData<FactionTag>(healer).Value;
             var healerPos = em.GetComponentData<LocalTransform>(healer).Position;
 
-            // TODO: Implement proper nearest target search
-            // For now, return Entity.Null
-            return Entity.Null;
+            // Query all units that could be heal candidates
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<Health>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            var entities = query.ToEntityArray(Allocator.Temp);
+            var healths = query.ToComponentDataArray<Health>(Allocator.Temp);
+            var factions = query.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+
+            Entity bestTarget = Entity.Null;
+            float bestDist = float.MaxValue;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                // Skip self
+                if (entities[i] == healer) continue;
+
+                // Same faction only
+                if (factions[i].Value != healerFaction) continue;
+
+                // Skip unhealable units
+                if (em.HasComponent<UnhealableTag>(entities[i])) continue;
+
+                // Skip dead units
+                if (healths[i].Value <= 0) continue;
+
+                // Skip full-health units
+                if (healths[i].Value >= healths[i].Max) continue;
+
+                // XZ distance check
+                float dist = math.distance(
+                    new float2(healerPos.x, healerPos.z),
+                    new float2(transforms[i].Position.x, transforms[i].Position.z)
+                );
+
+                if (dist <= maxRange && dist < bestDist)
+                {
+                    bestDist = dist;
+                    bestTarget = entities[i];
+                }
+            }
+
+            entities.Dispose();
+            healths.Dispose();
+            factions.Dispose();
+            transforms.Dispose();
+
+            return bestTarget;
         }
 
         private static void SetupHeal(EntityManager em, Entity healer, Entity target)


### PR DESCRIPTION
Closes #8

## Summary
- Implemented `FindNearestHealTarget()` in `HealCommandHelper` which was a stub returning `Entity.Null`
- Uses `EntityManager.CreateEntityQuery` to find all `UnitTag` entities with `Health`, `FactionTag`, and `LocalTransform`
- Iterates candidates to find nearest same-faction injured unit within `maxRange`
- Skips self, dead units, full-health units, and `UnhealableTag` entities
- Mirrors the proven search pattern from `LitharchHealingSystem` Phase 2

## Files Changed
| File | Change |
|------|--------|
| `Assets/Scripts/Core/Commands/CommandTypes/HealCommand.cs` | Implemented `FindNearestHealTarget()` body + added `Unity.Collections` using |

## Test Plan
- [ ] Litharch auto-finds nearest injured friendly unit when `FindNearestHealTarget` is called
- [ ] Only targets same-faction units (no cross-faction healing)
- [ ] Respects `maxRange` parameter
- [ ] Skips dead, full-health, and `UnhealableTag` units
- [ ] No compile errors in Unity

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)