### PR TITLE
feat(combat): crystal combat units - Crystalling, Veilstinger, Godsplinter

### DIFF
--- a/Assets/Scripts/Entities/Units/Crystalling.cs
+++ b/Assets/Scripts/Entities/Units/Crystalling.cs
@@ -1,0 +1,118 @@
+// File: Assets/Scripts/Entities/Units/Crystalling.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystalling unit - fast, weak melee crystal swarm unit.
+    /// Cheap crystal-cost melee infantry for the Crystal faction (Faction.White).
+    /// No population cost - crystal faction uses crystal resource economy.
+    /// </summary>
+    public static class Crystalling
+    {
+        private const float DefaultHP = 60f;
+        private const float DefaultSpeed = 5.5f;
+        private const float DefaultDamage = 8f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 0.8f;
+        private const float DefaultRadius = 0.4f;
+        private const int PresentationID = 320;
+
+        /// <summary>
+        /// Create Crystalling using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Crystalling", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(CrystalTag),
+                typeof(CrystalUnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = 35 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Crystalling using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Crystalling", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent<CrystalUnitTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = 35 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Godsplinter.cs
+++ b/Assets/Scripts/Entities/Units/Godsplinter.cs
@@ -1,0 +1,137 @@
+// File: Assets/Scripts/Entities/Units/Godsplinter.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Godsplinter unit - massive crystal siege monster.
+    /// Hybrid siege/ranged combat: melee siege damage to buildings (2x),
+    /// multi-target laser barrage at range. Slow but extremely durable.
+    /// No population cost - crystal faction uses crystal resource economy.
+    /// </summary>
+    public static class Godsplinter
+    {
+        private const float DefaultHP = 1200f;
+        private const float DefaultSpeed = 1.8f;
+        private const float DefaultDamage = 40f;
+        private const float DefaultLoS = 20f;
+        private const float DefaultRadius = 1.5f;
+        private const float DefaultSiegeRange = 4f;
+        private const float DefaultLaserRange = 22f;
+        private const int DefaultLaserMaxTargets = 4;
+        private const int PresentationID = 322;
+
+        /// <summary>
+        /// Create Godsplinter using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Godsplinter", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(CrystalTag),
+                typeof(CrystalUnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(GodsplinterState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Siege });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = 350 });
+
+            // Godsplinter-specific siege/laser state
+            em.SetComponentData(entity, new GodsplinterState
+            {
+                LaserCooldownTimer = 0,
+                SiegeCooldownTimer = 0,
+                SiegeRange = DefaultSiegeRange,
+                LaserRange = DefaultLaserRange,
+                LaserMaxTargets = DefaultLaserMaxTargets,
+                IsSieging = 0
+            });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Godsplinter using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Godsplinter", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Siege });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent<CrystalUnitTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = 350 });
+
+            // Godsplinter-specific siege/laser state
+            ecb.AddComponent(entity, new GodsplinterState
+            {
+                LaserCooldownTimer = 0,
+                SiegeCooldownTimer = 0,
+                SiegeRange = DefaultSiegeRange,
+                LaserRange = DefaultLaserRange,
+                LaserMaxTargets = DefaultLaserMaxTargets,
+                IsSieging = 0
+            });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/UnitFactory.cs
+++ b/Assets/Scripts/Entities/Units/UnitFactory.cs
@@ -37,6 +37,9 @@ namespace TheWaningBorder.Entities
                 "Scout" => Scout.Create(em, position, faction),
                 "Litharch" => Litharch.Create(em, position, faction),
                 "Berserker" or "Feraldis_Berserker" => Berserker.Create(em, position, faction),
+                "Crystalling" => Crystalling.Create(em, position, faction),
+                "Veilstinger" => Veilstinger.Create(em, position, faction),
+                "Godsplinter" => Godsplinter.Create(em, position, faction),
                 _ => CreateDefault(em, unitId, position, faction)
             };
         }
