### PR TITLE
feat(economy): implement Runai trade route system

### DIFF
--- a/Assets/Scripts/Core/Components/TradeComponents.cs
+++ b/Assets/Scripts/Core/Components/TradeComponents.cs
@@ -1,0 +1,87 @@
+// TradeComponents.cs
+// Components for the Runai trade route system
+// Place in: Assets/Scripts/Core/Components/Trade/
+
+using Unity.Entities;
+
+// ==================== Trade Route (on TradeHub buildings) ====================
+
+/// <summary>
+/// Defines a trade route from a TradeHub to its nearest same-faction Outpost.
+/// Attached to TradeHub entities after construction completes.
+/// Route income is proportional to distance: longer routes = more profit.
+/// </summary>
+public struct TradeRoute : IComponentData
+{
+    /// <summary>The target Outpost entity for this route</summary>
+    public Entity OutpostEntity;
+
+    /// <summary>Distance between TradeHub and Outpost positions</summary>
+    public float RouteLength;
+
+    /// <summary>Number of caravans currently active on this route (max 3)</summary>
+    public int ActiveCaravans;
+
+    /// <summary>Countdown timer until next caravan spawns (resets to 22s)</summary>
+    public float SpawnTimer;
+
+    /// <summary>1 = valid route found, 0 = no same-faction Outpost available</summary>
+    public byte RouteValid;
+}
+
+// ==================== Caravan Unit ====================
+
+/// <summary>Marker tag for caravan units. Caravans are uncontrollable auto-trade units.</summary>
+public struct CaravanTag : IComponentData { }
+
+/// <summary>
+/// State data for a caravan traveling a trade route.
+/// Caravans shuttle between a TradeHub (origin) and Outpost (destination),
+/// depositing Supplies on arrival at the Outpost.
+/// </summary>
+public struct CaravanState : IComponentData
+{
+    /// <summary>TradeHub entity where this caravan originates</summary>
+    public Entity Origin;
+
+    /// <summary>Outpost entity where this caravan delivers cargo</summary>
+    public Entity Destination;
+
+    /// <summary>Supplies currently being carried</summary>
+    public float CurrentCargo;
+
+    /// <summary>Max supplies per trip, calculated from route length + tariff</summary>
+    public float MaxCargo;
+
+    /// <summary>0 = traveling to Outpost, 1 = returning to TradeHub</summary>
+    public byte IsReturning;
+
+    /// <summary>The escort unit entity paired with this caravan</summary>
+    public Entity EscortEntity;
+}
+
+// ==================== Caravan Escort Unit ====================
+
+/// <summary>Marker tag for caravan escort units. Auto-follows and defends its caravan.</summary>
+public struct CaravanEscortTag : IComponentData { }
+
+/// <summary>
+/// Links an escort unit to its caravan. Escort follows the caravan
+/// and auto-attacks nearby enemies. Dies when its caravan dies.
+/// </summary>
+public struct CaravanEscort : IComponentData
+{
+    /// <summary>The caravan entity this escort is protecting</summary>
+    public Entity CaravanEntity;
+}
+
+// ==================== Kill Credit Tracking ====================
+
+/// <summary>
+/// Tracks which faction last dealt damage to this entity.
+/// Used by CaravanDeathSystem to credit the killer's faction with loot.
+/// </summary>
+public struct LastDamagedByFaction : IComponentData
+{
+    public Faction Value;
+}

