### PR TITLE
feat(combat): add 11 culture-specific units (Runai, Alanthor, Feraldis)

### DIFF
--- a/Assets/Scripts/Core/Components/UnitComponents.cs
+++ b/Assets/Scripts/Core/Components/UnitComponents.cs
@@ -41,6 +41,15 @@ public struct ArcherTag : IComponentData { }
 /// <summary>Marker tag for Berserker units (converted from miners at Fiendstone Keep).</summary>
 public struct BerserkerTag : IComponentData { }
 
+/// <summary>Marker tag for Cavalry units (mounted). Used for anti-cavalry bonus detection.</summary>
+public struct CavalryTag : IComponentData { }
+
+/// <summary>Marker tag for Siege units (anti-structure specialists).</summary>
+public struct SiegeTag : IComponentData { }
+
+/// <summary>Marker tag for Spearman units (anti-cavalry bonus).</summary>
+public struct SpearmanTag : IComponentData { }
+
 // ==================== Archer State ====================
 
 /// <summary>

--- a/Assets/Scripts/Economy/FactionPopulation.cs
+++ b/Assets/Scripts/Economy/FactionPopulation.cs
@@ -193,18 +193,24 @@ namespace TheWaningBorder.Economy
                 "Swordsman" => 1,
                 "Litharch" => 1,
                 
+                // Runai units
+                "Runai_Spearman" => 1,
+                "Runai_Skirmisher" => 1,
+                "Runai_Raider" => 1,
+                "Runai_SandBallista" => 2,
+
                 // Feraldis units
                 "Feraldis_Berserker" => 1,
                 "Feraldis_Hunter" => 1,
-                "Feraldis_WarboarRider" => 2,
-                "Feraldis_SiegeRam" => 3,
-                
+                "Feraldis_WarboarRider" => 1,
+                "Feraldis_SiegeRam" => 2,
+
                 // Alanthor units
                 "Alanthor_Sentinel" => 1,
                 "Alanthor_Crossbowman" => 1,
                 "Alanthor_Cataphract" => 2,
-                "Alanthor_Ballista" => 3,
-                
+                "Alanthor_Ballista" => 2,
+
                 // Default for unknown units
                 _ => 1
             };

