### PR TITLE
feat(building): add 14 culture-specific buildings (Runai, Alanthor, Feraldis)

### DIFF
--- a/Assets/Scripts/Core/Commands/CommandTypes/BuildCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/BuildCommand.cs
@@ -153,6 +153,22 @@ namespace TheWaningBorder.Core.Commands.Types
                 "FiendstoneKeep" => 2.4f,
                 "Alanthor_Wall" => 0.8f,
                 "Alanthor_Smelter" => 1.5f,
+                // Runai culture buildings
+                "Runai_Outpost" => 1.0f,
+                "Runai_TradeHub" => 1.5f,
+                "Runai_Bazaar" => 2.5f,
+                "Runai_SiegeWorkshop" => 1.2f,
+                // Alanthor culture buildings
+                "Alanthor_WatchTower" => 0.8f,
+                "Alanthor_Garrison" => 1.5f,
+                "Alanthor_RoyalStable" => 1.5f,
+                "Alanthor_SiegeYard" => 1.2f,
+                // Feraldis culture buildings
+                "Feraldis_HuntingLodge" => 1.2f,
+                "Feraldis_LoggingStation" => 1.2f,
+                "Feraldis_Longhouse" => 1.8f,
+                "Feraldis_TotemTower" => 0.8f,
+                "Feraldis_SiegeYard" => 1.2f,
                 _ => 1.5f
             };
         }

--- a/Assets/Scripts/Core/Components/BuildingComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingComponents.cs
@@ -101,6 +101,12 @@ public struct OutpostTag : IComponentData { }
 /// <summary>Runai trade building.</summary>
 public struct TradeHubTag : IComponentData { }
 
+/// <summary>Runai mobile HQ. Unique per player. +40 pop, dual training queue.</summary>
+public struct BazaarTag : IComponentData { }
+
+/// <summary>Runai siege unit training building.</summary>
+public struct SiegeWorkshopTag : IComponentData { }
+
 // ==================== Era 2 - Alanthor Culture Buildings ====================
 
 /// <summary>Alanthor metal processing building.</summary>
@@ -108,6 +114,18 @@ public struct SmelterTag : IComponentData { }
 
 /// <summary>Alanthor advanced construction building.</summary>
 public struct CrucibleTag : IComponentData { }
+
+/// <summary>Alanthor ranged defensive tower. Garrison 4.</summary>
+public struct WatchTowerTag : IComponentData { }
+
+/// <summary>Alanthor military training building. +8 pop. Trains Sentinel+Crossbowman.</summary>
+public struct GarrisonTag : IComponentData { }
+
+/// <summary>Alanthor cavalry training building. Trains Cataphract.</summary>
+public struct RoyalStableTag : IComponentData { }
+
+/// <summary>Alanthor siege unit training building. Trains Ballista.</summary>
+public struct SiegeYardTag : IComponentData { }
 
 // ==================== Era 2 - Feraldis Culture Buildings ====================
 
@@ -119,6 +137,18 @@ public struct LoggingStationTag : IComponentData { }
 
 /// <summary>Feraldis weapon forge building.</summary>
 public struct WarbrandFoundryTag : IComponentData { }
+
+/// <summary>Feraldis batch training longhouse. Has BatchTrainingTag.</summary>
+public struct LonghouseTag : IComponentData { }
+
+/// <summary>Marker for buildings that batch-train units (e.g., Feraldis Longhouse).</summary>
+public struct BatchTrainingTag : IComponentData { }
+
+/// <summary>Feraldis ranged defensive totem tower.</summary>
+public struct TotemTowerTag : IComponentData { }
+
+/// <summary>Feraldis siege unit training building. Trains Siege Ram.</summary>
+public struct FerSiegeYardTag : IComponentData { }
 
 // ==================== Sect Buildings ====================
 

--- a/Assets/Scripts/Data/TechTree/BuildingCosts.cs
+++ b/Assets/Scripts/Data/TechTree/BuildingCosts.cs
@@ -37,22 +37,28 @@ namespace TheWaningBorder.Data
             { "Keep",           Cost.Of(supplies: 300) },                           // Fiendstone Keep (alias)
             { "FiendstoneKeep", Cost.Of(supplies: 300) },                           // Fiendstone Keep
             
