### PR TITLE
feat(combat): crystal sub-node buildings and aura systems (#51)

### DIFF
--- a/Assets/Scripts/Core/Components/CrystalComponents.cs
+++ b/Assets/Scripts/Core/Components/CrystalComponents.cs
@@ -179,3 +179,29 @@ public struct RestorationAura : IComponentData
     public float HealPerSecond;
     public float HealTimer;
 }
+
+// ==================== Crystal Buff / Debuff ====================
+
+/// <summary>
+/// Applied to crystal-allied units within an Enforcement aura radius.
+/// Combat systems use these values to boost damage, defense, and speed.
+/// Removed when the unit leaves the aura radius.
+/// </summary>
+public struct CrystalBuff : IComponentData
+{
+    public float DefBonus;
+    public float AttBonus;
+    public float SpeedBonus;
+}
+
+/// <summary>
+/// Applied to enemy (non-White) units within a Suppression aura radius.
+/// Combat systems use these values to penalise damage, defense, and speed.
+/// Removed when the unit leaves the aura radius.
+/// </summary>
+public struct CrystalDebuff : IComponentData
+{
+    public float DefPenalty;
+    public float AttPenalty;
+    public float SpeedPenalty;
+}

--- a/Assets/Scripts/Entities/Buildings/CrystalEnforcementNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalEnforcementNode.cs
@@ -1,0 +1,89 @@
+// File: Assets/Scripts/Entities/Buildings/CrystalEnforcementNode.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystal Enforcement Node - a sub-node that buffs nearby crystal allies
+    /// with increased defense, attack, and speed via an Enforcement aura.
+    /// </summary>
+    public static class CrystalEnforcementNode
+    {
+        private const int DefaultHP = 600;
+        private const float DefaultRadius = 1.5f;
+        private const int DefaultBuildCost = 200;
+        private const int PresentationID = 313;
+
+        // Aura defaults
+        private const float AuraRadius = 20f;
+        private const float AuraDefBonus = 0.15f;
+        private const float AuraAttBonus = 0.15f;
+        private const float AuraSpeedBonus = 0.1f;
+
+        /// <summary>
+        /// Create CrystalEnforcementNode using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(Health),
+                typeof(Radius),
+                typeof(BuildingTag),
+                typeof(CrystalTag),
+                typeof(CrystalSubNodeTag),
+                typeof(EnforcementAura),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Enforcement });
+            em.SetComponentData(entity, new EnforcementAura
+            {
+                Radius = AuraRadius,
+                DefBonus = AuraDefBonus,
+                AttBonus = AuraAttBonus,
+                SpeedBonus = AuraSpeedBonus
+            });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CrystalEnforcementNode using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Enforcement });
+            ecb.AddComponent(entity, new EnforcementAura
+            {
+                Radius = AuraRadius,
+                DefBonus = AuraDefBonus,
+                AttBonus = AuraAttBonus,
+                SpeedBonus = AuraSpeedBonus
+            });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
@@ -1,0 +1,98 @@
+// File: Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystal Resource Node - a brittle sub-node that spreads cursed ground
+    /// at a smaller radius than the main node and generates crystal income.
+    /// </summary>
+    public static class CrystalResourceNode
+    {
+        private const int DefaultHP = 200;
+        private const float DefaultRadius = 1.5f;
+        private const float DefaultSpreadRadius = 8f;
+        private const float DefaultSpreadPerTick = 1f;
+        private const float DefaultTickInterval = 30f;
+        private const float DefaultIncomePerTick = 0f;
+        private const int DefaultBuildCost = 50;
+        private const int PresentationID = 312;
+
+        /// <summary>
+        /// Create CrystalResourceNode using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(Health),
+                typeof(Radius),
+                typeof(BuildingTag),
+                typeof(CrystalTag),
+                typeof(CrystalSubNodeTag),
+                typeof(CrystalNode),
+                typeof(CrystalResourceValue),
+                typeof(OwnerNode)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Resource });
+            em.SetComponentData(entity, new CrystalNode
+            {
+                IsMain = 0,
+                SpreadPerTick = DefaultSpreadPerTick,
+                SpreadRadius = DefaultSpreadRadius,
+                IncomePerTick = DefaultIncomePerTick,
+                TickInterval = DefaultTickInterval,
+                TickTimer = 0f,
+                CurrentRingRadius = 0f,
+                Enabled = 1
+            });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+            em.SetComponentData(entity, new OwnerNode { Value = Entity.Null });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CrystalResourceNode using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Resource });
+            ecb.AddComponent(entity, new CrystalNode
+            {
+                IsMain = 0,
+                SpreadPerTick = DefaultSpreadPerTick,
+                SpreadRadius = DefaultSpreadRadius,
+                IncomePerTick = DefaultIncomePerTick,
+                TickInterval = DefaultTickInterval,
+                TickTimer = 0f,
+                CurrentRingRadius = 0f,
+                Enabled = 1
+            });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+            ecb.AddComponent(entity, new OwnerNode { Value = Entity.Null });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Buildings/CrystalRestorationNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalRestorationNode.cs
@@ -1,0 +1,85 @@
+// File: Assets/Scripts/Entities/Buildings/CrystalRestorationNode.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystal Restoration Node - a sub-node that heals nearby crystal entities
+    /// (buildings and units) over time via a Restoration aura.
+    /// </summary>
+    public static class CrystalRestorationNode
+    {
+        private const int DefaultHP = 400;
+        private const float DefaultRadius = 1.5f;
+        private const int DefaultBuildCost = 120;
+        private const int PresentationID = 315;
+
+        // Aura defaults
+        private const float AuraRadius = 15f;
+        private const float AuraHealPerSecond = 5f;
+
+        /// <summary>
+        /// Create CrystalRestorationNode using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(Health),
+                typeof(Radius),
+                typeof(BuildingTag),
+                typeof(CrystalTag),
+                typeof(CrystalSubNodeTag),
+                typeof(RestorationAura),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Restoration });
+            em.SetComponentData(entity, new RestorationAura
+            {
+                Radius = AuraRadius,
+                HealPerSecond = AuraHealPerSecond,
+                HealTimer = 0f
+            });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CrystalRestorationNode using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Restoration });
+            ecb.AddComponent(entity, new RestorationAura
+            {
+                Radius = AuraRadius,
+                HealPerSecond = AuraHealPerSecond,
+                HealTimer = 0f
+            });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Buildings/CrystalSuppressionNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalSuppressionNode.cs
@@ -1,0 +1,89 @@
+// File: Assets/Scripts/Entities/Buildings/CrystalSuppressionNode.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystal Suppression Node - a sub-node that debuffs nearby enemies
+    /// with reduced defense, attack, and speed via a Suppression aura.
+    /// </summary>
+    public static class CrystalSuppressionNode
+    {
+        private const int DefaultHP = 600;
+        private const float DefaultRadius = 1.5f;
+        private const int DefaultBuildCost = 200;
+        private const int PresentationID = 314;
+
+        // Aura defaults
+        private const float AuraRadius = 20f;
+        private const float AuraDefPenalty = 0.15f;
+        private const float AuraAttPenalty = 0.15f;
+        private const float AuraSpeedPenalty = 0.1f;
+
+        /// <summary>
+        /// Create CrystalSuppressionNode using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(Health),
+                typeof(Radius),
+                typeof(BuildingTag),
+                typeof(CrystalTag),
+                typeof(CrystalSubNodeTag),
+                typeof(SuppressionAura),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Suppression });
+            em.SetComponentData(entity, new SuppressionAura
+            {
+                Radius = AuraRadius,
+                DefPenalty = AuraDefPenalty,
+                AttPenalty = AuraAttPenalty,
+                SpeedPenalty = AuraSpeedPenalty
+            });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CrystalSuppressionNode using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Suppression });
+            ecb.AddComponent(entity, new SuppressionAura
+            {
+                Radius = AuraRadius,
+                DefPenalty = AuraDefPenalty,
+                AttPenalty = AuraAttPenalty,
+                SpeedPenalty = AuraSpeedPenalty
+            });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Buildings/CrystalTurretNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalTurretNode.cs
@@ -1,0 +1,92 @@
+// File: Assets/Scripts/Entities/Buildings/CrystalTurretNode.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crystal Turret Node - a defensive sub-node that auto-fires projectiles
+    /// at enemies within range. Leverages the existing BuildingCombatSystem
+    /// via BuildingRangedAttack + BuildingTag components.
+    /// </summary>
+    public static class CrystalTurretNode
+    {
+        private const int DefaultHP = 500;
+        private const float DefaultRadius = 1.5f;
+        private const int DefaultBuildCost = 100;
+        private const int PresentationID = 316;
+
+        // Turret combat defaults
+        private const float TurretRange = 25f;
+        private const int TurretDamage = 15;
+        private const float TurretCooldown = 1.5f;
+        private const int TurretMaxTargets = 2;
+
+        /// <summary>
+        /// Create CrystalTurretNode using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(Health),
+                typeof(Radius),
+                typeof(BuildingTag),
+                typeof(CrystalTag),
+                typeof(CrystalSubNodeTag),
+                typeof(BuildingRangedAttack),
+                typeof(CrystalResourceValue)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Turret });
+            em.SetComponentData(entity, new BuildingRangedAttack
+            {
+                Range = TurretRange,
+                Damage = TurretDamage,
+                Cooldown = TurretCooldown,
+                Timer = 0f,
+                MaxTargets = TurretMaxTargets
+            });
+            em.SetComponentData(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CrystalTurretNode using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent<CrystalTag>(entity);
+            ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Turret });
+            ecb.AddComponent(entity, new BuildingRangedAttack
+            {
+                Range = TurretRange,
+                Damage = TurretDamage,
+                Cooldown = TurretCooldown,
+                Timer = 0f,
+                MaxTargets = TurretMaxTargets
+            });
+            ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = DefaultBuildCost });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
@@ -55,12 +55,20 @@ namespace TheWaningBorder.Systems.Creatures
                 existingGroundTotal++;
             }
 