--- a/Assets/Scripts/Entities/Units/Caravan.cs
+++ b/Assets/Scripts/Entities/Units/Caravan.cs
@@ -1,0 +1,104 @@
+// File: Assets/Scripts/Entities/Units/Caravan.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Caravan unit - Runai auto-trade unit.
+    /// Travels between TradeHub and Outpost, depositing Supplies on arrival.
+    /// Uncontrollable by the player. No attack capability.
+    /// Killed caravans drop 50% of carried cargo to the killer's faction.
+    /// </summary>
+    public static class Caravan
+    {
+        private const float DefaultHP = 120f;
+        private const float DefaultSpeed = 5.6f;
+        private const float DefaultLoS = 8f;
+        private const float DefaultRadius = 0.4f;
+        private const int PresentationID = 401;
+
+        /// <summary>
+        /// Create Caravan using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(LineOfSight),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(DesiredDestination)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Economy });
+            em.SetComponentData(entity, new Health { Value = (int)DefaultHP, Max = (int)DefaultHP });
+            em.SetComponentData(entity, new MoveSpeed { Value = DefaultSpeed });
+            em.SetComponentData(entity, new LineOfSight { Radius = DefaultLoS });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 0 });
+            em.SetComponentData(entity, new DesiredDestination { Position = float3.zero, Has = 0 });
+
+            // Caravan-specific components
+            em.AddComponent<CaravanTag>(entity);
+            em.AddComponentData(entity, new CaravanState
+            {
+                Origin = Entity.Null,
+                Destination = Entity.Null,
+                CurrentCargo = 0f,
+                MaxCargo = 0f,
+                IsReturning = 0,
+                EscortEntity = Entity.Null
+            });
+            em.AddComponentData(entity, new LastDamagedByFaction { Value = faction });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create Caravan using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Economy });
+            ecb.AddComponent(entity, new Health { Value = (int)DefaultHP, Max = (int)DefaultHP });
+            ecb.AddComponent(entity, new MoveSpeed { Value = DefaultSpeed });
+            ecb.AddComponent(entity, new LineOfSight { Radius = DefaultLoS });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 0 });
+            ecb.AddComponent(entity, new DesiredDestination { Position = float3.zero, Has = 0 });
+
+            // Caravan-specific components
+            ecb.AddComponent<CaravanTag>(entity);
+            ecb.AddComponent(entity, new CaravanState
+            {
+                Origin = Entity.Null,
+                Destination = Entity.Null,
+                CurrentCargo = 0f,
+                MaxCargo = 0f,
+                IsReturning = 0,
+                EscortEntity = Entity.Null
+            });
+            ecb.AddComponent(entity, new LastDamagedByFaction { Value = faction });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/CaravanEscort.cs
+++ b/Assets/Scripts/Entities/Units/CaravanEscort.cs
@@ -1,0 +1,111 @@
+// File: Assets/Scripts/Entities/Units/CaravanEscort.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Caravan Escort unit - Runai trade guard.
+    /// Auto-follows its paired caravan and attacks nearby enemies.
+    /// Dies when its caravan is destroyed.
+    /// Uncontrollable by the player.
+    /// </summary>
+    public static class CaravanEscortUnit
+    {
+        private const float DefaultHP = 110f;
+        private const float DefaultSpeed = 6.2f;
+        private const float DefaultDamage = 10f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.5f;
+        private const float DefaultRadius = 0.45f;
+        private const int PresentationID = 402;
+
+        /// <summary>
+        /// Create CaravanEscort using EntityManager.
+        /// </summary>
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost),
+                typeof(DesiredDestination)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)DefaultHP, Max = (int)DefaultHP });
+            em.SetComponentData(entity, new MoveSpeed { Value = DefaultSpeed });
+            em.SetComponentData(entity, new Damage { Value = (int)DefaultDamage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = DefaultAttackCooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = DefaultLoS });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 0 });
+            em.SetComponentData(entity, new DesiredDestination { Position = float3.zero, Has = 0 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            // Escort-specific components
+            em.AddComponent<CaravanEscortTag>(entity);
+            em.AddComponentData(entity, new CaravanEscort
+            {
+                CaravanEntity = Entity.Null
+            });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create CaravanEscort using EntityCommandBuffer for deferred creation.
+        /// </summary>
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)DefaultHP, Max = (int)DefaultHP });
+            ecb.AddComponent(entity, new MoveSpeed { Value = DefaultSpeed });
+            ecb.AddComponent(entity, new Damage { Value = (int)DefaultDamage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = DefaultAttackCooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = DefaultLoS });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 0 });
+            ecb.AddComponent(entity, new DesiredDestination { Position = float3.zero, Has = 0 });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            // Escort-specific components
+            ecb.AddComponent<CaravanEscortTag>(entity);
+            ecb.AddComponent(entity, new CaravanEscort
+            {
+                CaravanEntity = Entity.Null
+            });
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
@@ -139,6 +139,15 @@ namespace TheWaningBorder.Systems.Combat
                         if (health.Value < 0) health.Value = 0;
                         ecb.SetComponent(tgt.Value, health);
 