--- a/Assets/Scripts/Entities/Units/Ballista.cs
+++ b/Assets/Scripts/Entities/Units/Ballista.cs
@@ -1,0 +1,168 @@
+// File: Assets/Scripts/Entities/Units/Ballista.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Ballista unit - Alanthor culture siege ranged unit.
+    /// Longest range siege weapon in the game. Very slow reload but devastating damage.
+    /// Uses ArcherState for ranged aim mechanics with SiegeTag for identification.
+    /// </summary>
+    public static class Ballista
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 220f;
+        private const float DefaultSpeed = 2.8f;
+        private const float DefaultDamage = 40f;
+        private const float DefaultLoS = 26f;
+        private const float DefaultMinRange = 10f;
+        private const float DefaultMaxRange = 24f;
+        private const float DefaultCooldown = 4.0f;
+        private const float DefaultAimTime = 1.0f;
+        private const float DefaultRadius = 0.8f;
+        private const int PresentationID = 337;
+
+        /// <summary>
+        /// Create Ballista using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Ballista", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(ArcherTag),
+                typeof(SiegeTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(ArcherState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(AttackCooldown),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Siege });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 2 });
+
+            // Archer-specific state for siege ranged behavior
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Siege });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Structure });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 3, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Ballista using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Ballista", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Siege });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent<SiegeTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 2 });
+
+            // Archer-specific state for siege ranged behavior
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Siege });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Structure });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 3, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Cataphract.cs
+++ b/Assets/Scripts/Entities/Units/Cataphract.cs
@@ -1,0 +1,123 @@
+// File: Assets/Scripts/Entities/Units/Cataphract.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Cataphract unit - Alanthor culture heavy cavalry.
+    /// Heavily armored mounted unit. Slower than light cavalry but very durable.
+    /// </summary>
+    public static class Cataphract
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 180f;
+        private const float DefaultSpeed = 6.5f;
+        private const float DefaultDamage = 18f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.1f;
+        private const float DefaultRadius = 0.6f;
+        private const int PresentationID = 336;
+
+        /// <summary>
+        /// Create Cataphract using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Cataphract", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(CavalryTag)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 2 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            em.AddComponentData(entity, new Defense { Melee = 3, Ranged = 2, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Cataphract using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Cataphract", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 2 });
+            ecb.AddComponent<CavalryTag>(entity);
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            ecb.AddComponent(entity, new Defense { Melee = 3, Ranged = 2, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Crossbowman.cs
+++ b/Assets/Scripts/Entities/Units/Crossbowman.cs
@@ -1,0 +1,165 @@
+// File: Assets/Scripts/Entities/Units/Crossbowman.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Crossbowman unit - Alanthor culture ranged infantry.
+    /// Slow but armored ranged unit with long range and high damage.
+    /// Uses ArcherState for ranged aim/retreat behavior.
+    /// </summary>
+    public static class Crossbowman
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 100f;
+        private const float DefaultSpeed = 3.5f;
+        private const float DefaultDamage = 16f;
+        private const float DefaultLoS = 25f;
+        private const float DefaultMinRange = 6f;
+        private const float DefaultMaxRange = 22f;
+        private const float DefaultCooldown = 2.0f;
+        private const float DefaultAimTime = 0.5f;
+        private const int PresentationID = 335;
+
+        /// <summary>
+        /// Create Crossbowman using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Crossbowman", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(ArcherTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(ArcherState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(AttackCooldown),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Ranged });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags - armored ranged unit
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Ranged });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 2, Ranged = 2, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Crossbowman using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Crossbowman", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Ranged });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags - armored ranged unit
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 2, Ranged = 2, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Hunter.cs
+++ b/Assets/Scripts/Entities/Units/Hunter.cs
@@ -1,0 +1,165 @@
+// File: Assets/Scripts/Entities/Units/Hunter.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Hunter unit - Feraldis culture ranged infantry.
+    /// Fast ranged unit with hit-and-run tactics. Fragile but quick.
+    /// Uses ArcherState for ranged aim/retreat behavior.
+    /// </summary>
+    public static class Hunter
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 100f;
+        private const float DefaultSpeed = 5.7f;
+        private const float DefaultDamage = 11f;
+        private const float DefaultLoS = 15f;
+        private const float DefaultMinRange = 4f;
+        private const float DefaultMaxRange = 12f;
+        private const float DefaultCooldown = 1.2f;
+        private const float DefaultAimTime = 0.5f;
+        private const int PresentationID = 338;
+
+        /// <summary>
+        /// Create Hunter using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_Hunter", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(ArcherTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(ArcherState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(AttackCooldown),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Ranged });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Ranged });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Hunter using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_Hunter", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Ranged });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Raider.cs
+++ b/Assets/Scripts/Entities/Units/Raider.cs
@@ -1,0 +1,123 @@
+// File: Assets/Scripts/Entities/Units/Raider.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Raider unit - Runai culture cavalry.
+    /// Fast mounted unit with charge bonus.
+    /// </summary>
+    public static class Raider
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 150f;
+        private const float DefaultSpeed = 7.2f;
+        private const float DefaultDamage = 18f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.0f;
+        private const float DefaultRadius = 0.6f;
+        private const int PresentationID = 332;
+
+        /// <summary>
+        /// Create Raider using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Raider", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(CavalryTag)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            em.AddComponentData(entity, new Defense { Melee = 1, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Raider using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Raider", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+            ecb.AddComponent<CavalryTag>(entity);
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            ecb.AddComponent(entity, new Defense { Melee = 1, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/SandBallista.cs
+++ b/Assets/Scripts/Entities/Units/SandBallista.cs
@@ -1,0 +1,168 @@
+// File: Assets/Scripts/Entities/Units/SandBallista.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Sand Ballista unit - Runai culture siege ranged unit.
+    /// Long-range siege weapon effective against structures. Slow reload.
+    /// Uses ArcherState for ranged aim mechanics with SiegeTag for identification.
+    /// </summary>
+    public static class SandBallista
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 200f;
+        private const float DefaultSpeed = 3.4f;
+        private const float DefaultDamage = 36f;
+        private const float DefaultLoS = 22f;
+        private const float DefaultMinRange = 8f;
+        private const float DefaultMaxRange = 20f;
+        private const float DefaultCooldown = 3.5f;
+        private const float DefaultAimTime = 1.0f;
+        private const float DefaultRadius = 0.8f;
+        private const int PresentationID = 333;
+
+        /// <summary>
+        /// Create SandBallista using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_SandBallista", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(ArcherTag),
+                typeof(SiegeTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(ArcherState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(AttackCooldown),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Siege });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 2 });
+
+            // Archer-specific state for siege ranged behavior
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Siege });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Structure });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 2, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create SandBallista using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_SandBallista", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Siege });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent<SiegeTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 2 });
+
+            // Archer-specific state for siege ranged behavior
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Siege });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Structure });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 2, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Sentinel.cs
+++ b/Assets/Scripts/Entities/Units/Sentinel.cs
@@ -1,0 +1,121 @@
+// File: Assets/Scripts/Entities/Units/Sentinel.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Sentinel unit - Alanthor culture heavy melee infantry.
+    /// Extremely tanky with high defense values. Slow but hard to kill.
+    /// </summary>
+    public static class Sentinel
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 160f;
+        private const float DefaultSpeed = 3.2f;
+        private const float DefaultDamage = 14f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.4f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 334;
+
+        /// <summary>
+        /// Create Sentinel using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Sentinel", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Combat type tags - very high defense
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 8, Ranged = 4, Siege = 2, Magic = 1 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Sentinel using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Alanthor_Sentinel", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            // Combat type tags - very high defense
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 8, Ranged = 4, Siege = 2, Magic = 1 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/SiegeRam.cs
+++ b/Assets/Scripts/Entities/Units/SiegeRam.cs
@@ -1,0 +1,124 @@
+// File: Assets/Scripts/Entities/Units/SiegeRam.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Siege Ram unit - Feraldis culture melee siege unit.
+    /// Anti-structure melee siege weapon. Very high HP, slow, devastating vs buildings.
+    /// Uses melee pattern with SiegeTag and extended melee range (2.5).
+    /// </summary>
+    public static class SiegeRam
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 300f;
+        private const float DefaultSpeed = 3.0f;
+        private const float DefaultDamage = 34f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 3.0f;
+        private const float DefaultRadius = 1.0f;
+        private const int PresentationID = 340;
+
+        /// <summary>
+        /// Create SiegeRam using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_SiegeRam", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(SiegeTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Siege });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 2 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Siege });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 4, Ranged = 2, Siege = 6, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create SiegeRam using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_SiegeRam", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Siege });
+            ecb.AddComponent<SiegeTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 2 });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Siege });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 4, Ranged = 2, Siege = 6, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Skirmisher.cs
+++ b/Assets/Scripts/Entities/Units/Skirmisher.cs
@@ -1,0 +1,164 @@
+// File: Assets/Scripts/Entities/Units/Skirmisher.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Skirmisher unit - Runai culture ranged infantry.
+    /// Fast hit-and-run ranged unit. Retreats when enemies get too close (like Archer).
+    /// </summary>
+    public static class Skirmisher
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 95f;
+        private const float DefaultSpeed = 6.0f;
+        private const float DefaultDamage = 15f;
+        private const float DefaultLoS = 15f;
+        private const float DefaultMinRange = 5f;
+        private const float DefaultMaxRange = 11f;
+        private const float DefaultCooldown = 1.3f;
+        private const float DefaultAimTime = 0.5f;
+        private const int PresentationID = 331;
+
+        /// <summary>
+        /// Create Skirmisher using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Skirmisher", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(ArcherTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(LineOfSight),
+                typeof(ArcherState),
+                typeof(Target),
+                typeof(Radius),
+                typeof(AttackCooldown),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Ranged });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Ranged });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 1, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Skirmisher using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Skirmisher", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Ranged });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            // Archer-specific state for ranged behavior
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 1, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Spearman.cs
+++ b/Assets/Scripts/Entities/Units/Spearman.cs
@@ -1,0 +1,123 @@
+// File: Assets/Scripts/Entities/Units/Spearman.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Spearman unit - Runai culture melee infantry.
+    /// Anti-cavalry specialist with +50% bonus vs Cavalry armor.
+    /// </summary>
+    public static class Spearman
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 130f;
+        private const float DefaultSpeed = 5.6f;
+        private const float DefaultDamage = 12f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.0f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 330;
+
+        /// <summary>
+        /// Create Spearman using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Spearman", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(SpearmanTag)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Spearman using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Runai_Spearman", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+            ecb.AddComponent<SpearmanTag>(entity);
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/UnitFactory.cs
+++ b/Assets/Scripts/Entities/Units/UnitFactory.cs
@@ -40,6 +40,20 @@ namespace TheWaningBorder.Entities
                 "Crystalling" => Crystalling.Create(em, position, faction),
                 "Veilstinger" => Veilstinger.Create(em, position, faction),
                 "Godsplinter" => Godsplinter.Create(em, position, faction),