+            // Count all spreading nodes (main + resource sub-nodes)
             int nodeCount = 0;
             foreach (var _ in SystemAPI.Query<RefRO<CrystalMainNodeTag>>())
             {
                 nodeCount++;
             }
+            foreach (var (subTag, subNode) in SystemAPI
+                .Query<RefRO<CrystalSubNodeTag>, RefRO<CrystalNode>>())
+            {
+                if (subTag.ValueRO.Type == CrystalSubNodeType.Resource)
+                    nodeCount++;
+            }
 
+            // === Main Node Spread ===
             foreach (var (crystalNode, transform, entity) in SystemAPI
                 .Query<RefRW<CrystalNode>, RefRO<LocalTransform>>()
                 .WithAll<CrystalMainNodeTag>()
@@ -89,56 +97,104 @@ namespace TheWaningBorder.Systems.Creatures
                 int perNodeBudget = MaxTilesPerNode - (existingGroundTotal / math.max(1, nodeCount));
                 if (perNodeBudget <= 0) continue;
 
-                float3 nodePos = transform.ValueRO.Position;
-                int tilesSpawned = 0;
+                int tilesSpawned = SpawnRingTiles(ref ecb, transform.ValueRO.Position,
+                    prevRadius, newRadius, perNodeBudget, entity);
 
-                // Spawn tiles in the annular ring between prevRadius and newRadius
-                // Walk from inner to outer edge in radial steps
-                float radialStep = TileSpacing * 0.8f; // Slight overlap for coverage
-                for (float r = math.max(prevRadius, TileSpacing * 0.5f); r <= newRadius; r += radialStep)
-                {
-                    // Number of tiles at this radius based on circumference and spacing
-                    float circumference = 2f * math.PI * r;
-                    int tilesAtRadius = math.max(1, (int)(circumference / TileSpacing));
-                    float angleStep = (2f * math.PI) / tilesAtRadius;
+                existingGroundTotal += tilesSpawned;
+            }
 
-                    for (int i = 0; i < tilesAtRadius; i++)
-                    {
-                        if (tilesSpawned >= perNodeBudget) break;
+            // === Resource Sub-Node Spread ===
+            foreach (var (crystalNode, transform, subTag, entity) in SystemAPI
+                .Query<RefRW<CrystalNode>, RefRO<LocalTransform>, RefRO<CrystalSubNodeTag>>()
+                .WithAll<CrystalSubNodeTag>()
+                .WithNone<CrystalMainNodeTag>()
+                .WithEntityAccess())
+            {
+                // Only Resource sub-nodes spread cursed ground
+                if (subTag.ValueRO.Type != CrystalSubNodeType.Resource) continue;
 
-                        float angle = i * angleStep;
-                        float3 groundPos = nodePos + new float3(
-                            math.cos(angle) * r,
-                            0f,
-                            math.sin(angle) * r
-                        );
-                        groundPos.y = nodePos.y;
+                ref var node = ref crystalNode.ValueRW;
+                if (node.Enabled == 0) continue;
+                if (node.IsMain != 0) continue; // Safety check
 
-                        // Create cursed ground entity with full component set
-                        var groundEntity = ecb.CreateEntity();
-                        ecb.AddComponent<CursedGroundTag>(groundEntity);
-                        ecb.AddComponent(groundEntity, LocalTransform.FromPosition(groundPos));
-                        ecb.AddComponent(groundEntity, new PresentationId { Id = CursedGroundPresentationId });
-                        ecb.AddComponent(groundEntity, new Radius { Value = TileRadius });
-                        ecb.AddComponent(groundEntity, new FactionTag { Value = Faction.White });
-                        ecb.AddComponent(groundEntity, new CursedGroundDPS
-                        {
-                            DamagePerSecond = BaseDPS,
-                            EffectRadius = TileRadius
-                        });
-                        ecb.AddComponent(groundEntity, new OwnerNode { Value = entity });
+                // Tick timer
+                node.TickTimer += dt;
+                if (node.TickTimer < node.TickInterval) continue;
+                node.TickTimer = 0f;
 
-                        tilesSpawned++;
-                    }
+                // Ring already at max radius -- nothing to spread
+                if (node.CurrentRingRadius >= node.SpreadRadius) continue;
 
-                    if (tilesSpawned >= perNodeBudget) break;
-                }
+                float ringStep = BaseRingStep;
+
+                float prevRadius = node.CurrentRingRadius;
+                float newRadius = math.min(prevRadius + ringStep, node.SpreadRadius);
+                node.CurrentRingRadius = newRadius;
+
+                int perNodeBudget = MaxTilesPerNode - (existingGroundTotal / math.max(1, nodeCount));
+                if (perNodeBudget <= 0) continue;
+
+                // Sub-node entity is the OwnerNode for its cursed ground tiles
+                int tilesSpawned = SpawnRingTiles(ref ecb, transform.ValueRO.Position,
+                    prevRadius, newRadius, perNodeBudget, entity);
 
                 existingGroundTotal += tilesSpawned;
             }
 
             ecb.Playback(state.EntityManager);
             ecb.Dispose();