-            // Era 1 - Feraldis Variant
+            // Runai Culture Buildings
+            { "Runai_Outpost",           Cost.Of(supplies: 140, iron: 20) },
+            { "Runai_TradeHub",          Cost.Of(supplies: 240, iron: 40) },
+            { "Runai_Bazaar",            Cost.Of(supplies: 600, iron: 200, crystal: 100) },
+            { "Runai_SiegeWorkshop",     Cost.Of(supplies: 320, iron: 140, crystal: 60) },
+
+            // Feraldis Culture Buildings
             { "Feraldis_BeastPen",       Cost.Of(supplies: 150, iron: 30) },
-            { "Feraldis_HuntingLodge",   Cost.Of(supplies: 100, iron: 20) },
-            { "Feraldis_LoggingStation", Cost.Of(supplies: 80) },
+            { "Feraldis_HuntingLodge",   Cost.Of(supplies: 160, iron: 20) },
+            { "Feraldis_LoggingStation", Cost.Of(supplies: 160, iron: 20) },
             { "Feraldis_Foundry",        Cost.Of(supplies: 200, iron: 80) },
-            { "Feraldis_Tower",          Cost.Of(supplies: 150, iron: 50) },
-            { "Feraldis_Longhouse",      Cost.Of(supplies: 120) },
-            { "Feraldis_SiegeYard",      Cost.Of(supplies: 300, iron: 120) },
-            
-            // Era 2 - Alanthor
+            { "Feraldis_TotemTower",     Cost.Of(supplies: 120, iron: 60) },
+            { "Feraldis_Longhouse",      Cost.Of(supplies: 260, iron: 100) },
+            { "Feraldis_SiegeYard",      Cost.Of(supplies: 260, iron: 120, crystal: 40) },
+
+            // Alanthor Culture Buildings
             { "KingsCourt",              Cost.Of(supplies: 500, iron: 150, crystal: 50) },
             { "Alanthor_Wall",           Cost.Of(supplies: 50, iron: 20) },
-            { "Alanthor_Tower",          Cost.Of(supplies: 180, iron: 60) },
-            { "Alanthor_Garrison",       Cost.Of(supplies: 280, iron: 80) },
-            { "Alanthor_Stable",         Cost.Of(supplies: 250, iron: 60) },
-            { "Alanthor_SiegeYard",      Cost.Of(supplies: 350, iron: 140) },
+            { "Alanthor_WatchTower",     Cost.Of(supplies: 140, iron: 70) },
+            { "Alanthor_Garrison",       Cost.Of(supplies: 220, iron: 90) },
+            { "Alanthor_RoyalStable",    Cost.Of(supplies: 260, iron: 120, crystal: 40) },
+            { "Alanthor_SiegeYard",      Cost.Of(supplies: 260, iron: 100, crystal: 60) },
             { "Alanthor_Smelter",        Cost.Of(supplies: 220, iron: 100) },
             { "Alanthor_Crucible",       Cost.Of(supplies: 300, crystal: 80, veilsteel: 30) },
         };

--- a/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
+++ b/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
@@ -40,6 +40,22 @@ namespace TheWaningBorder.Entities
                 "FiendstoneKeep" => CreateFiendstoneKeep(em, position, faction),
                 "Alanthor_Wall" => AlanthorWall.CreateHub(em, position, faction),
                 "Alanthor_Smelter" => Smelter.Create(em, position, faction),
+                // Runai culture buildings
+                "Runai_Outpost" => CreateRunaiOutpost(em, position, faction),
+                "Runai_TradeHub" => CreateRunaiTradeHub(em, position, faction),
+                "Runai_Bazaar" => CreateRunaiBazaar(em, position, faction),
+                "Runai_SiegeWorkshop" => CreateRunaiSiegeWorkshop(em, position, faction),
+                // Alanthor culture buildings
+                "Alanthor_WatchTower" => CreateAlanthorWatchTower(em, position, faction),
+                "Alanthor_Garrison" => CreateAlanthorGarrison(em, position, faction),
+                "Alanthor_RoyalStable" => CreateAlanthorRoyalStable(em, position, faction),
+                "Alanthor_SiegeYard" => CreateAlanthorSiegeYard(em, position, faction),
+                // Feraldis culture buildings
+                "Feraldis_HuntingLodge" => CreateFeraldisHuntingLodge(em, position, faction),
+                "Feraldis_LoggingStation" => CreateFeraldisLoggingStation(em, position, faction),
+                "Feraldis_Longhouse" => CreateFeraldisLonghouse(em, position, faction),
+                "Feraldis_TotemTower" => CreateFeraldisTotemTower(em, position, faction),
+                "Feraldis_SiegeYard" => CreateFeraldisSiegeYard(em, position, faction),
                 _ => CreateDefault(em, buildingId, position, faction)
             };
         }