+                // Runai culture units
+                "Runai_Spearman" => Spearman.Create(em, position, faction),
+                "Runai_Skirmisher" => Skirmisher.Create(em, position, faction),
+                "Runai_Raider" => Raider.Create(em, position, faction),
+                "Runai_SandBallista" => SandBallista.Create(em, position, faction),
+                // Alanthor culture units
+                "Alanthor_Sentinel" => Sentinel.Create(em, position, faction),
+                "Alanthor_Crossbowman" => Crossbowman.Create(em, position, faction),
+                "Alanthor_Cataphract" => Cataphract.Create(em, position, faction),
+                "Alanthor_Ballista" => Ballista.Create(em, position, faction),
+                // Feraldis culture units
+                "Feraldis_Hunter" => Hunter.Create(em, position, faction),
+                "Feraldis_WarboarRider" => WarboarRider.Create(em, position, faction),
+                "Feraldis_SiegeRam" => SiegeRam.Create(em, position, faction),
                 _ => CreateDefault(em, unitId, position, faction)
             };
         }
@@ -62,6 +76,20 @@ namespace TheWaningBorder.Entities
                 "Crystalling" => Crystalling.Create(ecb, position, faction),
                 "Veilstinger" => Veilstinger.Create(ecb, position, faction),
                 "Godsplinter" => Godsplinter.Create(ecb, position, faction),
