### PR TITLE
feat(input): double-click to select all units of same type

### DIFF
--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -1036,9 +1036,11 @@ namespace TheWaningBorder.Input
         {
             if (!showHelp) return;
             
-            GUILayout.BeginArea(new Rect(10, 10, 300, 260));
+            GUILayout.BeginArea(new Rect(10, 10, 300, 300));
             GUILayout.Label("Controls:");
             GUILayout.Label("Left-click: Select unit");
+            GUILayout.Label("Double-click: Select all of type on screen");
+            GUILayout.Label("Ctrl+Double-click: Select all of type (map)");
             GUILayout.Label("Left-drag: Box select");
             GUILayout.Label("Right-click: Move/Attack/Gather");
             GUILayout.Label("A + Right-click: Attack-move");

--- a/Assets/Scripts/Input/SelectionSystem.cs
+++ b/Assets/Scripts/Input/SelectionSystem.cs
@@ -1,5 +1,5 @@
 // SelectionSystem.cs
-// Handles entity selection (click and box select)
+// Handles entity selection (click, double-click, and box select)
 // Part of: Input/
 
 using System.Collections.Generic;
@@ -17,8 +17,10 @@ namespace TheWaningBorder.Input
 {
     /// <summary>
     /// Manages entity selection for the local player.
-    /// Supports single-click selection and drag box selection.
-    /// 
+    /// Supports single-click, double-click (select all of same type), and drag box selection.
+    /// Double-click selects all on-screen units of the same UnitClass.
+    /// Ctrl+double-click selects all units of that type map-wide.
+    ///
     /// Static access: SelectionSystem.CurrentSelection
     /// </summary>
     public class SelectionSystem : MonoBehaviour
@@ -95,6 +97,12 @@ namespace TheWaningBorder.Input
         // GUI textures
         private Texture2D _boxTexture;
         private Texture2D _borderTexture;
+
+        // Double-click detection
+        private const float DoubleClickThreshold = 0.3f;
+        private float _lastClickTime = -1f;
+        private UnitClass _lastClickedClass;
+        private bool _lastClickWasUnit;
         
         // ═══════════════════════════════════════════════════════════════════════
         // LIFECYCLE
@@ -208,14 +216,97 @@ namespace TheWaningBorder.Input
         private void ClickSelect()
         {
             var e = RaycastPickEntity();
+            float now = Time.time;
+
+            // Check for double-click on a unit of the same type
+            if (e != Entity.Null && _em.Exists(e) && IsSelectableByPlayer(e)
+                && _em.HasComponent<UnitTag>(e) && IsOwnedByPlayer(e))
+            {
+                var clickedClass = _em.GetComponentData<UnitTag>(e).Class;
+
+                if (_lastClickWasUnit
+                    && clickedClass == _lastClickedClass
+                    && (now - _lastClickTime) < DoubleClickThreshold)
+                {
+                    // Double-click detected: select all units of this type
+                    bool mapWide = UnityEngine.Input.GetKey(KeyCode.LeftControl)
+                                || UnityEngine.Input.GetKey(KeyCode.RightControl);
+                    SelectAllOfType(clickedClass, mapWide);
+
+                    // Reset so a third click doesn't re-trigger
+                    _lastClickWasUnit = false;
+                    _lastClickTime = -1f;
+                    return;
+                }
+
+                // Record this click for potential double-click
+                _lastClickTime = now;
+                _lastClickedClass = clickedClass;
+                _lastClickWasUnit = true;
+            }
+            else
+            {
+                // Clicked something that isn't an owned unit — reset tracking
+                _lastClickWasUnit = false;
+                _lastClickTime = -1f;
+            }
+
+            // Normal single-click selection
             _selection.Clear();
-            
+
             if (e != Entity.Null && _em.Exists(e) && IsSelectableByPlayer(e))
             {
                 _selection.Add(e);
             }
         }
         
+        // ═══════════════════════════════════════════════════════════════════════
+        // DOUBLE-CLICK SELECT ALL OF TYPE
+        // ═══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Selects all player-owned units of the given UnitClass.
+        /// If mapWide is false, only units currently visible on screen are selected.
+        /// If mapWide is true (Ctrl+double-click), all units of that type are selected regardless of screen position.
+        /// </summary>
+        private void SelectAllOfType(UnitClass unitClass, bool mapWide)
+        {
+            var cam = Camera.main;
+            if (!cam && !mapWide) return;
+
+            _selection.Clear();
+
+            var query = _em.CreateEntityQuery(typeof(LocalTransform), typeof(FactionTag), typeof(UnitTag));
+            var ents = query.ToEntityArray(Allocator.Temp);
+
+            float screenW = Screen.width;
+            float screenH = Screen.height;
+
+            for (int i = 0; i < ents.Length; i++)
+            {
+                var e = ents[i];
+                if (!_em.Exists(e)) continue;
+                if (!IsOwnedByPlayer(e)) continue;
+                if (_em.GetComponentData<UnitTag>(e).Class != unitClass) continue;
+
+                if (!mapWide)
+                {
+                    // Check that the unit is on screen
+                    var pos = _em.GetComponentData<LocalTransform>(e).Position;
+                    Vector3 screenPos = cam.WorldToScreenPoint(new Vector3(pos.x, pos.y, pos.z));
+
+                    // Behind camera or outside viewport
+                    if (screenPos.z <= 0f) continue;
+                    if (screenPos.x < 0f || screenPos.x > screenW) continue;
+                    if (screenPos.y < 0f || screenPos.y > screenH) continue;
+                }
+
+                _selection.Add(e);
+            }
+
+            ents.Dispose();
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // BOX SELECTION
         // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Double-click an owned unit to select all visible units of the same `UnitClass` on screen
- Ctrl+double-click extends selection map-wide (ignores viewport bounds)
- Uses 0.3s threshold consistent with existing `ControlGroupSystem` double-tap

Closes #21

## Changes
- `SelectionSystem.cs`: Added double-click detection in `ClickSelect()` and new `SelectAllOfType()` method
- `RTSInputManager.cs`: Updated debug help overlay with new shortcuts

## Test plan
- [ ] Double-click a Swordsman selects all visible Swordsmen (same faction)
- [ ] Double-click a Miner does NOT select Swordsmen (type filtering)
- [ ] Enemy units are never selected by double-click
- [ ] Ctrl+double-click includes off-screen units of the same type
- [ ] Normal single-click still works (no regression)
- [ ] Box-select still works (no regression)
- [ ] Third rapid click does not re-trigger (reset guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)