### PR TITLE
feat(combat): crystal death drop loot system

### DIFF
--- a/Assets/Scripts/Entities/Cadaver.cs
+++ b/Assets/Scripts/Entities/Cadaver.cs
@@ -17,9 +17,26 @@ namespace TheWaningBorder.Entities
         private const int PresentationID = 301;
 
         /// <summary>
-        /// Create Cadaver using EntityManager.
+        /// Create Cadaver using EntityManager with default crystal amount.
         /// </summary>
         public static Entity Create(EntityManager em, float3 position)
+        {
+            return Create(em, position, DefaultCrystal);
+        }
+
+        /// <summary>
+        /// Create Cadaver using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position)
+        {
+            return Create(ecb, position, DefaultCrystal);
+        }
+
+        /// <summary>
+        /// Create Cadaver using EntityManager with a custom crystal amount.
+        /// Used by death drop system to set loot based on entity build cost.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, int crystalAmount)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -33,7 +50,7 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
             em.SetComponentData(entity, new CadaverState
             {
-                RemainingCrystal = DefaultCrystal,
+                RemainingCrystal = crystalAmount,
                 Depleted = 0
             });
             em.SetComponentData(entity, new Radius { Value = DefaultRadius });
@@ -42,9 +59,10 @@ namespace TheWaningBorder.Entities
         }
 
         /// <summary>
-        /// Create Cadaver using EntityCommandBuffer for deferred creation.
+        /// Create Cadaver using EntityCommandBuffer with a custom crystal amount.
+        /// Used by death drop system to set loot based on entity build cost.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, int crystalAmount)
         {
             var entity = ecb.CreateEntity();
 
@@ -53,7 +71,7 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent<CadaverTag>(entity);
             ecb.AddComponent(entity, new CadaverState
             {
-                RemainingCrystal = DefaultCrystal,
+                RemainingCrystal = crystalAmount,
                 Depleted = 0
             });
             ecb.AddComponent(entity, new Radius { Value = DefaultRadius });

--- a/Assets/Scripts/Systems/Crystal/CrystalDeathDropSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalDeathDropSystem.cs
@@ -1,0 +1,50 @@
+// File: Assets/Scripts/Systems/Crystal/CrystalDeathDropSystem.cs
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Transforms;
+using TheWaningBorder.Entities;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Intercepts crystal entity deaths (units and buildings) before DeathSystem
+    /// destroys them. Spawns a mineable loot pile (Cadaver) at the death position
+    /// containing 50% of the entity's build cost as crystal.
+    ///
+    /// Any entity with both Health &lt;= 0 and CrystalResourceValue gets a cadaver
+    /// spawned at its position. The cadaver amount = BuildCost / 2.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct CrystalDeathDropSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<CrystalResourceValue>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            foreach (var (health, transform, resourceValue, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<CrystalResourceValue>>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                var pos = transform.ValueRO.Position;
+                int lootAmount = resourceValue.ValueRO.BuildCost / 2;
+
+                if (lootAmount > 0)
+                {
+                    Cadaver.Create(ecb, pos, lootAmount);
+                }
+            }
+
+            ecb.Playback(state.EntityManager);
+            ecb.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Crystal Faction Rework Phase 2: Death Drops + Loot Mining (issue #49).

- **New `CrystalDeathDropSystem`** (`Systems/Crystal/CrystalDeathDropSystem.cs`): Intercepts crystal entity deaths before `DeathSystem` destroys them. Spawns a mineable Cadaver loot pile at the death position containing 50% of the entity's `CrystalResourceValue.BuildCost` as crystal.
- **Extended `Cadaver.Create`** with overloads that accept a custom `crystalAmount` parameter for both `EntityManager` and `EntityCommandBuffer` paths. Existing default overloads now delegate to the new ones.
- **Verified `CrystalMiningSystem`** is already clean of noise-related code (removed in Phase 1).

## Details

- `CrystalDeathDropSystem` queries for entities with `Health <= 0` and `CrystalResourceValue`, spawning cadavers via `EntityCommandBuffer` before `DeathSystem` runs
- Loot amount = `BuildCost / 2` (integer division, drops nothing if result is 0)
- Existing Cadaver default overloads (300 crystal) are preserved and delegate to the new parameterized versions

## Test plan

- [ ] Kill a crystal unit/building in-game and verify a cadaver spawns at the death location
- [ ] Verify cadaver contains 50% of the entity's BuildCost as crystal
- [ ] Verify miners can gather crystal from the death-drop cadaver
- [ ] Verify existing cadavers (from CrystalMainNode or manual spawns) still use default 300 crystal
- [ ] Confirm no compile errors in Unity

Closes #49

?? Generated with [Claude Code](https://claude.com/claude-code)