+                        // Track last damager faction for kill credit (used by CaravanDeathSystem)
+                        if (em.HasComponent<LastDamagedByFaction>(tgt.Value) && em.HasComponent<FactionTag>(entity))
+                        {
+                            ecb.SetComponent(tgt.Value, new LastDamagedByFaction
+                            {
+                                Value = em.GetComponentData<FactionTag>(entity).Value
+                            });
+                        }
+
                         // Reset cooldown
                         cd.Timer = cd.Cooldown;
                     }

--- a/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
+++ b/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
@@ -243,6 +243,12 @@ namespace TheWaningBorder.Systems.Combat
             targetHealth.Value -= impactDamage;
             if (targetHealth.Value <= 0) targetHealth.Value = 0;
             em.SetComponentData(targetEntity, targetHealth);
+
+            // Track last damager faction for kill credit (used by CaravanDeathSystem)
+            if (em.HasComponent<LastDamagedByFaction>(targetEntity))
+            {
+                em.SetComponentData(targetEntity, new LastDamagedByFaction { Value = proj.Faction });
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
@@ -143,6 +143,15 @@ namespace TheWaningBorder.Systems.Crystal
                     if (health.Value < 0) health.Value = 0;
                     ecb.SetComponent(tgt.Value, health);
 
+                    // Track last damager faction for kill credit (used by CaravanDeathSystem)
+                    if (em.HasComponent<LastDamagedByFaction>(tgt.Value) && em.HasComponent<FactionTag>(entity))
+                    {
+                        ecb.SetComponent(tgt.Value, new LastDamagedByFaction
+                        {
+                            Value = em.GetComponentData<FactionTag>(entity).Value
+                        });
+                    }
+
                     // Reset siege cooldown
                     gs.SiegeCooldownTimer = SiegeCooldownDuration;
                 }