@@ -59,6 +75,22 @@ namespace TheWaningBorder.Entities
                 "VaultOfAlmierra" => CreateVaultOfAlmierraECB(ecb, position, faction),
                 "FiendstoneKeep" => CreateFiendstoneKeepECB(ecb, position, faction),
                 "Alanthor_Smelter" => Smelter.Create(ecb, position, faction),
+                // Runai culture buildings
+                "Runai_Outpost" => CreateRunaiOutpostECB(ecb, position, faction),
+                "Runai_TradeHub" => CreateRunaiTradeHubECB(ecb, position, faction),
+                "Runai_Bazaar" => CreateRunaiBazaarECB(ecb, position, faction),
+                "Runai_SiegeWorkshop" => CreateRunaiSiegeWorkshopECB(ecb, position, faction),
+                // Alanthor culture buildings
+                "Alanthor_WatchTower" => CreateAlanthorWatchTowerECB(ecb, position, faction),
+                "Alanthor_Garrison" => CreateAlanthorGarrisonECB(ecb, position, faction),
+                "Alanthor_RoyalStable" => CreateAlanthorRoyalStableECB(ecb, position, faction),
+                "Alanthor_SiegeYard" => CreateAlanthorSiegeYardECB(ecb, position, faction),
+                // Feraldis culture buildings
+                "Feraldis_HuntingLodge" => CreateFeraldisHuntingLodgeECB(ecb, position, faction),
+                "Feraldis_LoggingStation" => CreateFeraldisLoggingStationECB(ecb, position, faction),
+                "Feraldis_Longhouse" => CreateFeraldisLonghouseECB(ecb, position, faction),
+                "Feraldis_TotemTower" => CreateFeraldisTotemTowerECB(ecb, position, faction),
+                "Feraldis_SiegeYard" => CreateFeraldisSiegeYardECB(ecb, position, faction),
                 _ => CreateDefault(ecb, buildingId, position, faction)
             };
         }
@@ -79,6 +111,22 @@ namespace TheWaningBorder.Entities
                 "FiendstoneKeep" => 540,
                 "Alanthor_Wall" => AlanthorWall.HubPresentationID,
                 "Alanthor_Smelter" => Smelter.PresentationID,
+                // Runai culture buildings
+                "Runai_Outpost" => 350,
+                "Runai_TradeHub" => 351,
+                "Runai_Bazaar" => 352,
+                "Runai_SiegeWorkshop" => 353,
+                // Alanthor culture buildings
+                "Alanthor_WatchTower" => 354,
+                "Alanthor_Garrison" => 355,
+                "Alanthor_RoyalStable" => 356,
+                "Alanthor_SiegeYard" => 357,
+                // Feraldis culture buildings
+                "Feraldis_HuntingLodge" => 358,
+                "Feraldis_LoggingStation" => 359,
+                "Feraldis_Longhouse" => 360,
+                "Feraldis_TotemTower" => 361,
+                "Feraldis_SiegeYard" => 362,
                 _ => 100
             };
         }
@@ -92,6 +140,10 @@ namespace TheWaningBorder.Entities
             {
                 "Hall" => 20,
                 "Hut" => 10,
+                "Runai_Bazaar" => 40,
+                "Alanthor_Garrison" => 8,
+                "Feraldis_HuntingLodge" => 10,
+                "Feraldis_LoggingStation" => 10,
                 _ => 0
             };
         }
@@ -106,6 +158,14 @@ namespace TheWaningBorder.Entities
                 "Hall" => true,
                 "Barracks" => true,
                 "TempleOfRidan" => true,
+                "Runai_TradeHub" => true,
+                "Runai_Bazaar" => true,
+                "Runai_SiegeWorkshop" => true,
+                "Alanthor_Garrison" => true,
+                "Alanthor_RoyalStable" => true,
+                "Alanthor_SiegeYard" => true,
+                "Feraldis_Longhouse" => true,
+                "Feraldis_SiegeYard" => true,
                 _ => false
             };
         }
@@ -345,6 +405,352 @@ namespace TheWaningBorder.Entities
             return entity;
         }
 
