### PR TITLE
feat(economy): implement Feraldis battle economy (pillage, batch training, passive income)

### DIFF
--- a/Assets/Scripts/Core/Components/FeraldisComponents.cs
+++ b/Assets/Scripts/Core/Components/FeraldisComponents.cs
@@ -1,0 +1,14 @@
+// FeraldisComponents.cs
+// ECS components for the Feraldis battle economy system
+// Location: Assets/Scripts/Core/Components/FeraldisComponents.cs
+
+using Unity.Entities;
+
+// ==================== Feraldis Economy Components ====================
+
+/// <summary>
+/// Marker tag for entities belonging to a Feraldis-culture faction.
+/// Reserved for future use — efficient query filtering for Feraldis-specific behaviors.
+/// Currently the PillageSystem uses FactionColors.GetFactionCulture() instead.
+/// </summary>
+public struct PillageBonusTag : IComponentData { }

--- a/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
+++ b/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
@@ -642,6 +642,7 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new Radius { Value = radius });
             em.SetComponentData(entity, new PopulationProvider { Amount = 10 });
             em.AddComponent<HuntingLodgeTag>(entity);
+            em.AddComponentData(entity, new SuppliesIncome { PerTick = 15, Interval = 30f, Elapsed = 0f });
             em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }
@@ -666,6 +667,7 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new Radius { Value = radius });
             em.SetComponentData(entity, new PopulationProvider { Amount = 10 });
             em.AddComponent<LoggingStationTag>(entity);
+            em.AddComponentData(entity, new SuppliesIncome { PerTick = 15, Interval = 30f, Elapsed = 0f });
             em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }
@@ -1101,6 +1103,7 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new Radius { Value = radius });
             ecb.AddComponent(entity, new PopulationProvider { Amount = 10 });
             ecb.AddComponent<HuntingLodgeTag>(entity);
+            ecb.AddComponent(entity, new SuppliesIncome { PerTick = 15, Interval = 30f, Elapsed = 0f });
             ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }
@@ -1121,6 +1124,7 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new Radius { Value = radius });
             ecb.AddComponent(entity, new PopulationProvider { Amount = 10 });
             ecb.AddComponent<LoggingStationTag>(entity);
+            ecb.AddComponent(entity, new SuppliesIncome { PerTick = 15, Interval = 30f, Elapsed = 0f });
             ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }

--- a/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
@@ -139,10 +139,10 @@ namespace TheWaningBorder.Systems.Combat
                         if (health.Value < 0) health.Value = 0;
                         ecb.SetComponent(tgt.Value, health);
 