--- a/Assets/Scripts/Systems/Economy/CaravanDeathSystem.cs
+++ b/Assets/Scripts/Systems/Economy/CaravanDeathSystem.cs
@@ -1,0 +1,83 @@
+// File: Assets/Scripts/Systems/Economy/CaravanDeathSystem.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    /// <summary>
+    /// Handles caravan death: loot distribution and escort cleanup.
+    ///
+    /// Runs BEFORE DeathSystem so it can process caravan-specific logic
+    /// before the entity is destroyed.
+    ///
+    /// On caravan death:
+    /// 1. Credits the killer's faction with 50% of the caravan's current cargo
+    /// 2. Sets the escort's health to 0 (escort dies with caravan)
+    /// 3. Decrements the origin TradeHub's active caravan count
+    ///
+    /// Escort death does NOT kill the caravan (escorts are expendable guards).
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct CaravanDeathSystem : ISystem
+    {
+        private const float DeathLootFraction = 0.5f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
+
+            // =============================================================
+            // Process dead caravans
+            // =============================================================
+            foreach (var (health, caravan, lastDamager, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<CaravanState>, RefRO<LastDamagedByFaction>>()
+                .WithAll<CaravanTag>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                // --- Loot: credit killer's faction with 50% of cargo ---
+                int lootAmount = (int)(caravan.ValueRO.CurrentCargo * DeathLootFraction);
+                if (lootAmount > 0)
+                {
+                    Faction killerFaction = lastDamager.ValueRO.Value;
+                    FactionEconomy.Add(em, killerFaction, Cost.Of(supplies: lootAmount));
+                }
+
+                // --- Kill escort ---
+                Entity escort = caravan.ValueRO.EscortEntity;
+                if (em.Exists(escort) && em.HasComponent<Health>(escort))
+                {
+                    var escortHealth = em.GetComponentData<Health>(escort);
+                    if (escortHealth.Value > 0)
+                    {
+                        escortHealth.Value = 0;
+                        ecb.SetComponent(escort, escortHealth);
+                    }
+                }
+
+                // --- Decrement active caravan count on origin TradeHub ---
+                Entity origin = caravan.ValueRO.Origin;
+                if (em.Exists(origin) && em.HasComponent<TradeRoute>(origin))
+                {
+                    var route = em.GetComponentData<TradeRoute>(origin);
+                    route.ActiveCaravans = math.max(0, route.ActiveCaravans - 1);
+                    ecb.SetComponent(origin, route);
+                }
+
+                // DeathSystem will handle actual entity destruction
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Economy/CaravanMovementSystem.cs
+++ b/Assets/Scripts/Systems/Economy/CaravanMovementSystem.cs
@@ -1,0 +1,160 @@
+// File: Assets/Scripts/Systems/Economy/CaravanMovementSystem.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    /// <summary>
+    /// Manages caravan travel between TradeHub and Outpost endpoints.
+    ///
+    /// Responsibilities:
+    /// 1. Detects when caravans arrive at their destination (DesiredDestination.Has == 0)
+    /// 2. Deposits cargo on arrival at Outpost (credits faction Supplies)
+    /// 3. Reverses direction: Outpost -> TradeHub (empty) -> Outpost (loaded)
+    /// 4. Validates that route endpoints still exist; destroys orphaned caravans
+    /// 5. Updates escort DesiredDestination to follow caravan position
+    ///
+    /// Runs after MovementSystem so arrival detection works on the same frame.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(TheWaningBorder.Systems.Movement.MovementSystem))]
+    public partial struct CaravanMovementSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
+
+            // =============================================================
+            // PHASE 1: Process caravan arrival and cargo operations
+            // =============================================================
+            foreach (var (caravan, dd, faction, transform, entity) in SystemAPI
+                .Query<RefRW<CaravanState>, RefRW<DesiredDestination>, RefRO<FactionTag>, RefRO<LocalTransform>>()
+                .WithAll<CaravanTag>()
+                .WithEntityAccess())
+            {
+                ref var cs = ref caravan.ValueRW;
+                ref var dest = ref dd.ValueRW;
+
+                // Validate that origin and destination still exist
+                bool originValid = em.Exists(cs.Origin) && em.HasComponent<TradeHubTag>(cs.Origin);
+                bool destValid = em.Exists(cs.Destination) && em.HasComponent<OutpostTag>(cs.Destination);
+
+                if (!originValid || !destValid)
+                {
+                    // Route endpoint destroyed - kill caravan and escort
+                    var health = em.GetComponentData<Health>(entity);
+                    health.Value = 0;
+                    ecb.SetComponent(entity, health);
+
+                    // Kill escort too
+                    if (em.Exists(cs.EscortEntity) && em.HasComponent<Health>(cs.EscortEntity))
+                    {
+                        var escortHealth = em.GetComponentData<Health>(cs.EscortEntity);
+                        escortHealth.Value = 0;
+                        ecb.SetComponent(cs.EscortEntity, escortHealth);
+                    }
+
+                    // Decrement active caravan count on origin if it still exists
+                    if (originValid && em.HasComponent<TradeRoute>(cs.Origin))
+                    {
+                        var route = em.GetComponentData<TradeRoute>(cs.Origin);
+                        route.ActiveCaravans = math.max(0, route.ActiveCaravans - 1);
+                        ecb.SetComponent(cs.Origin, route);
+                    }
+
+                    continue;
+                }
+
+                // Only process arrival when movement system says we've arrived
+                if (dest.Has != 0) continue;
+
+                if (cs.IsReturning == 0)
+                {
+                    // === ARRIVED AT OUTPOST ===
+                    // Deposit cargo to faction bank
+                    int suppliesDeposit = (int)cs.CurrentCargo;
+                    if (suppliesDeposit > 0)
+                    {
+                        FactionEconomy.Add(em, faction.ValueRO.Value, Cost.Of(supplies: suppliesDeposit));
+                    }
+
+                    cs.CurrentCargo = 0f;
+                    cs.IsReturning = 1;
+
+                    // Set destination back to TradeHub (return trip, no cargo)
+                    float3 originPos = em.GetComponentData<LocalTransform>(cs.Origin).Position;
+                    dest.Position = originPos;
+                    dest.Has = 1;
+                }
+                else
+                {
+                    // === ARRIVED BACK AT TRADEHUB ===
+                    // Reload cargo for next trip
+                    cs.CurrentCargo = cs.MaxCargo;
+                    cs.IsReturning = 0;
+
+                    // Set destination to Outpost
+                    float3 destPos = em.GetComponentData<LocalTransform>(cs.Destination).Position;
+                    dest.Position = destPos;
+                    dest.Has = 1;
+                }
+            }
+
+            // =============================================================
+            // PHASE 2: Escort follow behavior
+            // =============================================================
+            foreach (var (escort, dd, entity) in SystemAPI
+                .Query<RefRO<CaravanEscort>, RefRW<DesiredDestination>>()
+                .WithAll<CaravanEscortTag>()
+                .WithEntityAccess())
+            {
+                Entity caravanEntity = escort.ValueRO.CaravanEntity;
+
+                // If caravan is gone, escort will be killed by CaravanDeathSystem
+                if (!em.Exists(caravanEntity) || !em.HasComponent<LocalTransform>(caravanEntity))
+                    continue;
+
+                // Check if escort is currently engaged in combat (has an active target)
+                bool inCombat = false;
+                if (em.HasComponent<Target>(entity))
+                {
+                    var target = em.GetComponentData<Target>(entity);
+                    if (target.Value != Entity.Null && em.Exists(target.Value))
+                    {
+                        inCombat = true;
+                    }
+                }
+
+                // If not in combat, follow caravan position
+                if (!inCombat)
+                {
+                    float3 caravanPos = em.GetComponentData<LocalTransform>(caravanEntity).Position;
+                    float3 escortPos = em.GetComponentData<LocalTransform>(entity).Position;
+
+                    // Only update destination if caravan is more than 3 units away
+                    float distSq = math.distancesq(escortPos, caravanPos);
+                    if (distSq > 9f) // 3^2
+                    {
+                        dd.ValueRW.Position = caravanPos;
+                        dd.ValueRW.Has = 1;
+                    }
+                    else if (dd.ValueRO.Has == 0)
+                    {
+                        // Escort arrived near caravan, keep close
+                        // Don't set new destination; just idle near caravan
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Economy/TradeRouteSystem.cs
+++ b/Assets/Scripts/Systems/Economy/TradeRouteSystem.cs
@@ -1,0 +1,257 @@
+// File: Assets/Scripts/Systems/Economy/TradeRouteSystem.cs
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Entities;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    /// <summary>
+    /// Manages Runai trade routes between TradeHubs and Outposts.
+    ///
+    /// Responsibilities:
+    /// 1. Route Discovery: Periodically finds the nearest same-faction Outpost
+    ///    for each TradeHub and establishes a TradeRoute.
+    /// 2. Caravan Spawning: Spawns caravans (with escorts) on a 22-second timer,
+    ///    up to 3 active caravans per route.
+    ///
+    /// Design philosophy: Longer trade routes = more income per trip.
+    /// Formula: baseIncome (25) * (routeLength / 30.0), with +25% tariff bonus
+    /// for routes longer than 60 units.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct TradeRouteSystem : ISystem
+    {
+        // ==================== Constants ====================
+        private const float SpawnInterval = 22f;
+        private const int MaxCaravansPerRoute = 3;
+        private const float BaseIncome = 25f;
+        private const float RouteLengthDivisor = 30f;
+        private const float TariffThreshold = 60f;
+        private const float TariffBonus = 0.25f;
+        private const float RouteDiscoveryInterval = 2f;
+
+        private float _routeDiscoveryTimer;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
+
+            // =============================================================
+            // PHASE 1: Route Discovery (every 2 seconds)
+            // =============================================================
+            _routeDiscoveryTimer -= dt;
+            if (_routeDiscoveryTimer <= 0f)
+            {
+                _routeDiscoveryTimer = RouteDiscoveryInterval;
+                DiscoverRoutes(ref state, em, ecb);
+            }
+
+            // =============================================================
+            // PHASE 2: Caravan Spawning
+            // =============================================================
+            SpawnCaravans(ref state, em, ecb, dt);
+        }
+
+        /// <summary>
+        /// For each completed TradeHub, find the nearest same-faction Outpost
+        /// and create/update a TradeRoute component.
+        /// </summary>
+        private void DiscoverRoutes(ref SystemState state, EntityManager em, EntityCommandBuffer ecb)
+        {
+            // Collect all completed Outpost positions and factions for lookup
+            var outpostQuery = em.CreateEntityQuery(
+                ComponentType.ReadOnly<OutpostTag>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.Exclude<UnderConstruction>()
+            );
+
+            using var outpostEntities = outpostQuery.ToEntityArray(Allocator.Temp);
+            using var outpostFactions = outpostQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            using var outpostTransforms = outpostQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+
+            // Process each TradeHub
+            foreach (var (hubTransform, hubFaction, entity) in SystemAPI
+                .Query<RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<TradeHubTag>()
+                .WithNone<UnderConstruction>()
+                .WithEntityAccess())
+            {
+                float3 hubPos = hubTransform.ValueRO.Position;
+                Faction hubFac = hubFaction.ValueRO.Value;
+
+                // Find nearest same-faction Outpost
+                Entity nearestOutpost = Entity.Null;
+                float nearestDistSq = float.MaxValue;
+
+                for (int i = 0; i < outpostEntities.Length; i++)
+                {
+                    if (outpostFactions[i].Value != hubFac) continue;
+
+                    float3 outpostPos = outpostTransforms[i].Position;
+                    float distSq = math.distancesq(hubPos, outpostPos);
+
+                    if (distSq < nearestDistSq)
+                    {
+                        nearestDistSq = distSq;
+                        nearestOutpost = outpostEntities[i];
+                    }
+                }
+
+                // Update or add TradeRoute component
+                if (nearestOutpost != Entity.Null)
+                {
+                    float routeLength = math.sqrt(nearestDistSq);
+
+                    if (em.HasComponent<TradeRoute>(entity))
+                    {
+                        // Update route target and length only.
+                        // Do NOT touch ActiveCaravans or SpawnTimer -- SpawnCaravans manages those.
+                        var existing = em.GetComponentData<TradeRoute>(entity);
+                        existing.OutpostEntity = nearestOutpost;
+                        existing.RouteLength = routeLength;
+                        existing.RouteValid = 1;
+                        em.SetComponentData(entity, existing);
+                    }
+                    else
+                    {
+                        // First-time route setup (deferred via ECB since adding new component)
+                        ecb.AddComponent(entity, new TradeRoute
+                        {
+                            OutpostEntity = nearestOutpost,
+                            RouteLength = routeLength,
+                            ActiveCaravans = 0,
+                            SpawnTimer = SpawnInterval,
+                            RouteValid = 1
+                        });
+                    }
+                }
+                else
+                {
+                    // No outpost found
+                    if (em.HasComponent<TradeRoute>(entity))
+                    {
+                        var existing = em.GetComponentData<TradeRoute>(entity);
+                        existing.RouteValid = 0;
+                        em.SetComponentData(entity, existing);
+                    }
+                    else
+                    {
+                        ecb.AddComponent(entity, new TradeRoute
+                        {
+                            OutpostEntity = Entity.Null,
+                            RouteLength = 0f,
+                            ActiveCaravans = 0,
+                            SpawnTimer = SpawnInterval,
+                            RouteValid = 0
+                        });
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tick spawn timers on TradeHubs with valid routes.
+        /// Spawn caravan + escort when timer expires and under max count.
+        /// </summary>
+        private void SpawnCaravans(ref SystemState state, EntityManager em, EntityCommandBuffer ecb, float dt)
+        {
+            foreach (var (route, hubTransform, hubFaction, hubEntity) in SystemAPI
+                .Query<RefRW<TradeRoute>, RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<TradeHubTag>()
+                .WithNone<UnderConstruction>()
+                .WithEntityAccess())
+            {
+                ref var r = ref route.ValueRW;
+
+                // Skip invalid routes
+                if (r.RouteValid == 0) continue;
+
+                // Tick spawn timer
+                r.SpawnTimer -= dt;
+
+                if (r.SpawnTimer <= 0f && r.ActiveCaravans < MaxCaravansPerRoute)
+                {
+                    // Validate outpost still exists
+                    if (!em.Exists(r.OutpostEntity) || !em.HasComponent<OutpostTag>(r.OutpostEntity))
+                    {
+                        r.RouteValid = 0;
+                        r.SpawnTimer = SpawnInterval;
+                        continue;
+                    }
+
+                    Faction faction = hubFaction.ValueRO.Value;
+                    float3 hubPos = hubTransform.ValueRO.Position;
+                    float3 outpostPos = em.GetComponentData<LocalTransform>(r.OutpostEntity).Position;
+
+                    // Calculate max cargo for this route
+                    float maxCargo = BaseIncome * (r.RouteLength / RouteLengthDivisor);
+
+                    // Apply tariff bonus for long routes
+                    if (r.RouteLength > TariffThreshold)
+                    {
+                        maxCargo *= (1f + TariffBonus);
+                    }
+
+                    // Spawn caravan at hub position (offset slightly)
+                    float3 spawnPos = hubPos + new float3(2f, 0f, 2f);
+                    Entity caravan = Caravan.Create(em, spawnPos, faction);
+
+                    // Spawn escort at same position
+                    Entity escort = CaravanEscortUnit.Create(em, spawnPos + new float3(1f, 0f, 0f), faction);
+
+                    // Configure caravan state
+                    em.SetComponentData(caravan, new CaravanState
+                    {
+                        Origin = hubEntity,
+                        Destination = r.OutpostEntity,
+                        CurrentCargo = maxCargo, // Start loaded with cargo
+                        MaxCargo = maxCargo,
+                        IsReturning = 0,
+                        EscortEntity = escort
+                    });
+
+                    // Set caravan destination to outpost
+                    em.SetComponentData(caravan, new DesiredDestination
+                    {
+                        Position = outpostPos,
+                        Has = 1
+                    });
+
+                    // Configure escort
+                    em.SetComponentData(escort, new CaravanEscort
+                    {
+                        CaravanEntity = caravan
+                    });
+
+                    // Set escort destination to outpost (will be updated by CaravanMovementSystem)
+                    em.SetComponentData(escort, new DesiredDestination
+                    {
+                        Position = outpostPos,
+                        Has = 1
+                    });
+
+                    // Update route state
+                    r.ActiveCaravans++;
+                    r.SpawnTimer = SpawnInterval;
+                }
+                else if (r.SpawnTimer <= 0f)
+                {
+                    // At max caravans, just reset timer
+                    r.SpawnTimer = SpawnInterval;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements the Runai trade route system -- the unique Runai economic engine where longer trade routes = more profit.

- TradeHubs automatically establish routes to the nearest same-faction Outpost
- Caravans spawn every 22s (max 3 per route) and shuttle between endpoints
- Income formula: `25 * (routeLength / 30)` with +25% tariff bonus for routes > 60u
- Killed caravans credit the killer's faction with 50% of carried cargo
- Each caravan has a paired escort (110HP, 10 melee damage) that auto-follows and fights
- Escorts die when their caravan dies

## New Files
- `Assets/Scripts/Core/Components/TradeComponents.cs` -- TradeRoute, CaravanState, CaravanEscort, LastDamagedByFaction
- `Assets/Scripts/Entities/Units/Caravan.cs` -- 120HP, 5.6 speed, economy class, no attack
- `Assets/Scripts/Entities/Units/CaravanEscort.cs` -- 110HP, 6.2 speed, melee guard
- `Assets/Scripts/Systems/Economy/TradeRouteSystem.cs` -- route discovery + caravan spawning
- `Assets/Scripts/Systems/Economy/CaravanMovementSystem.cs` -- travel, cargo deposit, escort follow
- `Assets/Scripts/Systems/Economy/CaravanDeathSystem.cs` -- loot distribution, escort cleanup

## Modified Files
- `MeleeCombatSystem.cs` -- add LastDamagedByFaction tracking on damage
- `ProjectileSystem.cs` -- add LastDamagedByFaction tracking on projectile impact
- `GodsplinterCombatSystem.cs` -- add LastDamagedByFaction tracking on siege damage

## Design Decisions
- Caravans start loaded with cargo (deliver on first trip to outpost, reload on return)
- Route discovery runs every 2 seconds to find nearest outpost
- Escorts follow caravan position (not route endpoint) to stay near during combat
- Factory class renamed to `CaravanEscortUnit` to avoid naming conflict with `CaravanEscort` component
- `DiscoverRoutes` uses direct `em.SetComponentData` for existing routes to avoid ECB overwrite conflicts with `SpawnCaravans`

Closes #72