@@ -56,6 +59,9 @@ namespace TheWaningBorder.Entities
                 "Scout" => Scout.Create(ecb, position, faction),
                 "Litharch" => Litharch.Create(ecb, position, faction),
                 "Berserker" or "Feraldis_Berserker" => Berserker.Create(ecb, position, faction),
+                "Crystalling" => Crystalling.Create(ecb, position, faction),
+                "Veilstinger" => Veilstinger.Create(ecb, position, faction),
+                "Godsplinter" => Godsplinter.Create(ecb, position, faction),
                 _ => CreateDefault(ecb, unitId, position, faction)
             };
         }
@@ -83,6 +89,9 @@ namespace TheWaningBorder.Entities
                 "Scout" => UnitClass.Scout,
                 "Litharch" => UnitClass.Support,
                 "Berserker" or "Feraldis_Berserker" => UnitClass.Melee,
+                "Crystalling" => UnitClass.Melee,
+                "Veilstinger" => UnitClass.Ranged,
+                "Godsplinter" => UnitClass.Siege,
                 _ => UnitClass.Melee
             };
         }
@@ -101,6 +110,9 @@ namespace TheWaningBorder.Entities
                 "Scout" => 206,
                 "Litharch" => 207,
                 "Berserker" or "Feraldis_Berserker" => 210,
+                "Crystalling" => 320,
+                "Veilstinger" => 321,
+                "Godsplinter" => 322,
                 _ => 201
             };
         }