+        }
+
+        /// <summary>
+        /// Spawns cursed ground tiles in an annular ring between prevRadius and newRadius.
+        /// Returns the number of tiles spawned.
+        /// </summary>
+        private static int SpawnRingTiles(ref EntityCommandBuffer ecb, float3 nodePos,
+            float prevRadius, float newRadius, int budget, Entity ownerEntity)
+        {
+            int tilesSpawned = 0;
+
+            float radialStep = TileSpacing * 0.8f; // Slight overlap for coverage
+            for (float r = math.max(prevRadius, TileSpacing * 0.5f); r <= newRadius; r += radialStep)
+            {
+                // Number of tiles at this radius based on circumference and spacing
+                float circumference = 2f * math.PI * r;
+                int tilesAtRadius = math.max(1, (int)(circumference / TileSpacing));
+                float angleStep = (2f * math.PI) / tilesAtRadius;
+
+                for (int i = 0; i < tilesAtRadius; i++)
+                {
+                    if (tilesSpawned >= budget) break;
+
+                    float angle = i * angleStep;
+                    float3 groundPos = nodePos + new float3(
+                        math.cos(angle) * r,
+                        0f,
+                        math.sin(angle) * r
+                    );
+                    groundPos.y = nodePos.y;
+
+                    // Create cursed ground entity with full component set
+                    var groundEntity = ecb.CreateEntity();
+                    ecb.AddComponent<CursedGroundTag>(groundEntity);
+                    ecb.AddComponent(groundEntity, LocalTransform.FromPosition(groundPos));
+                    ecb.AddComponent(groundEntity, new PresentationId { Id = CursedGroundPresentationId });
+                    ecb.AddComponent(groundEntity, new Radius { Value = TileRadius });
+                    ecb.AddComponent(groundEntity, new FactionTag { Value = Faction.White });
+                    ecb.AddComponent(groundEntity, new CursedGroundDPS
+                    {
+                        DamagePerSecond = BaseDPS,
+                        EffectRadius = TileRadius
+                    });
+                    ecb.AddComponent(groundEntity, new OwnerNode { Value = ownerEntity });
+
+                    tilesSpawned++;
+                }
+
+                if (tilesSpawned >= budget) break;
+            }
+
+            return tilesSpawned;
         }
     }
 }

