### PR TITLE
feat(economy): crystal income system and bootstrap rework

### DIFF
--- a/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
@@ -4,6 +4,7 @@ using Unity.Entities;
 using Unity.Mathematics;
 using TheWaningBorder.Entities;
 using TheWaningBorder.Core.Config;
+using TheWaningBorder.Economy;
 using TheWaningBorder.World.Terrain;
 
 namespace TheWaningBorder.Bootstrap
@@ -16,8 +17,6 @@ namespace TheWaningBorder.Bootstrap
     /// </summary>
     public static class CrystalNodeBootstrap
     {
-        private const int MinNodes = 2;
-        private const int MaxNodes = 4;
         private const float MinDistFromPlayers = 60f;
         private const float MinDistBetweenNodes = 50f;
 
@@ -41,7 +40,7 @@ namespace TheWaningBorder.Bootstrap
             int half = GameSettings.MapHalfSize;
             float spawnRange = half * 0.7f;
 
-            int nodeCount = random.NextInt(MinNodes, MaxNodes + 1);
+            int nodeCount = playerPositions.Length; // one node per player
             var nodePosArray = new float3[nodeCount];
             int nodesSpawned = 0;
 
@@ -99,7 +98,15 @@ namespace TheWaningBorder.Bootstrap
                 nodesSpawned++;
             }
 
-            Debug.Log($"[CrystalNodeBootstrap] Spawned {nodesSpawned} crystal nodes");
+            // Initialize Faction.White crystal bank if it doesn't exist
+            if (!FactionEconomy.TryGetBank(em, Faction.White, out _))
+            {
+                var bankEntity = em.CreateEntity(typeof(FactionTag), typeof(FactionResources));
+                em.SetComponentData(bankEntity, new FactionTag { Value = Faction.White });
+                em.SetComponentData(bankEntity, new FactionResources { Crystal = 100 * nodesSpawned });
+            }
+
+            Debug.Log($"[CrystalNodeBootstrap] Spawned {nodesSpawned} crystal nodes, bank initialised with {100 * nodesSpawned} crystal");
             return nodesSpawned;
         }
 

--- a/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
@@ -12,7 +12,7 @@ namespace TheWaningBorder.Entities
     /// </summary>
     public static class CrystalMainNode
     {
-        private const int DefaultHP = 800;
+        private const int DefaultHP = 1500;
         private const float DefaultRadius = 2.5f;
         private const float DefaultSpreadRadius = 15f;
         private const float DefaultSpreadPerTick = 1f;
@@ -33,6 +33,7 @@ namespace TheWaningBorder.Entities
                 typeof(FactionTag),
                 typeof(Health),
                 typeof(Radius),
+                typeof(BuildingTag),
                 typeof(CrystalTag),
                 typeof(CrystalMainNodeTag),
                 typeof(CrystalNode),
@@ -45,6 +46,7 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new FactionTag { Value = faction });
             em.SetComponentData(entity, new Health { Value = DefaultHP, Max = DefaultHP });
             em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
             em.SetComponentData(entity, new CrystalNode
             {
                 IsMain = 1,
@@ -83,6 +85,7 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new FactionTag { Value = faction });
             ecb.AddComponent(entity, new Health { Value = DefaultHP, Max = DefaultHP });
             ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
             ecb.AddComponent<CrystalTag>(entity);
             ecb.AddComponent<CrystalMainNodeTag>(entity);
             ecb.AddComponent(entity, new CrystalNode

--- a/Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
@@ -1,0 +1,55 @@
+// File: Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
+// Crystal income system: generates Crystal resources based on cursed ground coverage.
+// Income is credited to Faction.White's resource bank every second.
+
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct CrystalIncomeSystem : ISystem
+    {
+        private float _timer;
+        private const float TickInterval = 1.0f;
+        private const float IncomePerAreaUnit = 0.1f;
+        private const float TileRadius = 2.0f; // matches CrystalSpreadSystem
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<CrystalMainNodeTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            _timer += SystemAPI.Time.DeltaTime;
+            if (_timer < TickInterval) return;
+            _timer = 0f;
+
+            var em = state.EntityManager;
+
+            // Count total cursed ground tiles
+            int totalTiles = 0;
+            foreach (var _ in SystemAPI.Query<RefRO<CursedGroundTag>>())
+            {
+                totalTiles++;
+            }
+
+            if (totalTiles == 0) return;
+
+            // Calculate total cursed area
+            float tileArea = math.PI * TileRadius * TileRadius;
+            float totalArea = totalTiles * tileArea;
+
+            // Income: 0.1 crystal per area unit per second
+            int income = (int)math.ceil(totalArea * IncomePerAreaUnit);
+
+            if (income <= 0) return;
+
+            // Credit to Faction.White bank
+            FactionEconomy.Add(em, Faction.White, new Cost { Crystal = income });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- **CrystalIncomeSystem**: New ECS system that generates Crystal income for Faction.White based on total cursed ground tile coverage. Calculates area from tile count and awards `ceil(totalArea * 0.1)` crystal per second via `FactionEconomy.Add`.
- **CrystalNodeBootstrap**: Node count now scales with player count (one crystal node per player, was random 2-4). Initializes a Faction.White resource bank entity with `100 * nodesSpawned` starting crystal.
- **CrystalMainNode**: HP increased from 800 to 1500 for durability. Added `BuildingTag` component to both `EntityManager` and `EntityCommandBuffer` creation paths so nodes register properly as buildings.

Closes #52

## Test plan
- [ ] Verify crystal nodes spawn equal to player count (2 players = 2 nodes, 4 = 4, etc.)
- [ ] Confirm Faction.White bank entity is created with correct starting crystal (100 per node)
- [ ] Check CrystalIncomeSystem ticks every second and adds crystal proportional to cursed ground count
- [ ] Verify CrystalMainNode shows 1500/1500 HP in EntityInfoPanel
- [ ] Confirm CrystalMainNode appears in building queries (BuildingTag present)
- [ ] Test that destroying all CrystalMainNodeTag entities stops the income system (RequireForUpdate guard)

?? Generated with [Claude Code](https://claude.com/claude-code)