+                // Runai culture units
+                "Runai_Spearman" => Spearman.Create(ecb, position, faction),
+                "Runai_Skirmisher" => Skirmisher.Create(ecb, position, faction),
+                "Runai_Raider" => Raider.Create(ecb, position, faction),
+                "Runai_SandBallista" => SandBallista.Create(ecb, position, faction),
+                // Alanthor culture units
+                "Alanthor_Sentinel" => Sentinel.Create(ecb, position, faction),
+                "Alanthor_Crossbowman" => Crossbowman.Create(ecb, position, faction),
+                "Alanthor_Cataphract" => Cataphract.Create(ecb, position, faction),
+                "Alanthor_Ballista" => Ballista.Create(ecb, position, faction),
+                // Feraldis culture units
+                "Feraldis_Hunter" => Hunter.Create(ecb, position, faction),
+                "Feraldis_WarboarRider" => WarboarRider.Create(ecb, position, faction),
+                "Feraldis_SiegeRam" => SiegeRam.Create(ecb, position, faction),
                 _ => CreateDefault(ecb, unitId, position, faction)
             };
         }
@@ -92,6 +120,20 @@ namespace TheWaningBorder.Entities
                 "Crystalling" => UnitClass.Melee,
                 "Veilstinger" => UnitClass.Ranged,
                 "Godsplinter" => UnitClass.Siege,
+                // Runai culture units
+                "Runai_Spearman" => UnitClass.Melee,
+                "Runai_Skirmisher" => UnitClass.Ranged,
+                "Runai_Raider" => UnitClass.Melee,
+                "Runai_SandBallista" => UnitClass.Siege,
+                // Alanthor culture units
+                "Alanthor_Sentinel" => UnitClass.Melee,
+                "Alanthor_Crossbowman" => UnitClass.Ranged,
+                "Alanthor_Cataphract" => UnitClass.Melee,
+                "Alanthor_Ballista" => UnitClass.Siege,
+                // Feraldis culture units
+                "Feraldis_Hunter" => UnitClass.Ranged,
+                "Feraldis_WarboarRider" => UnitClass.Melee,
+                "Feraldis_SiegeRam" => UnitClass.Siege,
                 _ => UnitClass.Melee
             };
         }
@@ -113,6 +155,20 @@ namespace TheWaningBorder.Entities
                 "Crystalling" => 320,
                 "Veilstinger" => 321,
                 "Godsplinter" => 322,