--- a/Assets/Scripts/Systems/Crystal/EnforcementNodeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/EnforcementNodeSystem.cs
@@ -1,0 +1,102 @@
+// File: Assets/Scripts/Systems/Crystal/EnforcementNodeSystem.cs
+// Applies CrystalBuff to crystal-allied units within Enforcement aura range.
+// Removes the buff when units leave the aura radius.
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Ticks every 1 second. For each Enforcement node, queries all
+    /// CrystalUnitTag entities and adds/removes CrystalBuff based on distance.
+    /// The strongest overlapping buff wins (max of all auras in range).
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct EnforcementNodeSystem : ISystem
+    {
+        private const float TickInterval = 1f;
+        private float _timer;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EnforcementAura>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            _timer += dt;
+            if (_timer < TickInterval) return;
+            _timer = 0f;
+
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var em = state.EntityManager;
+
+            // Snapshot all enforcement aura sources
+            var auraQuery = SystemAPI.QueryBuilder()
+                .WithAll<EnforcementAura, LocalTransform, CrystalSubNodeTag>()
+                .WithNone<UnderConstruction>()
+                .Build();
+
+            var auraTransforms = auraQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var auraData = auraQuery.ToComponentDataArray<EnforcementAura>(Allocator.Temp);
+
+            // Process all crystal units -- add or update CrystalBuff
+            foreach (var (unitTransform, faction, entity) in SystemAPI
+                .Query<RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<CrystalUnitTag>()
+                .WithEntityAccess())
+            {
+                float3 unitPos = unitTransform.ValueRO.Position;
+
+                // Find strongest buff from all enforcement auras in range
+                float bestDef = 0f;
+                float bestAtt = 0f;
+                float bestSpd = 0f;
+                bool inRange = false;
+
+                for (int i = 0; i < auraTransforms.Length; i++)
+                {
+                    float dist = math.distance(unitPos, auraTransforms[i].Position);
+                    if (dist <= auraData[i].Radius)
+                    {
+                        inRange = true;
+                        bestDef = math.max(bestDef, auraData[i].DefBonus);
+                        bestAtt = math.max(bestAtt, auraData[i].AttBonus);
+                        bestSpd = math.max(bestSpd, auraData[i].SpeedBonus);
+                    }
+                }
+
+                bool hasBuff = em.HasComponent<CrystalBuff>(entity);
+
+                if (inRange)
+                {
+                    var buff = new CrystalBuff
+                    {
+                        DefBonus = bestDef,
+                        AttBonus = bestAtt,
+                        SpeedBonus = bestSpd
+                    };
+
+                    if (hasBuff)
+                        ecb.SetComponent(entity, buff);
+                    else
+                        ecb.AddComponent(entity, buff);
+                }
+                else if (hasBuff)
+                {
+                    ecb.RemoveComponent<CrystalBuff>(entity);
+                }
+            }
+
+            auraTransforms.Dispose();
+            auraData.Dispose();
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Crystal/RestorationNodeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/RestorationNodeSystem.cs
@@ -1,0 +1,89 @@
+// File: Assets/Scripts/Systems/Crystal/RestorationNodeSystem.cs
+// Heals nearby CrystalTag entities (buildings and units) within Restoration aura range.
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Ticks every 1 second. For each Restoration node, queries all
+    /// CrystalTag entities with Health and heals damaged ones within range.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct RestorationNodeSystem : ISystem
+    {
+        private const float TickInterval = 1f;
+        private float _timer;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<RestorationAura>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            _timer += dt;
+            if (_timer < TickInterval) return;
+            _timer = 0f;
+
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var em = state.EntityManager;
+
+            // Snapshot all restoration aura sources
+            var auraQuery = SystemAPI.QueryBuilder()
+                .WithAll<RestorationAura, LocalTransform, CrystalSubNodeTag>()
+                .WithNone<UnderConstruction>()
+                .Build();
+
+            var auraTransforms = auraQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var auraData = auraQuery.ToComponentDataArray<RestorationAura>(Allocator.Temp);
+
+            // Process all crystal entities with Health
+            foreach (var (health, transform, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>>()
+                .WithAll<CrystalTag>()
+                .WithEntityAccess())
+            {
+                int currentHP = health.ValueRO.Value;
+                int maxHP = health.ValueRO.Max;
+
+                // Skip entities already at full health or dead
+                if (currentHP >= maxHP || currentHP <= 0) continue;
+
+                float3 entityPos = transform.ValueRO.Position;
+
+                // Sum heal from all restoration auras in range (they stack)
+                float totalHeal = 0f;
+
+                for (int i = 0; i < auraTransforms.Length; i++)
+                {
+                    float dist = math.distance(entityPos, auraTransforms[i].Position);
+                    if (dist <= auraData[i].Radius)
+                    {
+                        totalHeal += auraData[i].HealPerSecond;
+                    }
+                }
+
+                if (totalHeal > 0f)
+                {
+                    int newHP = math.min(currentHP + (int)totalHeal, maxHP);
+                    ecb.SetComponent(entity, new Health
+                    {
+                        Value = newHP,
+                        Max = maxHP
+                    });
+                }
+            }
+
+            auraTransforms.Dispose();
+            auraData.Dispose();
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Crystal/SuppressionNodeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/SuppressionNodeSystem.cs
@@ -1,0 +1,105 @@
+// File: Assets/Scripts/Systems/Crystal/SuppressionNodeSystem.cs
+// Applies CrystalDebuff to enemy (non-White) units within Suppression aura range.
+// Removes the debuff when units leave the aura radius.
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Ticks every 1 second. For each Suppression node, queries all
+    /// non-White UnitTag entities and adds/removes CrystalDebuff based on distance.
+    /// The strongest overlapping debuff wins (max of all auras in range).
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SuppressionNodeSystem : ISystem
+    {
+        private const float TickInterval = 1f;
+        private float _timer;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<SuppressionAura>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            _timer += dt;
+            if (_timer < TickInterval) return;
+            _timer = 0f;
+
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var em = state.EntityManager;
+
+            // Snapshot all suppression aura sources
+            var auraQuery = SystemAPI.QueryBuilder()
+                .WithAll<SuppressionAura, LocalTransform, CrystalSubNodeTag>()
+                .WithNone<UnderConstruction>()
+                .Build();
+
+            var auraTransforms = auraQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var auraData = auraQuery.ToComponentDataArray<SuppressionAura>(Allocator.Temp);
+
+            // Process all non-crystal units (enemy units with UnitTag)
+            foreach (var (unitTransform, faction, entity) in SystemAPI
+                .Query<RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                // Only debuff non-White (non-crystal) faction units
+                if (faction.ValueRO.Value == Faction.White) continue;
+
+                float3 unitPos = unitTransform.ValueRO.Position;
+
+                // Find strongest debuff from all suppression auras in range
+                float bestDef = 0f;
+                float bestAtt = 0f;
+                float bestSpd = 0f;
+                bool inRange = false;
+
+                for (int i = 0; i < auraTransforms.Length; i++)
+                {
+                    float dist = math.distance(unitPos, auraTransforms[i].Position);
+                    if (dist <= auraData[i].Radius)
+                    {
+                        inRange = true;
+                        bestDef = math.max(bestDef, auraData[i].DefPenalty);
+                        bestAtt = math.max(bestAtt, auraData[i].AttPenalty);
+                        bestSpd = math.max(bestSpd, auraData[i].SpeedPenalty);
+                    }
+                }
+
+                bool hasDebuff = em.HasComponent<CrystalDebuff>(entity);
+
+                if (inRange)
+                {
+                    var debuff = new CrystalDebuff
+                    {
+                        DefPenalty = bestDef,
+                        AttPenalty = bestAtt,
+                        SpeedPenalty = bestSpd
+                    };
+
+                    if (hasDebuff)
+                        ecb.SetComponent(entity, debuff);
+                    else
+                        ecb.AddComponent(entity, debuff);
+                }
+                else if (hasDebuff)
+                {
+                    ecb.RemoveComponent<CrystalDebuff>(entity);
+                }
+            }
+
+            auraTransforms.Dispose();
+            auraData.Dispose();
+
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements Crystal Faction Rework Phase 4: Sub-Node Buildings (5 types) and their supporting aura systems.

### New Entity Factories (`Assets/Scripts/Entities/Buildings/`)
- **CrystalResourceNode** (cost 50, HP 200) - Brittle node that spreads cursed ground at radius 8
- **CrystalEnforcementNode** (cost 200, HP 600) - Buffs crystal allies with +15% def/att, +10% speed
- **CrystalSuppressionNode** (cost 200, HP 600) - Debuffs enemies with -15% def/att, -10% speed
- **CrystalRestorationNode** (cost 120, HP 400) - Heals crystal entities at 5 HP/sec within radius 15
- **CrystalTurretNode** (cost 100, HP 500) - Auto-fires via BuildingCombatSystem (range 25, 15 dmg, 2 targets)

### New Aura Systems (`Assets/Scripts/Systems/Crystal/`)
- **EnforcementNodeSystem** - Adds/removes CrystalBuff on crystal units in aura range (1s tick)
- **SuppressionNodeSystem** - Adds/removes CrystalDebuff on enemy units in aura range (1s tick)
- **RestorationNodeSystem** - Heals damaged CrystalTag entities in aura range (1s tick)

### Modified Files
- **CrystalComponents.cs** - Added `CrystalBuff` and `CrystalDebuff` IComponentData structs
- **CrystalSpreadSystem.cs** - Added Resource sub-node spread loop; extracted `SpawnRingTiles` helper

### Design Notes
- All factories follow the CrystalMainNode dual-overload pattern (EntityManager + ECB)
- Turret node reuses existing BuildingCombatSystem via BuildingTag + BuildingRangedAttack
- Buff/debuff components are markers for Phase 7 combat integration; strongest aura wins
- Resource sub-node spreads at radius 8 (vs main node 15) with shared tile budget

Closes #51