--- a/Assets/Scripts/Entities/Units/Veilstinger.cs
+++ b/Assets/Scripts/Entities/Units/Veilstinger.cs
@@ -1,0 +1,149 @@
+// File: Assets/Scripts/Entities/Units/Veilstinger.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Veilstinger unit - dual-laser ranged glass cannon for the Crystal faction.
+    /// Fires at up to two targets simultaneously. Very fragile but high damage.
+    /// Uses VeilstingerState instead of ArcherState for dual-target tracking.
+    /// No population cost - crystal faction uses crystal resource economy.
+    /// </summary>
+    public static class Veilstinger
+    {
+        private const float DefaultHP = 40f;
+        private const float DefaultSpeed = 4.0f;
+        private const float DefaultDamage = 18f;
+        private const float DefaultLoS = 28f;
+        private const float DefaultMinRange = 8f;
+        private const float DefaultMaxRange = 24f;
+        private const float DefaultAimTime = 0.4f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 321;
+
+        /// <summary>
+        /// Create Veilstinger using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Veilstinger", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(CrystalTag),
+                typeof(CrystalUnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(VeilstingerState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Ranged });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = 80 });
+
+            // Veilstinger-specific dual-target state
+            em.SetComponentData(entity, new VeilstingerState
+            {
+                Target1 = Entity.Null,
+                Target2 = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                IsFiring = 0
+            });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Veilstinger using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Veilstinger", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Ranged });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent<CrystalUnitTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = 80 });
+
+            // Veilstinger-specific dual-target state
+            ecb.AddComponent(entity, new VeilstingerState
+            {
+                Target1 = Entity.Null,
+                Target2 = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                IsFiring = 0
+            });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
@@ -1,0 +1,280 @@
+// File: Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Hybrid siege/ranged combat system for Godsplinter crystal units.
+    ///
+    /// Two combat modes:
+    /// 1. Siege mode (close range): Direct damage to target, 2x vs buildings
+    /// 2. Laser mode (medium range): Multi-target laser barrage (up to 4 targets)
+    ///
+    /// Behavior priority:
+    /// - If in siege range and siege cooldown ready: siege attack
+    /// - Else if in laser range and laser cooldown ready: laser barrage
+    /// - Else if beyond laser range: chase (unless HoldPositionTag)
+    ///
+    /// Uses Projectile + ArrowProjectile entities for laser visuals,
+    /// processed by the existing ProjectileSystem.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(TargetingSystem))]
+    public partial struct GodsplinterCombatSystem : ISystem
+    {
+        private const float LaserSpeed = 35f;
+        private const float SiegeCooldownDuration = 3.0f;
+        private const float LaserCooldownDuration = 2.0f;
+        private const int BuildingDamageMultiplier = 2;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
+            float dt = SystemAPI.Time.DeltaTime;
+            float time = (float)SystemAPI.Time.ElapsedTime;
+            var em = state.EntityManager;
+
+            // Snapshot all potential targets for multi-target laser search
+            var targetQuery = SystemAPI.QueryBuilder()
+                .WithAll<LocalTransform, FactionTag, Health>()
+                .Build();
+
+            var tgtEntities = targetQuery.ToEntityArray(Allocator.Temp);
+            var tgtTransforms = targetQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var tgtFactions = targetQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            var tgtHealth = targetQuery.ToComponentDataArray<Health>(Allocator.Temp);
+
+            foreach (var (transform, target, godState, damage, faction, entity) in SystemAPI
+                .Query<RefRO<LocalTransform>, RefRW<Target>, RefRW<GodsplinterState>, RefRO<Damage>, RefRO<FactionTag>>()
+                .WithAll<CrystalUnitTag>()
+                .WithEntityAccess())
+            {
+                ref var tgt = ref target.ValueRW;
+                ref var gs = ref godState.ValueRW;
+
+                // Update cooldown timers
+                if (gs.SiegeCooldownTimer > 0)
+                    gs.SiegeCooldownTimer -= dt;
+                if (gs.LaserCooldownTimer > 0)
+                    gs.LaserCooldownTimer -= dt;
+
+                // Validate target exists and is alive
+                if (tgt.Value == Entity.Null || !em.Exists(tgt.Value))
+                {
+                    tgt.Value = Entity.Null;
+                    gs.IsSieging = 0;
+                    continue;
+                }
+
+                var targetHealth = em.GetComponentData<Health>(tgt.Value);
+                if (targetHealth.Value <= 0)
+                {
+                    tgt.Value = Entity.Null;
+                    gs.IsSieging = 0;
+                    continue;
+                }
+
+                var myPos = transform.ValueRO.Position;
+                var targetPos = em.GetComponentData<LocalTransform>(tgt.Value).Position;
+                var dist = DistXZ(myPos, targetPos);
+                int baseDmg = damage.ValueRO.Value;
+                Faction myFaction = faction.ValueRO.Value;
+
+                // =============================================================================
+                // BEHAVIOR 1: Siege mode - close range direct damage
+                // =============================================================================
+                if (dist <= gs.SiegeRange && gs.SiegeCooldownTimer <= 0)
+                {
+                    gs.IsSieging = 1;
+
+                    // Stop moving
+                    if (em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination { Has = 0 });
+                    }
+
+                    // Calculate siege damage (2x vs buildings)
+                    int siegeDmg = baseDmg;
+                    if (em.HasComponent<BuildingTag>(tgt.Value))
+                    {
+                        siegeDmg *= BuildingDamageMultiplier;
+                    }
+
+                    // Apply direct damage to target
+                    var health = em.GetComponentData<Health>(tgt.Value);
+                    health.Value -= siegeDmg;
+                    if (health.Value < 0) health.Value = 0;
+                    ecb.SetComponent(tgt.Value, health);
+
+                    // Reset siege cooldown
+                    gs.SiegeCooldownTimer = SiegeCooldownDuration;
+                }
+                // =============================================================================
+                // BEHAVIOR 2: Laser barrage - medium range multi-target
+                // =============================================================================
+                else if (dist <= gs.LaserRange && gs.LaserCooldownTimer <= 0)
+                {
+                    gs.IsSieging = 0;
+
+                    // Stop moving
+                    if (em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination { Has = 0 });
+                    }
+
+                    int maxTargets = math.max(1, gs.LaserMaxTargets);
+
+                    // Find up to LaserMaxTargets nearest enemies within laser range
+                    var targets = new NativeList<LaserTarget>(maxTargets, Allocator.Temp);
+
+                    for (int i = 0; i < tgtEntities.Length; i++)
+                    {
+                        if (tgtFactions[i].Value == myFaction) continue;
+                        if (tgtHealth[i].Value <= 0) continue;
+
+                        float d = DistXZ(myPos, tgtTransforms[i].Position);
+                        if (d > gs.LaserRange) continue;
+
+                        var candidate = new LaserTarget
+                        {
+                            Entity = tgtEntities[i],
+                            Position = tgtTransforms[i].Position,
+                            Distance = d
+                        };
+
+                        if (targets.Length < maxTargets)
+                        {
+                            targets.Add(candidate);
+                        }
+                        else if (d < targets[targets.Length - 1].Distance)
+                        {
+                            targets[targets.Length - 1] = candidate;
+                        }
+
+                        // Bubble sort last element into position
+                        for (int j = targets.Length - 1; j > 0; j--)
+                        {
+                            if (targets[j].Distance < targets[j - 1].Distance)
+                            {
+                                var tmp = targets[j];
+                                targets[j] = targets[j - 1];
+                                targets[j - 1] = tmp;
+                            }
+                        }
+                    }
+
+                    // Fire laser at each target
+                    for (int t = 0; t < targets.Length; t++)
+                    {
+                        CreateLaser(ref ecb, myPos, targets[t].Position,
+                            targets[t].Distance, entity, myFaction, baseDmg, time, targets[t].Entity);
+                    }
+
+                    if (targets.Length > 0)
+                    {
+                        gs.LaserCooldownTimer = LaserCooldownDuration;
+                    }
+
+                    targets.Dispose();
+                }
+                // =============================================================================
+                // BEHAVIOR 3: Too far - CHASE (unless holding position)
+                // =============================================================================
+                else if (dist > gs.LaserRange)
+                {
+                    gs.IsSieging = 0;
+
+                    // Hold position units do NOT chase
+                    if (em.HasComponent<HoldPositionTag>(entity))
+                    {
+                        tgt.Value = Entity.Null;
+                        continue;
+                    }
+
+                    if (!em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.AddComponent(entity, new DesiredDestination
+                        {
+                            Position = targetPos,
+                            Has = 1
+                        });
+                    }
+                    else
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination
+                        {
+                            Position = targetPos,
+                            Has = 1
+                        });
+                    }
+                }
+            }
+
+            tgtEntities.Dispose();
+            tgtTransforms.Dispose();
+            tgtFactions.Dispose();
+            tgtHealth.Dispose();
+        }
+
+        /// <summary>
+        /// Create a laser projectile entity (reuses Projectile + ArrowProjectile pattern).
+        /// </summary>
+        private static void CreateLaser(ref EntityCommandBuffer ecb, float3 start, float3 targetPos,
+            float distance, Entity shooter, Faction faction, int damage, float time, Entity targetEntity)
+        {
+            var direction = math.normalize(targetPos - start);
+            var velocity = direction * LaserSpeed;
+            var flightTime = distance / LaserSpeed;
+
+            var laser = ecb.CreateEntity();
+
+            ecb.AddComponent(laser, new LocalTransform
+            {
+                Position = start + new float3(0, 2.5f, 0), // Spawn above Godsplinter (tall unit)
+                Rotation = quaternion.LookRotation(velocity, new float3(0, 1, 0)),
+                Scale = 1f
+            });
+
+            ecb.AddComponent(laser, new ArrowProjectile
+            {
+                Velocity = velocity,
+                Gravity = 0f,
+                Shooter = shooter,
+                IsParabolic = false
+            });
+
+            ecb.AddComponent(laser, new Projectile
+            {
+                Start = start,
+                End = targetPos,
+                StartTime = time,
+                FlightTime = flightTime,
+                Damage = damage,
+                Target = targetEntity,
+                Faction = faction
+            });
+        }
+
+        private struct LaserTarget
+        {
+            public Entity Entity;
+            public float3 Position;
+            public float Distance;
+        }
+
+        private static float DistXZ(float3 a, float3 b)
+        {
+            return math.distance(new float2(a.x, a.z), new float2(b.x, b.z));
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Crystal/VeilstingerCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/VeilstingerCombatSystem.cs
@@ -1,0 +1,275 @@
+// File: Assets/Scripts/Systems/Crystal/VeilstingerCombatSystem.cs
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Dual-target ranged combat system for Veilstinger crystal units.
+    ///
+    /// Veilstingers fire lasers at up to two targets simultaneously:
+    /// - Primary target is provided by TargetingSystem (Target component)
+    /// - Secondary target is the nearest other enemy within range
+    ///
+    /// Behavior:
+    /// - Too close (below MinRange): retreat away from target
+    /// - In range (MinRange..MaxRange): aim, then fire dual lasers
+    /// - Too far (above MaxRange): chase target (unless HoldPositionTag)
+    ///
+    /// Uses Projectile + ArrowProjectile entities for laser visuals,
+    /// processed by the existing ProjectileSystem.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(TargetingSystem))]
+    public partial struct VeilstingerCombatSystem : ISystem
+    {
+        private const float LaserSpeed = 40f;
+        private const float FireCooldown = 1.5f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
+            float dt = SystemAPI.Time.DeltaTime;
+            float time = (float)SystemAPI.Time.ElapsedTime;
+            var em = state.EntityManager;
+
+            // Snapshot all potential targets for secondary target search
+            var targetQuery = SystemAPI.QueryBuilder()
+                .WithAll<LocalTransform, FactionTag, Health>()
+                .Build();
+
+            var tgtEntities = targetQuery.ToEntityArray(Allocator.Temp);
+            var tgtTransforms = targetQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var tgtFactions = targetQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            var tgtHealth = targetQuery.ToComponentDataArray<Health>(Allocator.Temp);
+
+            foreach (var (transform, target, veilState, damage, faction, entity) in SystemAPI
+                .Query<RefRO<LocalTransform>, RefRW<Target>, RefRW<VeilstingerState>, RefRO<Damage>, RefRO<FactionTag>>()
+                .WithAll<CrystalUnitTag>()
+                .WithEntityAccess())
+            {
+                ref var tgt = ref target.ValueRW;
+                ref var vs = ref veilState.ValueRW;
+
+                // Update cooldown timer
+                if (vs.CooldownTimer > 0)
+                {
+                    vs.CooldownTimer -= dt;
+                }
+
+                // Validate primary target exists and is alive
+                if (tgt.Value == Entity.Null || !em.Exists(tgt.Value))
+                {
+                    tgt.Value = Entity.Null;
+                    vs.Target1 = Entity.Null;
+                    vs.Target2 = Entity.Null;
+                    vs.AimTimer = 0;
+                    continue;
+                }
+
+                var targetHealth = em.GetComponentData<Health>(tgt.Value);
+                if (targetHealth.Value <= 0)
+                {
+                    tgt.Value = Entity.Null;
+                    vs.Target1 = Entity.Null;
+                    vs.Target2 = Entity.Null;
+                    vs.AimTimer = 0;
+                    continue;
+                }
+
+                vs.Target1 = tgt.Value;
+                var myPos = transform.ValueRO.Position;
+                var targetPos = em.GetComponentData<LocalTransform>(tgt.Value).Position;
+                var dist = DistXZ(myPos, targetPos);
+
+                float minRange = vs.MinRange;
+                float maxRange = vs.MaxRange;
+
+                // =============================================================================
+                // BEHAVIOR: Too close - RETREAT
+                // =============================================================================
+                if (dist < minRange)
+                {
+                    vs.AimTimer = 0;
+                    vs.IsFiring = 0;
+
+                    var retreatDir = math.normalize(myPos - targetPos);
+                    var retreatTarget = myPos + retreatDir * (minRange - dist + 3f);
+
+                    if (!em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.AddComponent(entity, new DesiredDestination
+                        {
+                            Position = retreatTarget,
+                            Has = 1
+                        });
+                    }
+                    else
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination
+                        {
+                            Position = retreatTarget,
+                            Has = 1
+                        });
+                    }
+                }
+                // =============================================================================
+                // BEHAVIOR: In range - AIM AND FIRE dual lasers
+                // =============================================================================
+                else if (dist <= maxRange)
+                {
+                    // Stop moving when in range
+                    if (em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination { Has = 0 });
+                    }
+
+                    // Accumulate aim time
+                    vs.AimTimer += dt;
+
+                    // Fire when aim is ready and cooldown is complete
+                    if (vs.AimTimer >= vs.AimTimeRequired && vs.CooldownTimer <= 0)
+                    {
+                        vs.IsFiring = 1;
+                        int dmg = damage.ValueRO.Value;
+                        Faction myFaction = faction.ValueRO.Value;
+
+                        // Fire primary laser at Target1
+                        CreateLaser(ref ecb, myPos, targetPos, dist, entity, myFaction, dmg, time, tgt.Value);
+
+                        // Find secondary target: nearest enemy within range that isn't primary
+                        Entity secondTarget = Entity.Null;
+                        float3 secondPos = float3.zero;
+                        float bestDist = float.MaxValue;
+
+                        for (int i = 0; i < tgtEntities.Length; i++)
+                        {
+                            if (tgtFactions[i].Value == myFaction) continue;
+                            if (tgtHealth[i].Value <= 0) continue;
+                            if (tgtEntities[i] == tgt.Value) continue; // Skip primary target
+
+                            float d = DistXZ(myPos, tgtTransforms[i].Position);
+                            if (d > maxRange) continue;
+
+                            if (d < bestDist)
+                            {
+                                bestDist = d;
+                                secondTarget = tgtEntities[i];
+                                secondPos = tgtTransforms[i].Position;
+                            }
+                        }
+
+                        // Fire second laser if secondary target found
+                        if (secondTarget != Entity.Null)
+                        {
+                            vs.Target2 = secondTarget;
+                            CreateLaser(ref ecb, myPos, secondPos, bestDist, entity, myFaction, dmg, time, secondTarget);
+                        }
+                        else
+                        {
+                            vs.Target2 = Entity.Null;
+                        }
+
+                        // Reset cooldown and aim
+                        vs.CooldownTimer = FireCooldown;
+                        vs.AimTimer = 0;
+                        vs.IsFiring = 0;
+                    }
+                }
+                // =============================================================================
+                // BEHAVIOR: Too far - CHASE (unless holding position)
+                // =============================================================================
+                else
+                {
+                    // Hold position units do NOT chase
+                    if (em.HasComponent<HoldPositionTag>(entity))
+                    {
+                        tgt.Value = Entity.Null;
+                        vs.Target1 = Entity.Null;
+                        vs.Target2 = Entity.Null;
+                        vs.AimTimer = 0;
+                        continue;
+                    }
+
+                    vs.AimTimer = 0;
+                    vs.IsFiring = 0;
+
+                    if (!em.HasComponent<DesiredDestination>(entity))
+                    {
+                        ecb.AddComponent(entity, new DesiredDestination
+                        {
+                            Position = targetPos,
+                            Has = 1
+                        });
+                    }
+                    else
+                    {
+                        ecb.SetComponent(entity, new DesiredDestination
+                        {
+                            Position = targetPos,
+                            Has = 1
+                        });
+                    }
+                }
+            }
+
+            tgtEntities.Dispose();
+            tgtTransforms.Dispose();
+            tgtFactions.Dispose();
+            tgtHealth.Dispose();
+        }
+
+        /// <summary>
+        /// Create a laser projectile entity (reuses Projectile + ArrowProjectile pattern).
+        /// </summary>
+        private static void CreateLaser(ref EntityCommandBuffer ecb, float3 start, float3 targetPos,
+            float distance, Entity shooter, Faction faction, int damage, float time, Entity targetEntity)
+        {
+            var direction = math.normalize(targetPos - start);
+            var velocity = direction * LaserSpeed;
+            var flightTime = distance / LaserSpeed;
+
+            var laser = ecb.CreateEntity();
+
+            ecb.AddComponent(laser, new LocalTransform
+            {
+                Position = start + new float3(0, 1.2f, 0), // Spawn at unit height
+                Rotation = quaternion.LookRotation(velocity, new float3(0, 1, 0)),
+                Scale = 1f
+            });
+
+            ecb.AddComponent(laser, new ArrowProjectile
+            {
+                Velocity = velocity,
+                Gravity = 0f,
+                Shooter = shooter,
+                IsParabolic = false
+            });
+
+            ecb.AddComponent(laser, new Projectile
+            {
+                Start = start,
+                End = targetPos,
+                StartTime = time,
+                FlightTime = flightTime,
+                Damage = damage,
+                Target = targetEntity,
+                Faction = faction
+            });
+        }
+
+        private static float DistXZ(float3 a, float3 b)
+        {
+            return math.distance(new float2(a.x, a.z), new float2(b.x, b.z));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Crystal Faction Rework Phase 3 (#50): three new crystal combat units with dedicated combat systems.

### New Units
- **Crystalling** (PID 320) - Fast melee swarm unit. HP 60, Speed 5.5, Damage 8, Cost 35 crystal. Handled by existing MeleeCombatSystem.
- **Veilstinger** (PID 321) - Dual-laser ranged glass cannon. HP 40, Speed 4.0, Damage 18, LoS 28, Cost 80 crystal. Fires at 2 targets simultaneously.
- **Godsplinter** (PID 322) - Siege monster. HP 1200, Speed 1.8, Damage 40, Cost 350 crystal. Hybrid siege (2x vs buildings) + 4-target laser barrage.

### New Systems
- `VeilstingerCombatSystem` - Dual-target ranged combat with retreat/aim/fire cycle and secondary target acquisition
- `GodsplinterCombatSystem` - Close-range siege mode (direct damage, 2x buildings) + mid-range laser barrage (up to 4 targets)

### Changes
- Created `Entities/Units/Crystalling.cs` - Factory with EM + ECB overloads
- Created `Entities/Units/Veilstinger.cs` - Factory with EM + ECB overloads
- Created `Entities/Units/Godsplinter.cs` - Factory with EM + ECB overloads
- Created `Systems/Crystal/VeilstingerCombatSystem.cs`
- Created `Systems/Crystal/GodsplinterCombatSystem.cs`
- Updated `Entities/Units/UnitFactory.cs` - Registered all 3 units in Create, GetUnitClass, GetPresentationId

### Design Notes
- Crystal units use `CrystalResourceValue` instead of `PopulationCost` (no pop system for crystal faction)
- All units tagged with `CrystalTag` + `CrystalUnitTag` for faction identification
- Laser projectiles reuse existing `Projectile` + `ArrowProjectile` pipeline
- Both combat systems use `EndSimulationEntityCommandBufferSystem` for entity creation
- `UnitClass.Siege` already existed in enum (no changes needed)

Closes #50

## Test Plan
- [ ] Verify Crystalling spawns and attacks via MeleeCombatSystem (melee range, no ArcherTag)
- [ ] Verify Veilstinger fires dual lasers at two separate targets within range
- [ ] Verify Veilstinger retreats when enemies are below MinRange (8)
- [ ] Verify Godsplinter siege mode applies 2x damage to buildings at close range
- [ ] Verify Godsplinter laser mode fires at up to 4 enemies at medium range
- [ ] Verify HoldPositionTag prevents chase behavior on all 3 units
- [ ] Verify UnitFactory.Create works for all 3 units with both EM and ECB
- [ ] Verify no compile errors in Unity

?? Generated with [Claude Code](https://claude.com/claude-code)