+        // ==================== Runai Culture Buildings (EntityManager) ====================
+
+        /// <summary>
+        /// Runai Outpost — trade node endpoint with extended vision.
+        /// </summary>
+        private static Entity CreateRunaiOutpost(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 900f, los = 20f, radius = 1.0f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_Outpost", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius));
+            em.SetComponentData(entity, new PresentationId { Id = 350 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.AddComponent<OutpostTag>(entity);
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Runai Trade Hub — spawns caravans, defines trade routes. Training building.
+        /// </summary>
+        private static Entity CreateRunaiTradeHub(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1200f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_TradeHub", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 351 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<TradeHubTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Runai Bazaar — mobile HQ. +40 pop. Dual training queue. Unique per player.
+        /// </summary>
+        private static Entity CreateRunaiBazaar(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 2700f, los = 35f, radius = 2.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_Bazaar", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius),
+                typeof(TrainingState), typeof(PopulationProvider));
+            em.SetComponentData(entity, new PresentationId { Id = 352 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 1 }); // Acts as a base
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.SetComponentData(entity, new PopulationProvider { Amount = 40 });
+            em.AddComponent<BazaarTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(4f, 0, 4f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Runai Siege Workshop — trains Sand Ballista.
+        /// </summary>
+        private static Entity CreateRunaiSiegeWorkshop(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1100f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_SiegeWorkshop", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 353 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<SiegeWorkshopTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        // ==================== Alanthor Culture Buildings (EntityManager) ====================
+
+        /// <summary>
+        /// Alanthor Watch Tower — ranged defense (18u range, 14 dmg, 2.0s CD). Garrison 4.
+        /// </summary>
+        private static Entity CreateAlanthorWatchTower(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 950f, los = 22f, radius = 0.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_WatchTower", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius));
+            em.SetComponentData(entity, new PresentationId { Id = 354 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.AddComponent<WatchTowerTag>(entity);
+            em.AddComponentData(entity, new BuildingRangedAttack
+            {
+                Range = 18f, Damage = 14, Cooldown = 2.0f, Timer = 0f, MaxTargets = 1
+            });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Ranged });
+            return entity;
+        }
+
+        /// <summary>
+        /// Alanthor Garrison — trains Sentinel+Crossbowman. +8 pop.
+        /// </summary>
+        private static Entity CreateAlanthorGarrison(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1500f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_Garrison", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius),
+                typeof(TrainingState), typeof(PopulationProvider));
+            em.SetComponentData(entity, new PresentationId { Id = 355 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.SetComponentData(entity, new PopulationProvider { Amount = 8 });
+            em.AddComponent<GarrisonTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Alanthor Royal Stable — trains Cataphract.
+        /// </summary>
+        private static Entity CreateAlanthorRoyalStable(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1300f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_RoyalStable", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 356 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<RoyalStableTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Alanthor Siege Yard — trains Ballista.
+        /// </summary>
+        private static Entity CreateAlanthorSiegeYard(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1100f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_SiegeYard", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 357 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<SiegeYardTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        // ==================== Feraldis Culture Buildings (EntityManager) ====================
+
+        /// <summary>
+        /// Feraldis Hunting Lodge — +10 pop. Passive income near wildlife areas.
+        /// </summary>
+        private static Entity CreateFeraldisHuntingLodge(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1000f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_HuntingLodge", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(PopulationProvider));
+            em.SetComponentData(entity, new PresentationId { Id = 358 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationProvider { Amount = 10 });
+            em.AddComponent<HuntingLodgeTag>(entity);
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Feraldis Logging Station — +10 pop. Passive income near forest areas.
+        /// </summary>
+        private static Entity CreateFeraldisLoggingStation(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1000f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_LoggingStation", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(PopulationProvider));
+            em.SetComponentData(entity, new PresentationId { Id = 359 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationProvider { Amount = 10 });
+            em.AddComponent<LoggingStationTag>(entity);
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Feraldis Longhouse — batch-trains units. Has BatchTrainingTag.
+        /// </summary>
+        private static Entity CreateFeraldisLonghouse(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1400f, los = 14f, radius = 1.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_Longhouse", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 360 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<LonghouseTag>(entity);
+            em.AddComponent<BatchTrainingTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        /// <summary>
+        /// Feraldis Totem Tower — ranged defense (15u range, 12 dmg, 2.0s CD).
+        /// </summary>
+        private static Entity CreateFeraldisTotemTower(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 900f, los = 18f, radius = 0.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_TotemTower", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius));
+            em.SetComponentData(entity, new PresentationId { Id = 361 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.AddComponent<TotemTowerTag>(entity);
+            em.AddComponentData(entity, new BuildingRangedAttack
+            {
+                Range = 15f, Damage = 12, Cooldown = 2.0f, Timer = 0f, MaxTargets = 1
+            });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Ranged });
+            return entity;
+        }
+
+        /// <summary>
+        /// Feraldis Siege Yard — trains Siege Ram.
+        /// </summary>
+        private static Entity CreateFeraldisSiegeYard(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = 1200f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_SiegeYard", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = em.CreateEntity(typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(BuildingTag), typeof(Health), typeof(LineOfSight), typeof(Radius), typeof(TrainingState));
+            em.SetComponentData(entity, new PresentationId { Id = 362 });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            em.AddComponent<FerSiegeYardTag>(entity);
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
         /// <summary>
         /// Default building creation for unknown types.
         /// </summary>
@@ -493,6 +899,298 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
 
+            return entity;
+        }
+
+        // ==================== Runai Culture Buildings (ECB) ====================
+
+        private static Entity CreateRunaiOutpostECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 900f, los = 20f, radius = 1.0f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_Outpost", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 350 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent<OutpostTag>(entity);
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateRunaiTradeHubECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1200f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_TradeHub", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 351 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<TradeHubTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateRunaiBazaarECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 2700f, los = 35f, radius = 2.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_Bazaar", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 352 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 1 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent(entity, new PopulationProvider { Amount = 40 });
+            ecb.AddComponent<BazaarTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(4f, 0, 4f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateRunaiSiegeWorkshopECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1100f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Runai_SiegeWorkshop", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 353 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<SiegeWorkshopTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        // ==================== Alanthor Culture Buildings (ECB) ====================
+
+        private static Entity CreateAlanthorWatchTowerECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 950f, los = 22f, radius = 0.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_WatchTower", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 354 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent<WatchTowerTag>(entity);
+            ecb.AddComponent(entity, new BuildingRangedAttack
+            {
+                Range = 18f, Damage = 14, Cooldown = 2.0f, Timer = 0f, MaxTargets = 1
+            });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
+            return entity;
+        }
+
+        private static Entity CreateAlanthorGarrisonECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1500f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_Garrison", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 355 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent(entity, new PopulationProvider { Amount = 8 });
+            ecb.AddComponent<GarrisonTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateAlanthorRoyalStableECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1300f, los = 14f, radius = 1.5f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_RoyalStable", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 356 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<RoyalStableTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateAlanthorSiegeYardECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1100f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Alanthor_SiegeYard", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 357 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<SiegeYardTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        // ==================== Feraldis Culture Buildings (ECB) ====================
+
+        private static Entity CreateFeraldisHuntingLodgeECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1000f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_HuntingLodge", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 358 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationProvider { Amount = 10 });
+            ecb.AddComponent<HuntingLodgeTag>(entity);
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateFeraldisLoggingStationECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1000f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_LoggingStation", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 359 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationProvider { Amount = 10 });
+            ecb.AddComponent<LoggingStationTag>(entity);
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateFeraldisLonghouseECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1400f, los = 14f, radius = 1.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_Longhouse", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 360 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<LonghouseTag>(entity);
+            ecb.AddComponent<BatchTrainingTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            return entity;
+        }
+
+        private static Entity CreateFeraldisTotemTowerECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 900f, los = 18f, radius = 0.8f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_TotemTower", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 361 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent<TotemTowerTag>(entity);
+            ecb.AddComponent(entity, new BuildingRangedAttack
+            {
+                Range = 15f, Damage = 12, Cooldown = 2.0f, Timer = 0f, MaxTargets = 1
+            });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Ranged });
+            return entity;
+        }
+
+        private static Entity CreateFeraldisSiegeYardECB(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = 1200f, los = 14f, radius = 1.2f;
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetBuilding("Feraldis_SiegeYard", out var def))
+            { if (def.hp > 0) hp = def.hp; if (def.lineOfSight > 0) los = def.lineOfSight; if (def.radius > 0) radius = def.radius; }
+
+            var entity = ecb.CreateEntity();
+            ecb.AddComponent(entity, new PresentationId { Id = 362 });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+            ecb.AddComponent<FerSiegeYardTag>(entity);
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }
 

--- a/Assets/Scripts/UI/Panels/BuildCommandPannel.cs
+++ b/Assets/Scripts/UI/Panels/BuildCommandPannel.cs
@@ -40,7 +40,16 @@ namespace TheWaningBorder.UI.Panels
         private GameObject _placingInstance;
 
         // Build type
-        public enum BuildType { Hut, GatherersHut, Barracks, Shrine, Vault, Keep, Wall, Smelter }
+        public enum BuildType
+        {
+            Hut, GatherersHut, Barracks, Shrine, Vault, Keep, Wall, Smelter,
+            // Runai culture buildings
+            RunaiOutpost, RunaiTradeHub, RunaiBazaar, RunaiSiegeWorkshop,
+            // Alanthor culture buildings
+            AlanthorWatchTower, AlanthorGarrison, AlanthorRoyalStable, AlanthorSiegeYard,
+            // Feraldis culture buildings
+            FeraldisHuntingLodge, FeraldisLoggingStation, FeraldisLonghouse, FeraldisTotemTower, FeraldisSiegeYard
+        }
         private BuildType _currentBuild = BuildType.Hut;
 
         // Wall chain-placement state
@@ -178,6 +187,22 @@ namespace TheWaningBorder.UI.Panels
                 "FiendstoneKeep" => BuildType.Keep,
                 "Alanthor_Wall" => BuildType.Wall,
                 "Alanthor_Smelter" => BuildType.Smelter,
+                // Runai culture buildings
+                "Runai_Outpost" => BuildType.RunaiOutpost,
+                "Runai_TradeHub" => BuildType.RunaiTradeHub,
+                "Runai_Bazaar" => BuildType.RunaiBazaar,
+                "Runai_SiegeWorkshop" => BuildType.RunaiSiegeWorkshop,
+                // Alanthor culture buildings
+                "Alanthor_WatchTower" => BuildType.AlanthorWatchTower,
+                "Alanthor_Garrison" => BuildType.AlanthorGarrison,
+                "Alanthor_RoyalStable" => BuildType.AlanthorRoyalStable,
+                "Alanthor_SiegeYard" => BuildType.AlanthorSiegeYard,
+                // Feraldis culture buildings
+                "Feraldis_HuntingLodge" => BuildType.FeraldisHuntingLodge,
+                "Feraldis_LoggingStation" => BuildType.FeraldisLoggingStation,
+                "Feraldis_Longhouse" => BuildType.FeraldisLonghouse,
+                "Feraldis_TotemTower" => BuildType.FeraldisTotemTower,
+                "Feraldis_SiegeYard" => BuildType.FeraldisSiegeYard,
                 _ => BuildType.Hut
             };
 
@@ -345,6 +370,64 @@ namespace TheWaningBorder.UI.Panels
                     buildTime = 30f;
                     break;
 
+                // Runai culture buildings
+                case BuildType.RunaiOutpost:
+                    building = BuildingFactory.Create(_em, "Runai_Outpost", pos, fac);
+                    buildTime = 25f;
+                    break;
+                case BuildType.RunaiTradeHub:
+                    building = BuildingFactory.Create(_em, "Runai_TradeHub", pos, fac);
+                    buildTime = 30f;
+                    break;
+                case BuildType.RunaiBazaar:
+                    building = BuildingFactory.Create(_em, "Runai_Bazaar", pos, fac);
+                    buildTime = 40f;
+                    break;
+                case BuildType.RunaiSiegeWorkshop:
+                    building = BuildingFactory.Create(_em, "Runai_SiegeWorkshop", pos, fac);
+                    buildTime = 35f;
+                    break;
+
+                // Alanthor culture buildings
+                case BuildType.AlanthorWatchTower:
+                    building = BuildingFactory.Create(_em, "Alanthor_WatchTower", pos, fac);
+                    buildTime = 25f;
+                    break;
+                case BuildType.AlanthorGarrison:
+                    building = BuildingFactory.Create(_em, "Alanthor_Garrison", pos, fac);
+                    buildTime = 30f;
+                    break;
+                case BuildType.AlanthorRoyalStable:
+                    building = BuildingFactory.Create(_em, "Alanthor_RoyalStable", pos, fac);
+                    buildTime = 35f;
+                    break;
+                case BuildType.AlanthorSiegeYard:
+                    building = BuildingFactory.Create(_em, "Alanthor_SiegeYard", pos, fac);
+                    buildTime = 35f;
+                    break;
+
+                // Feraldis culture buildings
+                case BuildType.FeraldisHuntingLodge:
+                    building = BuildingFactory.Create(_em, "Feraldis_HuntingLodge", pos, fac);
+                    buildTime = 25f;
+                    break;
+                case BuildType.FeraldisLoggingStation:
+                    building = BuildingFactory.Create(_em, "Feraldis_LoggingStation", pos, fac);
+                    buildTime = 25f;
+                    break;
+                case BuildType.FeraldisLonghouse:
+                    building = BuildingFactory.Create(_em, "Feraldis_Longhouse", pos, fac);
+                    buildTime = 30f;
+                    break;
+                case BuildType.FeraldisTotemTower:
+                    building = BuildingFactory.Create(_em, "Feraldis_TotemTower", pos, fac);
+                    buildTime = 25f;
+                    break;
+                case BuildType.FeraldisSiegeYard:
+                    building = BuildingFactory.Create(_em, "Feraldis_SiegeYard", pos, fac);
+                    buildTime = 35f;
+                    break;
+
                 default:
                     return;
             }
@@ -405,6 +488,22 @@ namespace TheWaningBorder.UI.Panels
             BuildType.Keep => "FiendstoneKeep",
             BuildType.Wall => "Alanthor_Wall",
             BuildType.Smelter => "Alanthor_Smelter",
+            // Runai culture buildings
+            BuildType.RunaiOutpost => "Runai_Outpost",
+            BuildType.RunaiTradeHub => "Runai_TradeHub",
+            BuildType.RunaiBazaar => "Runai_Bazaar",
+            BuildType.RunaiSiegeWorkshop => "Runai_SiegeWorkshop",
+            // Alanthor culture buildings
+            BuildType.AlanthorWatchTower => "Alanthor_WatchTower",
+            BuildType.AlanthorGarrison => "Alanthor_Garrison",
+            BuildType.AlanthorRoyalStable => "Alanthor_RoyalStable",
+            BuildType.AlanthorSiegeYard => "Alanthor_SiegeYard",
+            // Feraldis culture buildings
+            BuildType.FeraldisHuntingLodge => "Feraldis_HuntingLodge",
+            BuildType.FeraldisLoggingStation => "Feraldis_LoggingStation",
+            BuildType.FeraldisLonghouse => "Feraldis_Longhouse",
+            BuildType.FeraldisTotemTower => "Feraldis_TotemTower",
+            BuildType.FeraldisSiegeYard => "Feraldis_SiegeYard",
             _ => "Hut"
         };
 

--- a/Assets/Scripts/UI/Panels/EntityExtractors.cs
+++ b/Assets/Scripts/UI/Panels/EntityExtractors.cs
@@ -205,6 +205,22 @@ namespace TheWaningBorder.UI
             if (em.HasComponent<SmelterTag>(entity)) return "Smelter";
             if (em.HasComponent<WallHubTag>(entity)) return "Wall Hub";
             if (em.HasComponent<WallSegmentTag>(entity)) return "Wall";
+            // Runai culture buildings
+            if (em.HasComponent<OutpostTag>(entity)) return "Runai Outpost";
+            if (em.HasComponent<TradeHubTag>(entity)) return "Trade Hub";
+            if (em.HasComponent<BazaarTag>(entity)) return "Bazaar";
+            if (em.HasComponent<SiegeWorkshopTag>(entity)) return "Siege Workshop";
+            // Alanthor culture buildings
+            if (em.HasComponent<WatchTowerTag>(entity)) return "Watch Tower";
+            if (em.HasComponent<GarrisonTag>(entity)) return "Garrison";
+            if (em.HasComponent<RoyalStableTag>(entity)) return "Royal Stable";
+            if (em.HasComponent<SiegeYardTag>(entity)) return "Siege Yard";
+            // Feraldis culture buildings
+            if (em.HasComponent<HuntingLodgeTag>(entity)) return "Hunting Lodge";
+            if (em.HasComponent<LoggingStationTag>(entity)) return "Logging Station";
+            if (em.HasComponent<LonghouseTag>(entity)) return "Longhouse";
+            if (em.HasComponent<TotemTowerTag>(entity)) return "Totem Tower";
+            if (em.HasComponent<FerSiegeYardTag>(entity)) return "Siege Yard";
             return "Building";
         }
 
@@ -360,7 +376,14 @@ namespace TheWaningBorder.UI
         private static readonly HashSet<string> BuildableBuildings = new()
         {
             "Hut", "GatherersHut", "Barracks", "TempleOfRidan", "VaultOfAlmierra", "FiendstoneKeep",
-            "Alanthor_Wall", "Alanthor_Smelter"
+            "Alanthor_Wall", "Alanthor_Smelter",
+            // Runai culture buildings
+            "Runai_Outpost", "Runai_TradeHub", "Runai_Bazaar", "Runai_SiegeWorkshop",
+            // Alanthor culture buildings
+            "Alanthor_WatchTower", "Alanthor_Garrison", "Alanthor_RoyalStable", "Alanthor_SiegeYard",
+            // Feraldis culture buildings
+            "Feraldis_HuntingLodge", "Feraldis_LoggingStation", "Feraldis_Longhouse",
+            "Feraldis_TotemTower", "Feraldis_SiegeYard"
         };
 
         private static List<ActionButton> GetBuildingActions()
@@ -735,6 +758,22 @@ namespace TheWaningBorder.UI
             if (em.HasComponent<VaultTag>(entity)) return "VaultOfAlmierra";
             if (em.HasComponent<FiendstoneKeepTag>(entity)) return "FiendstoneKeep";
             if (em.HasComponent<SmelterTag>(entity)) return "Alanthor_Smelter";
+            // Runai culture buildings
+            if (em.HasComponent<OutpostTag>(entity)) return "Runai_Outpost";
+            if (em.HasComponent<TradeHubTag>(entity)) return "Runai_TradeHub";
+            if (em.HasComponent<BazaarTag>(entity)) return "Runai_Bazaar";
+            if (em.HasComponent<SiegeWorkshopTag>(entity)) return "Runai_SiegeWorkshop";
+            // Alanthor culture buildings
+            if (em.HasComponent<WatchTowerTag>(entity)) return "Alanthor_WatchTower";
+            if (em.HasComponent<GarrisonTag>(entity)) return "Alanthor_Garrison";
+            if (em.HasComponent<RoyalStableTag>(entity)) return "Alanthor_RoyalStable";
+            if (em.HasComponent<SiegeYardTag>(entity)) return "Alanthor_SiegeYard";
+            // Feraldis culture buildings
+            if (em.HasComponent<HuntingLodgeTag>(entity)) return "Feraldis_HuntingLodge";
+            if (em.HasComponent<LoggingStationTag>(entity)) return "Feraldis_LoggingStation";
+            if (em.HasComponent<LonghouseTag>(entity)) return "Feraldis_Longhouse";
+            if (em.HasComponent<TotemTowerTag>(entity)) return "Feraldis_TotemTower";
+            if (em.HasComponent<FerSiegeYardTag>(entity)) return "Feraldis_SiegeYard";
             return null;
         }
     }


### PR DESCRIPTION
Closes #70

## Summary

Adds factory methods for 13 new culture-specific buildings (14 total, FiendstoneKeep already existed) across three cultures:

**Runai (4):** Outpost, TradeHub, Bazaar, SiegeWorkshop
**Alanthor (4):** WatchTower, Garrison, RoyalStable, SiegeYard
**Feraldis (5):** HuntingLodge, LoggingStation, Longhouse, TotemTower, SiegeYard

## Changes

### BuildingComponents.cs
- Added 10 new marker tags: BazaarTag, SiegeWorkshopTag, WatchTowerTag, GarrisonTag, RoyalStableTag, SiegeYardTag, LonghouseTag, BatchTrainingTag, TotemTowerTag, FerSiegeYardTag

### BuildingFactory.cs
- Added 13 EntityManager factory methods + 13 ECB factory methods
- Updated Create() switches, GetPresentationId(), GetPopulationProvided(), CanTrainUnits()
- Training buildings: TrainingState + TrainQueueItem + RallyPoint
- Defense buildings: BuildingRangedAttack + DamageTypeData(Ranged)
- Population buildings: PopulationProvider
- All buildings: ArmorTypeData(StructureHuman)

### BuildCommandPannel.cs
- Extended BuildType enum with 13 new entries
- Updated TriggerBuildingPlacement, BuildId, SpawnSelectedBuilding
- Build times: 25-40s per building type

### EntityExtractors.cs
- Updated GetBuildingName (13 new tag-to-name mappings)
- Updated GetBuildingId (13 new tag-to-ID mappings)
- Expanded BuildableBuildings set with all 13 new IDs

### BuildingCosts.cs
- Added Runai cost entries (4 buildings)
- Updated Feraldis costs to match spec
- Added Alanthor WatchTower/Garrison/RoyalStable/SiegeYard costs

### BuildCommand.cs
- Added 13 new radius fallbacks to GetBuildingRadius()

## PresentationId Assignments
350-353 (Runai), 354-357 (Alanthor), 358-362 (Feraldis)