+                // Runai culture units
+                "Runai_Spearman" => 330,
+                "Runai_Skirmisher" => 331,
+                "Runai_Raider" => 332,
+                "Runai_SandBallista" => 333,
+                // Alanthor culture units
+                "Alanthor_Sentinel" => 334,
+                "Alanthor_Crossbowman" => 335,
+                "Alanthor_Cataphract" => 336,
+                "Alanthor_Ballista" => 337,
+                // Feraldis culture units
+                "Feraldis_Hunter" => 338,
+                "Feraldis_WarboarRider" => 339,
+                "Feraldis_SiegeRam" => 340,
                 _ => 201
             };
         }

--- a/Assets/Scripts/Entities/Units/WarboarRider.cs
+++ b/Assets/Scripts/Entities/Units/WarboarRider.cs
@@ -1,0 +1,123 @@
+// File: Assets/Scripts/Entities/Units/WarboarRider.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Warboar Rider unit - Feraldis culture cavalry.
+    /// Fast mounted unit riding a warboar. Aggressive and hard-hitting.
+    /// </summary>
+    public static class WarboarRider
+    {
+        // Default stats (used if TechTreeDB unavailable)
+        private const float DefaultHP = 160f;
+        private const float DefaultSpeed = 7.0f;
+        private const float DefaultDamage = 16f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.0f;
+        private const float DefaultRadius = 0.6f;
+        private const int PresentationID = 339;
+
+        /// <summary>
+        /// Create WarboarRider using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_WarboarRider", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(CavalryTag)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            em.AddComponentData(entity, new Defense { Melee = 1, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create WarboarRider using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Feraldis_WarboarRider", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+            ecb.AddComponent<CavalryTag>(entity);
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Cavalry });
+            ecb.AddComponent(entity, new Defense { Melee = 1, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #68

Adds factory files for all 11 culture-specific units across three cultures, plus new marker components and factory routing.

### New Unit Files (11)

**Runai:**
- `Spearman.cs` - Anti-cavalry melee (HP:130, Spd:5.6, Dmg:12, Pop:1, ID:330)
- `Skirmisher.cs` - Hit-and-run ranged (HP:95, Spd:6.0, Dmg:15, Pop:1, ID:331)
- `Raider.cs` - Cavalry melee (HP:150, Spd:7.2, Dmg:18, Pop:1, ID:332)
- `SandBallista.cs` - Siege ranged (HP:200, Spd:3.4, Dmg:36, Pop:2, ID:333)

**Alanthor:**
- `Sentinel.cs` - Heavy melee tank (HP:160, Spd:3.2, Dmg:14, Pop:1, ID:334)
- `Crossbowman.cs` - Armored ranged (HP:100, Spd:3.5, Dmg:16, Pop:1, ID:335)
- `Cataphract.cs` - Heavy cavalry (HP:180, Spd:6.5, Dmg:18, Pop:2, ID:336)
- `Ballista.cs` - Long-range siege (HP:220, Spd:2.8, Dmg:40, Pop:2, ID:337)

**Feraldis:**
- `Hunter.cs` - Fast ranged (HP:100, Spd:5.7, Dmg:11, Pop:1, ID:338)
- `WarboarRider.cs` - Cavalry melee (HP:160, Spd:7.0, Dmg:16, Pop:1, ID:339)
- `SiegeRam.cs` - Melee siege (HP:300, Spd:3.0, Dmg:34, Pop:2, ID:340)

### Modified Files (3)
- `UnitComponents.cs` - Added `CavalryTag`, `SiegeTag`, `SpearmanTag`
- `UnitFactory.cs` - Added 11 entries to all 4 switch statements (Create EM, Create ECB, GetUnitClass, GetPresentationId)
- `FactionPopulation.cs` - Added Runai pop costs, fixed Feraldis/Alanthor pop values

## Test Plan
- [ ] Verify no compile errors in Unity Editor
- [ ] Spawn each unit via UnitFactory.Create with culture-prefixed IDs
- [ ] Verify stats match design tables in issue #68
- [ ] Verify ranged units (Skirmisher, Crossbowman, Hunter) have ArcherState aim/retreat
- [ ] Verify siege ranged units (SandBallista, Ballista) have SiegeTag + ArcherState
- [ ] Verify cavalry units (Raider, Cataphract, WarboarRider) have CavalryTag
- [ ] Verify PopulationCost amounts match spec

---
*Generated by Coder agent for issue #68*