-                        // Track last damager faction for kill credit (used by CaravanDeathSystem)
-                        if (em.HasComponent<LastDamagedByFaction>(tgt.Value) && em.HasComponent<FactionTag>(entity))
+                        // Track last damager faction for kill credit (used by PillageSystem, CaravanDeathSystem)
+                        if (em.HasComponent<FactionTag>(entity))
                         {
-                            ecb.SetComponent(tgt.Value, new LastDamagedByFaction
+                            ecb.AddComponent(tgt.Value, new LastDamagedByFaction
                             {
                                 Value = em.GetComponentData<FactionTag>(entity).Value
                             });

--- a/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
+++ b/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
@@ -244,11 +244,11 @@ namespace TheWaningBorder.Systems.Combat
             if (targetHealth.Value <= 0) targetHealth.Value = 0;
             em.SetComponentData(targetEntity, targetHealth);
 
-            // Track last damager faction for kill credit (used by CaravanDeathSystem)
+            // Track last damager faction for kill credit (used by PillageSystem, CaravanDeathSystem)
             if (em.HasComponent<LastDamagedByFaction>(targetEntity))
-            {
                 em.SetComponentData(targetEntity, new LastDamagedByFaction { Value = proj.Faction });
-            }
+            else
+                em.AddComponentData(targetEntity, new LastDamagedByFaction { Value = proj.Faction });
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
@@ -143,10 +143,10 @@ namespace TheWaningBorder.Systems.Crystal
                     if (health.Value < 0) health.Value = 0;
                     ecb.SetComponent(tgt.Value, health);
 
-                    // Track last damager faction for kill credit (used by CaravanDeathSystem)
-                    if (em.HasComponent<LastDamagedByFaction>(tgt.Value) && em.HasComponent<FactionTag>(entity))
+                    // Track last damager faction for kill credit (used by PillageSystem, CaravanDeathSystem)
+                    if (em.HasComponent<FactionTag>(entity))
                     {
-                        ecb.SetComponent(tgt.Value, new LastDamagedByFaction
+                        ecb.AddComponent(tgt.Value, new LastDamagedByFaction
                         {
                             Value = em.GetComponentData<FactionTag>(entity).Value
                         });

--- a/Assets/Scripts/Systems/Economy/PillageSystem.cs
+++ b/Assets/Scripts/Systems/Economy/PillageSystem.cs
@@ -1,0 +1,97 @@
+// PillageSystem.cs
+// Grants resources to Feraldis factions when they kill enemy units or destroy buildings
+// Location: Assets/Scripts/Systems/Economy/PillageSystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    /// <summary>
+    /// Feraldis battle economy: pillage rewards on kills.
+    ///
+    /// Runs BEFORE DeathSystem so it can inspect dead entities before destruction.
+    /// When an entity dies (Health &lt;= 0) and the killer faction has Feraldis culture:
+    ///   - Enemy non-military unit killed (Damage &lt;= 5): +15 Supplies, +1 Iron
+    ///   - Enemy military unit killed (Damage &gt; 5): +5 Supplies
+    ///   - Enemy building destroyed: +50 Supplies, +5 Iron
+    ///
+    /// Uses LastDamagedByFaction to identify the killer faction.
+    /// Only triggers if the killer faction has Feraldis culture (via FactionColors).
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct PillageSystem : ISystem
+    {
+        // Pillage rewards
+        private const int UnitKillSupplies_NonMilitary = 15;
+        private const int UnitKillIron_NonMilitary = 1;
+        private const int UnitKillSupplies_Military = 5;
+        private const int BuildingKillSupplies = 50;
+        private const int BuildingKillIron = 5;
+
+        // Military threshold: units with Damage > this are considered military
+        private const int MilitaryDamageThreshold = 5;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Process all dead entities that have kill credit tracking
+            foreach (var (health, lastDamager, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastDamagedByFaction>, RefRO<FactionTag>>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                // Get killer faction
+                Faction killerFaction = lastDamager.ValueRO.Value;
+
+                // Only grant pillage if killer is Feraldis culture
+                byte killerCulture = FactionColors.GetFactionCulture(killerFaction);
+                if (killerCulture != Cultures.Feraldis) continue;
+
+                // Don't grant pillage for killing your own faction's entities
+                if (faction.ValueRO.Value == killerFaction) continue;
+
+                // Determine reward based on entity type
+                if (em.HasComponent<BuildingTag>(entity))
+                {
+                    // Building destroyed: +50 Supplies, +5 Iron
+                    FactionEconomy.Add(em, killerFaction,
+                        Cost.Of(supplies: BuildingKillSupplies, iron: BuildingKillIron));
+                }
+                else if (em.HasComponent<UnitTag>(entity))
+                {
+                    // Unit killed: check if military or non-military
+                    int damage = 0;
+                    if (em.HasComponent<Damage>(entity))
+                    {
+                        damage = em.GetComponentData<Damage>(entity).Value;
+                    }
+
+                    if (damage > MilitaryDamageThreshold)
+                    {
+                        // Military unit: +5 Supplies
+                        FactionEconomy.Add(em, killerFaction,
+                            Cost.Of(supplies: UnitKillSupplies_Military));
+                    }
+                    else
+                    {
+                        // Non-military unit (worker/miner): +15 Supplies, +1 Iron
+                        FactionEconomy.Add(em, killerFaction,
+                            Cost.Of(supplies: UnitKillSupplies_NonMilitary,
+                                    iron: UnitKillIron_NonMilitary));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Training/BatchTrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/BatchTrainingSystem.cs
@@ -1,0 +1,266 @@
+// BatchTrainingSystem.cs
+// Handles batch training for Feraldis Longhouse (5 units at once with discounts)
+// Location: Assets/Scripts/Systems/Training/BatchTrainingSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Research;
+
+namespace TheWaningBorder.Systems.Training
+{
+    /// <summary>
+    /// Batch training system for Feraldis Longhouse buildings.
+    ///
+    /// The Longhouse batch-trains 5 units of the same type simultaneously:
+    /// - 10% time discount: totalTime = singleTime * 0.9 (NOT singleTime * 5)
+    /// - All 5 units spawn at once when training completes
+    /// - Cost discount (5%) is handled at queue time by the UI
+    ///
+    /// This system handles ONLY entities with BatchTrainingTag.
+    /// The regular TrainingSystem excludes BatchTrainingTag entities.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct BatchTrainingSystem : ISystem
+    {
+        /// <summary>Holds data for batch spawn deferred until after query iteration.</summary>
+        private struct DeferredBatchSpawn
+        {
+            public Entity Building;
+            public FixedString64Bytes UnitId;
+            public int Count;
+        }
+
+        /// <summary>Number of units spawned per batch.</summary>
+        private const int BatchSize = 5;
+
+        /// <summary>Training time multiplier (10% discount).</summary>
+        private const float TimeMultiplier = 0.9f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BatchTrainingTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var db = TechTreeDB.Instance;
+            if (db == null) return;
+
+            float dt = SystemAPI.Time.DeltaTime;
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            // Track pop consumed this frame to avoid over-spawning
+            var spawnedPopThisFrame = new NativeHashMap<int, int>(8, Allocator.Temp);
+
+            // Collect deferred batch spawns
+            var deferredSpawns = new NativeList<DeferredBatchSpawn>(4, Allocator.Temp);
+
+            // ========== Phase 1: Process timers, collect batch spawn requests ==========
+            foreach (var (ts, entity) in SystemAPI
+                         .Query<RefRW<TrainingState>>()
+                         .WithAll<BatchTrainingTag>()
+                         .WithNone<UnderConstruction>()
+                         .WithEntityAccess())
+            {
+                var queue = state.EntityManager.GetBuffer<TrainQueueItem>(entity);
+
+                // Start training if idle and queue has items
+                if (ts.ValueRO.Busy == 0)
+                {
+                    if (queue.Length == 0) continue;
+
+                    var unitId = queue[0].UnitId.ToString();
+                    if (!db.TryGetUnit(unitId, out var udef))
+                    {
+                        queue.RemoveAt(0);
+                        UnityEngine.Debug.LogWarning($"[BatchTraining] Unknown unit ID: {unitId}");
+                        continue;
+                    }
+
+                    // Start training with 10% time discount
+                    float trainingTime = udef.trainingTime > 0 ? udef.trainingTime : 1f;
+                    float batchTime = trainingTime * TimeMultiplier;
+
+                    ts.ValueRW.Busy = 1;
+                    ts.ValueRW.Remaining = batchTime;
+                }
+                else
+                {
+                    // Tick training timer
+                    ts.ValueRW.Remaining -= dt;
+
+                    if (ts.ValueRO.Remaining <= 0f && queue.Length > 0)
+                    {
+                        // Training complete - check population for all 5 units
+                        var unitId = queue[0].UnitId.ToString();
+                        var em = state.EntityManager;
+                        var faction = em.GetComponentData<FactionTag>(entity).Value;
+                        int perUnitPop = PopulationHelper.GetUnitPopulationCost(unitId);
+                        int totalPopNeeded = perUnitPop * BatchSize;
+
+                        // Include units already spawned this frame
+                        int facKey = (int)faction;
+                        spawnedPopThisFrame.TryGetValue(facKey, out int extraSpawned);
+
+                        if (HasPopulationCapacity(ref state, faction, totalPopNeeded, extraSpawned))
+                        {
+                            // Remove queue item and reset state
+                            queue.RemoveAt(0);
+                            ts.ValueRW.Busy = 0;
+                            ts.ValueRW.Remaining = 0f;
+
+                            // Defer batch spawn
+                            deferredSpawns.Add(new DeferredBatchSpawn
+                            {
+                                Building = entity,
+                                UnitId = new FixedString64Bytes(unitId),
+                                Count = BatchSize
+                            });
+
+                            // Track pop consumed
+                            spawnedPopThisFrame[facKey] = extraSpawned + totalPopNeeded;
+                        }
+                        else
+                        {
+                            // Not enough pop - wait (keep Busy=1, Remaining=0)
+                            ts.ValueRW.Remaining = 0f;
+                        }
+                    }
+                }
+            }
+
+            // ========== Phase 2: Spawn batch units AFTER iteration ==========
+            for (int i = 0; i < deferredSpawns.Length; i++)
+            {
+                var spawn = deferredSpawns[i];
+                SpawnBatch(ref state, ecb, spawn.Building, spawn.UnitId.ToString(), spawn.Count);
+            }
+
+            deferredSpawns.Dispose();
+            spawnedPopThisFrame.Dispose();
+            ecb.Playback(state.EntityManager);
+            ecb.Dispose();
+        }
+
+        /// <summary>
+        /// Check if faction has enough population capacity for the batch,
+        /// accounting for units already spawned this frame.
+        /// </summary>
+        private bool HasPopulationCapacity(ref SystemState state, Faction faction, int requiredPop, int extraSpawnedThisFrame)
+        {
+            foreach (var (tag, pop) in SystemAPI.Query<RefRO<FactionTag>, RefRO<FactionPopulation>>())
+            {
+                if (tag.ValueRO.Value == faction)
+                {
+                    return (pop.ValueRO.Current + extraSpawnedThisFrame + requiredPop) <= pop.ValueRO.Max;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Spawns a batch of units around the building.
+        /// Uses SpawnPlacementHelper to find non-overlapping positions.
+        /// </summary>
+        private static void SpawnBatch(ref SystemState state, EntityCommandBuffer ecb,
+            Entity building, string unitId, int count)
+        {
+            var em = state.EntityManager;
+            var transform = em.GetComponentData<LocalTransform>(building);
+            var faction = em.GetComponentData<FactionTag>(building).Value;
+
+            // Get rally point
+            float3 rallyTarget = float3.zero;
+            bool hasRally = false;
+            if (em.HasComponent<RallyPoint>(building))
+            {
+                var rally = em.GetComponentData<RallyPoint>(building);
+                if (rally.Has != 0)
+                {
+                    rallyTarget = rally.Position;
+                    hasRally = true;
+                }
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                // Offset spawn position slightly for each unit in the batch
+                float angle = (i / (float)count) * math.PI * 2f;
+                float3 offset = new float3(math.cos(angle) * 1.5f, 0, math.sin(angle) * 1.5f);
+                float3 spawnPos = transform.Position + new float3(1.6f, 0, 1.6f) + offset;
+
+                float3 finalPos = SpawnPlacementHelper.FindEmptyPosition(
+                    spawnPos, 0.5f, em, maxAttempts: 16);
+
+                // Create unit via the same factory switch
+                Entity unit = SpawnSingleUnit(em, unitId, finalPos, faction);
+
+                // Apply TechTreeDB stats
+                if (TechTreeDB.Instance != null &&
+                    TechTreeDB.Instance.TryGetUnit(unitId, out var udef))
+                {
+                    ecb.SetComponent(unit, new Health { Value = (int)udef.hp, Max = (int)udef.hp });
+                    ecb.SetComponent(unit, new MoveSpeed { Value = udef.speed });
+                    ecb.SetComponent(unit, new Damage { Value = (int)udef.damage });
+                    ecb.SetComponent(unit, new LineOfSight { Radius = udef.lineOfSight });
+                }
+
+                // Apply completed tech effects
+                TechEffectSystem.ApplyCompletedTechEffects(em, unit, faction);
+
+                // Issue move to rally point
+                if (hasRally)
+                {
+                    if (!em.HasComponent<DesiredDestination>(unit))
+                        em.AddComponentData(unit, new DesiredDestination { Position = rallyTarget, Has = 1 });
+                    else
+                        em.SetComponentData(unit, new DesiredDestination { Position = rallyTarget, Has = 1 });
+
+                    if (!em.HasComponent<GuardPoint>(unit))
+                        em.AddComponentData(unit, new GuardPoint { Position = rallyTarget, Has = 1 });
+                    else
+                        em.SetComponentData(unit, new GuardPoint { Position = rallyTarget, Has = 1 });
+                }
+            }
+
+            UnityEngine.Debug.Log($"[BatchTraining] Spawned {count}x {unitId} for {faction}");
+        }
+
+        /// <summary>
+        /// Create a single unit from its ID string using EntityManager.
+        /// Mirrors the switch in TrainingSystem.SpawnUnit.
+        /// </summary>
+        private static Entity SpawnSingleUnit(EntityManager em, string unitId, float3 position, Faction faction)
+        {
+            return unitId switch
+            {
+                "Swordsman" => Swordsman.Create(em, position, faction),
+                "Archer" => Archer.Create(em, position, faction),
+                "Builder" => Builder.Create(em, position, faction),
+                "Miner" => Miner.Create(em, position, faction),
+                "Scout" => Scout.Create(em, position, faction),
+                "Litharch" => Litharch.Create(em, position, faction),
+                "Berserker" or "Feraldis_Berserker" => Berserker.Create(em, position, faction),
+                // Feraldis culture units
+                "Feraldis_Hunter" => Hunter.Create(em, position, faction),
+                "Feraldis_WarboarRider" => WarboarRider.Create(em, position, faction),
+                "Feraldis_SiegeRam" => SiegeRam.Create(em, position, faction),
+                // Runai culture units
+                "Runai_Spearman" => Spearman.Create(em, position, faction),
+                "Runai_Skirmisher" => Skirmisher.Create(em, position, faction),
+                "Runai_Raider" => Raider.Create(em, position, faction),
+                "Runai_SandBallista" => SandBallista.Create(em, position, faction),
+                // Alanthor culture units
+                "Alanthor_Sentinel" => Sentinel.Create(em, position, faction),
+                "Alanthor_Crossbowman" => Crossbowman.Create(em, position, faction),
+                "Alanthor_Cataphract" => Cataphract.Create(em, position, faction),
+                "Alanthor_Ballista" => Ballista.Create(em, position, faction),
+                _ => Swordsman.Create(em, position, faction)
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -58,9 +58,10 @@ namespace TheWaningBorder.Systems.Training
             var deferredSpawns = new NativeList<DeferredSpawn>(4, Allocator.Temp);
 
             // ═══════════ Phase 1: Process timers, collect spawn requests ═══════════
+            // Exclude BatchTrainingTag entities — those are handled by BatchTrainingSystem
             foreach (var (ts, entity) in SystemAPI
                          .Query<RefRW<TrainingState>>()
-                         .WithNone<UnderConstruction>()
+                         .WithNone<UnderConstruction, BatchTrainingTag>()
                          .WithEntityAccess())
             {
                 var queue = state.EntityManager.GetBuffer<TrainQueueItem>(entity);


### PR DESCRIPTION
## Summary
Implements the Feraldis conquest economy with three subsystems that reward aggressive play:

- **PillageSystem**: Grants resources to Feraldis factions on kills (non-military: +15 Supplies/+1 Iron, military: +5 Supplies, building: +50 Supplies/+5 Iron)
- **BatchTrainingSystem**: Longhouse batch-trains 5 units at once with 10% time discount
- **Passive Income**: HuntingLodge and LoggingStation provide +15 Supplies every 30s via existing SuppliesIncome

Also extends LastDamagedByFaction tracking to ALL entities (not just caravans) by modifying combat systems to always add the component on damage.

## Files Changed
| File | Change |
|------|--------|
| Core/Components/FeraldisComponents.cs | NEW - PillageBonusTag marker component |
| Systems/Economy/PillageSystem.cs | NEW - Kill-based resource rewards |
| Systems/Training/BatchTrainingSystem.cs | NEW - Longhouse 5-unit batch training |
| Entities/Buildings/BuildingFactory.cs | ADD SuppliesIncome to Lodge/Station (EM + ECB) |
| Systems/Combat/MeleeCombatSystem.cs | Always add LastDamagedByFaction on melee damage |
| Systems/Combat/ProjectileSystem.cs | Always add LastDamagedByFaction on projectile impact |
| Systems/Crystal/GodsplinterCombatSystem.cs | Always add LastDamagedByFaction on siege damage |
| Systems/Training/TrainingSystem.cs | Exclude BatchTrainingTag from query |

## Test Plan
- [ ] Kill enemy non-military unit as Feraldis faction -> verify +15 Supplies, +1 Iron
- [ ] Kill enemy military unit as Feraldis faction -> verify +5 Supplies
- [ ] Destroy enemy building as Feraldis faction -> verify +50 Supplies, +5 Iron
- [ ] Kill as non-Feraldis faction -> verify NO pillage bonus
- [ ] Queue unit in Longhouse -> verify training time is 90% of normal
- [ ] Training completes -> verify 5 units spawn simultaneously
- [ ] Build HuntingLodge -> verify +15 Supplies every 30s after construction
- [ ] Build LoggingStation -> verify +15 Supplies every 30s after construction
- [ ] Regular Barracks training still works (not affected by BatchTrainingTag exclusion)
- [ ] No compile errors in Unity

Closes #74