### PR TITLE
feat(core): add sect content - 12 units, 12 chapels, 12 techs, 12 spells

### DIFF
--- a/Assets/Scripts/Core/Components/BuildingComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingComponents.cs
@@ -158,6 +158,16 @@ public struct ChapelSmallTag : IComponentData { }
 /// <summary>Large religious building for sects.</summary>
 public struct ChapelLargeTag : IComponentData { }
 
+/// <summary>
+/// Chapel building tag — generic across all 12 sects.
+/// SectId identifies which sect this chapel belongs to (e.g., "Sect_Renewal").
+/// Chapels train sect-unique units and research sect technologies.
+/// </summary>
+public struct ChapelTag : IComponentData
+{
+    public FixedString64Bytes SectId;
+}
+
 /// <summary>Unique sect-specific building.</summary>
 public struct SectUniqueBuildingTag : IComponentData { }
 

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -1,0 +1,54 @@
+// SpellComponents.cs
+// ECS components for spell buff/debuff effects
+// Location: Assets/Scripts/Core/Components/SpellComponents.cs
+
+using Unity.Entities;
+
+// ==================== Spell Buff/Debuff Components ====================
+
+/// <summary>
+/// Temporary buff applied by a spell. Ticked down by SpellBuffSystem.
+/// Removed automatically when TimeRemaining reaches 0.
+/// </summary>
+public struct SpellBuff : IComponentData
+{
+    /// <summary>Flat armor bonus added to all defense types</summary>
+    public float ArmorBonus;
+
+    /// <summary>Damage multiplier (1.25 = +25% damage)</summary>
+    public float DamageMultiplier;
+
+    /// <summary>Speed multiplier (1.25 = +25% speed)</summary>
+    public float SpeedMultiplier;
+
+    /// <summary>Fraction of damage reflected back to attacker (0.25 = 25%)</summary>
+    public float DamageReflect;
+
+    /// <summary>Seconds remaining for this buff</summary>
+    public float TimeRemaining;
+}
+
+/// <summary>
+/// Temporary debuff applied by a spell. Ticked down by SpellBuffSystem.
+/// Removed automatically when TimeRemaining reaches 0.
+/// </summary>
+public struct SpellDebuff : IComponentData
+{
+    /// <summary>Speed reduction as a fraction (0.30 = -30% speed)</summary>
+    public float SpeedReduction;
+
+    /// <summary>Supplies drained per second from the entity's faction</summary>
+    public float SuppliesDrainPerSecond;
+
+    /// <summary>Seconds remaining for this debuff</summary>
+    public float TimeRemaining;
+}
+
+/// <summary>
+/// Makes an entity temporarily invulnerable (takes no damage).
+/// Applied by LockdownVault spell. Removed when TimeRemaining reaches 0.
+/// </summary>
+public struct Invulnerable : IComponentData
+{
+    public float TimeRemaining;
+}

--- a/Assets/Scripts/Economy/FactionSectState.cs
+++ b/Assets/Scripts/Economy/FactionSectState.cs
@@ -61,6 +61,11 @@ namespace TheWaningBorder.Economy
         private readonly Dictionary<int, SectMultipliers> _multipliersByFaction = new();
 
         /// <summary>
+        /// Researched sect tech flags per faction. Key = (int)Faction.
+        /// </summary>
+        private readonly Dictionary<int, SectTechFlags> _techFlagsByFaction = new();
+
+        /// <summary>
         /// Fired when a sect is successfully adopted. Parameters: (faction, sectId).
         /// Subscribed to by SectEffectSystem to apply entity-level effects.
         /// </summary>
@@ -127,6 +132,20 @@ namespace TheWaningBorder.Economy
             /// <summary>Renewal income bonus value (scaled)</summary>
             public float RenewalIncomeBonus;
 
+            // ── Tech-derived multipliers ──
+
+            /// <summary>Multiplier for magic damage (default 1.0, from RefinedSilverInlays)</summary>
+            public float MagicDamage;
+
+            /// <summary>Spell cooldown reduction (0.0 to 1.0, additive from ClockworkArchives + RefinedSilverInlays)</summary>
+            public float SpellCooldownReduction;
+
+            /// <summary>Additional wall income from TerracePlanning tech (additive)</summary>
+            public float WallIncomeFromTech;
+
+            /// <summary>Out-of-combat HP regen per second from DietaryMandate (0 = none)</summary>
+            public float RegenPerSecond;
+
             /// <summary>Create default multipliers (all 1.0 or 0.0)</summary>
             public static SectMultipliers Default => new SectMultipliers
             {
@@ -146,8 +165,119 @@ namespace TheWaningBorder.Economy
                 PanicChance = 0.0f,
                 ControlChance = 0.0f,
                 HasRenewal = false,
-                RenewalIncomeBonus = 0.0f
+                RenewalIncomeBonus = 0.0f,
+                MagicDamage = 1.0f,
+                SpellCooldownReduction = 0.0f,
+                WallIncomeFromTech = 0.0f,
+                RegenPerSecond = 0.0f
             };
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // SECT TECH FLAGS
+        // ═══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Tracks which sect technologies have been researched per faction.
+        /// Each flag corresponds to one sect's unique researchable technology.
+        /// Systems check these flags to apply tech-specific gameplay effects.
+        /// </summary>
+        public struct SectTechFlags
+        {
+            /// <summary>Renewal: All units gain +2 HP/s out-of-combat regen</summary>
+            public bool DietaryMandate;
+            /// <summary>Antiquity: -15% research time, -5% spell cooldowns</summary>
+            public bool ClockworkArchives;
+            /// <summary>LivingStone: +20% Supplies from wall compartment area</summary>
+            public bool TerracePlanning;
+            /// <summary>VeiledMemory: -25% Crystal retaliation from curse ground</summary>
+            public bool HiddenRecords;
+            /// <summary>StillFlame: Trade routes grant +5 armor to nearby units</summary>
+            public bool SanctifiedRoutes;
+            /// <summary>QuietVault: Retain 50% Crystal+Iron on depot destroyed</summary>
+            public bool HiddenLedgers;
+            /// <summary>MirrorRite: +10% magic attack, -10% spell cooldown</summary>
+            public bool RefinedSilverInlays;
+            /// <summary>ShardJudgment: Enemy buildings near trade routes build 20% slower</summary>
+            public bool IronDecrees;
+            /// <summary>EmberAsh: Enemy civilian kills refund +5 extra Supplies</summary>
+            public bool WarTithe;
+            /// <summary>HollowBrand: Enemy morale auras -20% effectiveness</summary>
+            public bool DesecrateStandards;
+            /// <summary>FlamewroughtChains: +1% damage reduction per Veilsteel stored</summary>
+            public bool VeilsteelLinks;
+            /// <summary>UnmakersGrasp: Crystal death drops yield +20% more crystal</summary>
+            public bool ErasureRites;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // PUBLIC API - SECT TECHS
+        // ═══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Set a sect tech flag for a faction. Called when a sect tech research completes.
+        /// </summary>
+        public void SetTechFlag(Faction faction, string sectId)
+        {
+            int key = (int)faction;
+            if (!_techFlagsByFaction.TryGetValue(key, out var flags))
+                flags = new SectTechFlags();
+
+            switch (sectId)
+            {
+                case SectConfig.Renewal: flags.DietaryMandate = true; break;
+                case SectConfig.Antiquity: flags.ClockworkArchives = true; break;
+                case SectConfig.LivingStone: flags.TerracePlanning = true; break;
+                case SectConfig.VeiledMemory: flags.HiddenRecords = true; break;
+                case SectConfig.StillFlame: flags.SanctifiedRoutes = true; break;
+                case SectConfig.QuietVault: flags.HiddenLedgers = true; break;
+                case SectConfig.MirrorRite: flags.RefinedSilverInlays = true; break;
+                case SectConfig.ShardJudgment: flags.IronDecrees = true; break;
+                case SectConfig.EmberAsh: flags.WarTithe = true; break;
+                case SectConfig.HollowBrand: flags.DesecrateStandards = true; break;
+                case SectConfig.FlamewroughtChains: flags.VeilsteelLinks = true; break;
+                case SectConfig.UnmakersGrasp: flags.ErasureRites = true; break;
+            }
+
+            _techFlagsByFaction[key] = flags;
+            Debug.Log($"[FactionSectState] {faction} researched sect tech: {SectConfig.GetTechDisplayName(sectId)}");
+
+            // Update multipliers to account for tech effects
+            RecomputeMultipliers(faction);
+        }
+
+        /// <summary>
+        /// Check if a faction has researched a specific sect's tech.
+        /// </summary>
+        public bool HasTechFlag(Faction faction, string sectId)
+        {
+            int key = (int)faction;
+            if (!_techFlagsByFaction.TryGetValue(key, out var flags))
+                return false;
+
+            return sectId switch
+            {
+                SectConfig.Renewal => flags.DietaryMandate,
+                SectConfig.Antiquity => flags.ClockworkArchives,
+                SectConfig.LivingStone => flags.TerracePlanning,
+                SectConfig.VeiledMemory => flags.HiddenRecords,
+                SectConfig.StillFlame => flags.SanctifiedRoutes,
+                SectConfig.QuietVault => flags.HiddenLedgers,
+                SectConfig.MirrorRite => flags.RefinedSilverInlays,
+                SectConfig.ShardJudgment => flags.IronDecrees,
+                SectConfig.EmberAsh => flags.WarTithe,
+                SectConfig.HollowBrand => flags.DesecrateStandards,
+                SectConfig.FlamewroughtChains => flags.VeilsteelLinks,
+                SectConfig.UnmakersGrasp => flags.ErasureRites,
+                _ => false
+            };
+        }
+
+        /// <summary>Get all sect tech flags for a faction.</summary>
+        public SectTechFlags GetTechFlags(Faction faction)
+        {
+            int key = (int)faction;
+            return _techFlagsByFaction.TryGetValue(key, out var flags) ? flags : new SectTechFlags();
         }
 
         // ═══════════════════════════════════════════════════════════════════════
@@ -322,6 +452,12 @@ namespace TheWaningBorder.Economy
                 }
             }
 
+            // Apply sect tech effects to multipliers
+            if (_techFlagsByFaction.TryGetValue(key, out var techFlags))
+            {
+                ApplyTechFlagsToMultipliers(ref mults, techFlags, scaling);
+            }
+
             _multipliersByFaction[key] = mults;
 
             Debug.Log($"[FactionSectState] Recomputed multipliers for {faction}: " +
@@ -452,6 +588,38 @@ namespace TheWaningBorder.Economy
             Debug.Log($"[FactionSectState] Synergy '{pair.Name}' active: {pair.Description} (x{scaling} scaling)");
         }
 
+        /// <summary>
+        /// Apply researched sect tech effects to the multiplier struct.
+        /// </summary>
+        private static void ApplyTechFlagsToMultipliers(ref SectMultipliers m, SectTechFlags flags, float scaling)
+        {
+            // DietaryMandate: +2 HP/s out-of-combat regen (scaled by temple)
+            if (flags.DietaryMandate)
+                m.RegenPerSecond += 2f * scaling;
+
+            // ClockworkArchives: -15% research time, -5% spell cooldown
+            if (flags.ClockworkArchives)
+            {
+                m.ResearchSpeed += 0.15f * scaling;
+                m.SpellCooldownReduction += 0.05f * scaling;
+            }
+
+            // TerracePlanning: +20% wall income
+            if (flags.TerracePlanning)
+                m.WallIncomeFromTech += 0.20f * scaling;
+
+            // RefinedSilverInlays: +10% magic attack, -10% spell cooldown
+            if (flags.RefinedSilverInlays)
+            {
+                m.MagicDamage += 0.10f * scaling;
+                m.SpellCooldownReduction += 0.10f * scaling;
+            }
+
+            // Note: Other tech flags (HiddenRecords, SanctifiedRoutes, HiddenLedgers,
+            // IronDecrees, WarTithe, DesecrateStandards, VeilsteelLinks, ErasureRites)
+            // are checked directly by their respective gameplay systems via HasTechFlag().
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // RESET
         // ═══════════════════════════════════════════════════════════════════════
@@ -463,6 +631,7 @@ namespace TheWaningBorder.Economy
         {
             _adoptedByFaction.Clear();
             _multipliersByFaction.Clear();
+            _techFlagsByFaction.Clear();
             Debug.Log("[FactionSectState] Reset all sect state");
         }
     }

--- a/Assets/Scripts/Economy/SectConfig.cs
+++ b/Assets/Scripts/Economy/SectConfig.cs
@@ -223,6 +223,86 @@ namespace TheWaningBorder.Economy
             _ => ""
         };
 
+        // ═══════════════════════════════════════════════════════════════════
+        // SECT TECHNOLOGIES
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>Get the tech ID for a sect's researchable technology.</summary>
+        public static string GetTechId(string sectId) => sectId switch
+        {
+            Renewal => "Tech_DietaryMandate",
+            Antiquity => "Tech_ClockworkArchives",
+            LivingStone => "Tech_TerracePlanning",
+            VeiledMemory => "Tech_HiddenRecords",
+            StillFlame => "Tech_SanctifiedRoutes",
+            QuietVault => "Tech_HiddenLedgers",
+            MirrorRite => "Tech_RefinedSilverInlays",
+            ShardJudgment => "Tech_IronDecrees",
+            EmberAsh => "Tech_WarTithe",
+            HollowBrand => "Tech_DesecrateStandards",
+            FlamewroughtChains => "Tech_VeilsteelLinks",
+            UnmakersGrasp => "Tech_ErasureRites",
+            _ => ""
+        };
+
+        /// <summary>Get the display name for a sect technology.</summary>
+        public static string GetTechDisplayName(string sectId) => sectId switch
+        {
+            Renewal => "Dietary Mandate",
+            Antiquity => "Clockwork Archives",
+            LivingStone => "Terrace Planning",
+            VeiledMemory => "Hidden Records",
+            StillFlame => "Sanctified Routes",
+            QuietVault => "Hidden Ledgers",
+            MirrorRite => "Refined Silver Inlays",
+            ShardJudgment => "Iron Decrees",
+            EmberAsh => "War Tithe",
+            HollowBrand => "Desecrate Standards",
+            FlamewroughtChains => "Veilsteel Links",
+            UnmakersGrasp => "Erasure Rites",
+            _ => ""
+        };
+
+        /// <summary>Get the description for a sect technology.</summary>
+        public static string GetTechDescription(string sectId) => sectId switch
+        {
+            Renewal => "All units gain +2 HP/s out-of-combat regen",
+            Antiquity => "-15% research time, -5% spell cooldowns",
+            LivingStone => "+20% Supplies from wall compartment area",
+            VeiledMemory => "-25% Crystal retaliation from curse ground",
+            StillFlame => "Trade routes grant +5 armor to nearby units",
+            QuietVault => "Retain 50% Crystal+Iron on depot destroyed",
+            MirrorRite => "+10% magic attack, -10% spell cooldown",
+            ShardJudgment => "Enemy buildings near trade routes build 20% slower",
+            EmberAsh => "Enemy civilian kills refund +5 extra Supplies",
+            HollowBrand => "Enemy morale auras -20% effectiveness",
+            FlamewroughtChains => "+1% damage reduction per Veilsteel stored",
+            UnmakersGrasp => "Crystal death drops yield +20% more crystal",
+            _ => ""
+        };
+
+        /// <summary>Get the unique unit ID trainable at a sect's chapel.</summary>
+        public static string GetSectUnitId(string sectId) => sectId switch
+        {
+            Renewal => "Sect_ScarGuard",
+            Antiquity => "Sect_GolemAutark",
+            LivingStone => "Sect_StoneWarden",
+            VeiledMemory => "Sect_ArchivistAdept",
+            StillFlame => "Sect_FlameWarden",
+            QuietVault => "Sect_VaultKeeper",
+            MirrorRite => "Sect_GlassmarkArcanist",
+            ShardJudgment => "Sect_Judicator",
+            EmberAsh => "Sect_Ashblade",
+            HollowBrand => "Sect_Brandbreaker",
+            FlamewroughtChains => "Sect_Chaincaster",
+            UnmakersGrasp => "Sect_Nullblade",
+            _ => ""
+        };
+
+        // ═══════════════════════════════════════════════════════════════════
+        // CULTURE AFFINITY
+        // ═══════════════════════════════════════════════════════════════════
+
         /// <summary>
         /// Get the culture byte constant for a sect's affinity.
         /// </summary>

--- a/Assets/Scripts/Economy/SpellCastSystem.cs
+++ b/Assets/Scripts/Economy/SpellCastSystem.cs
@@ -1,0 +1,393 @@
+// SpellCastSystem.cs
+// Handles spell casting, targeting, and effect application
+// Location: Assets/Scripts/Economy/SpellCastSystem.cs
+
+using UnityEngine;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// MonoBehaviour singleton that executes spell effects on the game world.
+    ///
+    /// Workflow:
+    /// 1. SpellPanel sets SpellCastSystem into targeting mode (BeginTargeting)
+    /// 2. Player clicks a world position
+    /// 3. CastSpell is called with the target position
+    /// 4. System finds entities in area and applies the spell effect
+    /// 5. Cooldown starts via SpellState
+    ///
+    /// Pattern: same as SectEffectSystem (MonoBehaviour singleton with ECS queries).
+    /// </summary>
+    public class SpellCastSystem : MonoBehaviour
+    {
+        // ═══════════════════════════════════════════════════════════════════
+        // SINGLETON
+        // ═══════════════════════════════════════════════════════════════════
+
+        public static SpellCastSystem Instance { get; private set; }
+
+        void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(this);
+                return;
+            }
+            Instance = this;
+        }
+
+        void OnDestroy()
+        {
+            if (Instance == this) Instance = null;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // TARGETING STATE
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>True when waiting for player to click a target location.</summary>
+        public bool IsTargeting { get; private set; }
+
+        /// <summary>The spell being targeted (null if not targeting).</summary>
+        public SpellDefinition ActiveSpell { get; private set; }
+
+        /// <summary>The faction casting the spell.</summary>
+        public Faction CastingFaction { get; private set; }
+
+        /// <summary>
+        /// Enter spell targeting mode. Player must click a world position to cast.
+        /// </summary>
+        public void BeginTargeting(Faction faction, SpellDefinition spell)
+        {
+            IsTargeting = true;
+            ActiveSpell = spell;
+            CastingFaction = faction;
+            Debug.Log($"[SpellCastSystem] Targeting mode: {spell.Name} for {faction}");
+        }
+
+        /// <summary>
+        /// Cancel targeting mode without casting.
+        /// </summary>
+        public void CancelTargeting()
+        {
+            IsTargeting = false;
+            ActiveSpell = null;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // CAST SPELL
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Cast the active spell at the given world position.
+        /// Applies effects to entities in area, starts cooldown, exits targeting mode.
+        /// </summary>
+        /// <returns>True if cast was successful.</returns>
+        public bool CastAtPosition(float3 targetPosition)
+        {
+            if (!IsTargeting || ActiveSpell == null) return false;
+
+            var spell = ActiveSpell;
+            var faction = CastingFaction;
+
+            // Check cooldown
+            var spellState = SpellState.Instance;
+            if (spellState != null && spellState.IsOnCooldown(faction, spell.Id))
+            {
+                Debug.Log($"[SpellCastSystem] {spell.Name} is on cooldown");
+                CancelTargeting();
+                return false;
+            }
+
+            // Execute spell effect
+            bool success = ApplySpellEffect(spell, faction, targetPosition);
+
+            if (success)
+            {
+                // Start cooldown
+                spellState?.StartCooldown(faction, spell.Id, spell.Cooldown);
+                Debug.Log($"[SpellCastSystem] {faction} cast {spell.Name} at {targetPosition}");
+            }
+
+            // Exit targeting mode
+            IsTargeting = false;
+            ActiveSpell = null;
+
+            return success;
+        }
+
+        /// <summary>
+        /// Direct cast without targeting mode (for AI use).
+        /// </summary>
+        public bool CastSpell(Faction faction, string spellId, float3 targetPosition)
+        {
+            var spell = SpellDatabase.GetSpell(spellId);
+            if (spell == null) return false;
+
+            var spellState = SpellState.Instance;
+            if (spellState != null && spellState.IsOnCooldown(faction, spellId))
+                return false;
+
+            bool success = ApplySpellEffect(spell, faction, targetPosition);
+
+            if (success)
+                spellState?.StartCooldown(faction, spellId, spell.Cooldown);
+
+            return success;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // EFFECT APPLICATION
+        // ═══════════════════════════════════════════════════════════════════
+
+        private bool ApplySpellEffect(SpellDefinition spell, Faction faction, float3 targetPosition)
+        {
+            var world = World.DefaultGameObjectInjectionWorld;
+            if (world == null || !world.IsCreated) return false;
+
+            var em = world.EntityManager;
+
+            switch (spell.EffectType)
+            {
+                case "Heal":
+                    return ApplyHeal(em, faction, targetPosition, spell);
+                case "Buff":
+                    return ApplyBuff(em, faction, targetPosition, spell);
+                case "Debuff":
+                    return ApplyDebuff(em, faction, targetPosition, spell);
+                case "Damage":
+                    return ApplyDamage(em, faction, targetPosition, spell);
+                case "Invulnerable":
+                    return ApplyInvulnerable(em, faction, targetPosition, spell);
+                case "Vision":
+                    // Vision spells are flag-based, handled elsewhere
+                    Debug.Log($"[SpellCastSystem] Vision spell '{spell.Name}' activated for {spell.Duration}s");
+                    return true;
+                case "Disable":
+                    // Disable spells are flag-based, handled elsewhere
+                    Debug.Log($"[SpellCastSystem] Disable spell '{spell.Name}' activated for {spell.Duration}s");
+                    return true;
+                default:
+                    Debug.LogWarning($"[SpellCastSystem] Unknown effect type: {spell.EffectType}");
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Heal friendly buildings in area.
+        /// </summary>
+        private static bool ApplyHeal(EntityManager em, Faction faction, float3 center, SpellDefinition spell)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<BuildingTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadWrite<Health>()
+            );
+
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            using var factions = query.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            using var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            using var healths = query.ToComponentDataArray<Health>(Allocator.Temp);
+
+            float radiusSq = spell.AreaRadius * spell.AreaRadius;
+            int healed = 0;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (factions[i].Value != faction) continue;
+
+                float distSq = math.distancesq(transforms[i].Position, center);
+                if (distSq > radiusSq) continue;
+
+                var hp = healths[i];
+                if (hp.Value >= hp.Max) continue;
+
+                hp.Value = math.min(hp.Value + (int)spell.EffectValue, hp.Max);
+                em.SetComponentData(entities[i], hp);
+                healed++;
+            }
+
+            Debug.Log($"[SpellCastSystem] Healed {healed} buildings by {spell.EffectValue} HP");
+            return true;
+        }
+
+        /// <summary>
+        /// Apply buff to friendly entities in area.
+        /// </summary>
+        private static bool ApplyBuff(EntityManager em, Faction faction, float3 center, SpellDefinition spell)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            using var factions = query.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            using var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+
+            float radiusSq = spell.AreaRadius * spell.AreaRadius;
+            int buffed = 0;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (factions[i].Value != faction) continue;
+
+                float distSq = math.distancesq(transforms[i].Position, center);
+                if (distSq > radiusSq) continue;
+
+                // Determine buff values based on spell
+                var buff = new SpellBuff
+                {
+                    ArmorBonus = spell.EffectValue > 0f && spell.SecondaryValue == 0f ? spell.EffectValue : 0f,
+                    DamageMultiplier = spell.Id == "Spell_BattleFervor" ? spell.EffectValue : 1.0f,
+                    SpeedMultiplier = spell.Id == "Spell_BattleFervor" ? spell.SecondaryValue : 1.0f,
+                    DamageReflect = spell.Id == "Spell_ReflectiveWard" ? spell.SecondaryValue : 0f,
+                    TimeRemaining = spell.Duration
+                };
+
+                // Add or replace buff
+                if (em.HasComponent<SpellBuff>(entities[i]))
+                    em.SetComponentData(entities[i], buff);
+                else
+                    em.AddComponentData(entities[i], buff);
+
+                buffed++;
+            }
+
+            Debug.Log($"[SpellCastSystem] Buffed {buffed} entities with {spell.Name}");
+            return true;
+        }
+
+        /// <summary>
+        /// Apply debuff to enemy entities in area.
+        /// </summary>
+        private static bool ApplyDebuff(EntityManager em, Faction faction, float3 center, SpellDefinition spell)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            using var factions = query.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            using var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+
+            float radiusSq = spell.AreaRadius * spell.AreaRadius;
+            int debuffed = 0;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                // Target enemies only
+                if (factions[i].Value == faction) continue;
+
+                float distSq = math.distancesq(transforms[i].Position, center);
+                if (distSq > radiusSq) continue;
+
+                var debuff = new SpellDebuff
+                {
+                    SpeedReduction = spell.Id == "Spell_ProfaneRally" ? spell.EffectValue : 0f,
+                    SuppliesDrainPerSecond = spell.Id == "Spell_EdictOfSeizure" ?
+                        spell.EffectValue / spell.Duration : 0f,
+                    TimeRemaining = spell.Duration
+                };
+
+                if (em.HasComponent<SpellDebuff>(entities[i]))
+                    em.SetComponentData(entities[i], debuff);
+                else
+                    em.AddComponentData(entities[i], debuff);
+
+                debuffed++;
+            }
+
+            Debug.Log($"[SpellCastSystem] Debuffed {debuffed} enemy entities with {spell.Name}");
+            return true;
+        }
+
+        /// <summary>
+        /// Deal damage to target entity (Unravel - single target true damage).
+        /// </summary>
+        private static bool ApplyDamage(EntityManager em, Faction faction, float3 center, SpellDefinition spell)
+        {
+            // Find nearest Crystal entity at target position
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadWrite<Health>()
+            );
+
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            using var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            using var healths = query.ToComponentDataArray<Health>(Allocator.Temp);
+
+            float closestDist = float.MaxValue;
+            int closestIdx = -1;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                float dist = math.distance(transforms[i].Position, center);
+                if (dist < closestDist && dist < 5f) // Must click within 5 units
+                {
+                    closestDist = dist;
+                    closestIdx = i;
+                }
+            }
+
+            if (closestIdx < 0)
+            {
+                Debug.Log("[SpellCastSystem] No valid target found for damage spell");
+                return false;
+            }
+
+            var hp = healths[closestIdx];
+            hp.Value -= (int)spell.EffectValue;
+            if (hp.Value < 0) hp.Value = 0;
+            em.SetComponentData(entities[closestIdx], hp);
+
+            Debug.Log($"[SpellCastSystem] Dealt {spell.EffectValue} true damage to entity");
+            return true;
+        }
+
+        /// <summary>
+        /// Make friendly buildings invulnerable in area.
+        /// </summary>
+        private static bool ApplyInvulnerable(EntityManager em, Faction faction, float3 center, SpellDefinition spell)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<BuildingTag>(),
+                ComponentType.ReadOnly<LocalTransform>()
+            );
+
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            using var factions = query.ToComponentDataArray<FactionTag>(Allocator.Temp);
+            using var transforms = query.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+
+            float radiusSq = spell.AreaRadius * spell.AreaRadius;
+            int count = 0;
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (factions[i].Value != faction) continue;
+
+                float distSq = math.distancesq(transforms[i].Position, center);
+                if (distSq > radiusSq) continue;
+
+                var invuln = new Invulnerable { TimeRemaining = spell.Duration };
+
+                if (em.HasComponent<Invulnerable>(entities[i]))
+                    em.SetComponentData(entities[i], invuln);
+                else
+                    em.AddComponentData(entities[i], invuln);
+
+                count++;
+            }
+
+            Debug.Log($"[SpellCastSystem] Made {count} buildings invulnerable for {spell.Duration}s");
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Economy/SpellDefinition.cs
+++ b/Assets/Scripts/Economy/SpellDefinition.cs
@@ -1,0 +1,296 @@
+// SpellDefinition.cs
+// Static data definitions for all 12 sect spells
+// Location: Assets/Scripts/Economy/SpellDefinition.cs
+
+using System.Collections.Generic;
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// Data definition for a single active spell.
+    /// Spells are unlocked when a faction adopts a sect.
+    /// Cast by selecting the spell and clicking a target location.
+    /// </summary>
+    public class SpellDefinition
+    {
+        /// <summary>Unique spell identifier (e.g., "Spell_RepairLevies")</summary>
+        public string Id;
+
+        /// <summary>Sect ID that unlocks this spell (e.g., "Sect_Renewal")</summary>
+        public string SectId;
+
+        /// <summary>Display name shown in UI</summary>
+        public string Name;
+
+        /// <summary>Base cooldown in seconds</summary>
+        public float Cooldown;
+
+        /// <summary>Maximum cast range from caster (0 = global)</summary>
+        public float Range;
+
+        /// <summary>Area of effect radius (0 = single target)</summary>
+        public float AreaRadius;
+
+        /// <summary>Duration of the effect in seconds (0 = instant)</summary>
+        public float Duration;
+
+        /// <summary>
+        /// Effect category: Heal, Buff, Debuff, Damage, Vision, Invulnerable, Disable
+        /// </summary>
+        public string EffectType;
+
+        /// <summary>Primary numeric effect value (HP healed, armor bonus, etc.)</summary>
+        public float EffectValue;
+
+        /// <summary>Secondary effect value (e.g., speed multiplier for BattleFervor)</summary>
+        public float SecondaryValue;
+
+        /// <summary>Short description shown in tooltip</summary>
+        public string Description;
+
+        /// <summary>Whether this spell targets friendly entities (true) or enemy (false)</summary>
+        public bool TargetsFriendly;
+    }
+
+    /// <summary>
+    /// Static database of all 12 sect spells.
+    /// One spell per sect, unlocked on adoption.
+    /// </summary>
+    public static class SpellDatabase
+    {
+        private static readonly Dictionary<string, SpellDefinition> _spellsBySect = new();
+        private static readonly Dictionary<string, SpellDefinition> _spellsById = new();
+        private static bool _initialized;
+
+        /// <summary>
+        /// Get the spell definition for a sect. Returns null if sect has no spell.
+        /// </summary>
+        public static SpellDefinition GetSpellForSect(string sectId)
+        {
+            EnsureInitialized();
+            return _spellsBySect.TryGetValue(sectId, out var spell) ? spell : null;
+        }
+
+        /// <summary>
+        /// Get a spell definition by its spell ID.
+        /// </summary>
+        public static SpellDefinition GetSpell(string spellId)
+        {
+            EnsureInitialized();
+            return _spellsById.TryGetValue(spellId, out var spell) ? spell : null;
+        }
+
+        /// <summary>
+        /// Get all spell definitions.
+        /// </summary>
+        public static IReadOnlyCollection<SpellDefinition> GetAllSpells()
+        {
+            EnsureInitialized();
+            return _spellsBySect.Values;
+        }
+
+        private static void EnsureInitialized()
+        {
+            if (_initialized) return;
+            _initialized = true;
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_RepairLevies",
+                SectId = SectConfig.Renewal,
+                Name = "Repair Levies",
+                Cooldown = 40f,
+                Range = 30f,
+                AreaRadius = 15f,
+                Duration = 0f,
+                EffectType = "Heal",
+                EffectValue = 200f,
+                SecondaryValue = 0f,
+                Description = "Repair buildings in area by 200 HP",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_CrystalSurvey",
+                SectId = SectConfig.Antiquity,
+                Name = "Crystal Survey",
+                Cooldown = 50f,
+                Range = 0f, // Global
+                AreaRadius = 0f,
+                Duration = 30f,
+                EffectType = "Vision",
+                EffectValue = 0f,
+                SecondaryValue = 0f,
+                Description = "Reveal Crystal nodes on minimap for 30s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_BulwarkRise",
+                SectId = SectConfig.LivingStone,
+                Name = "Bulwark Rise",
+                Cooldown = 60f,
+                Range = 30f,
+                AreaRadius = 15f,
+                Duration = 20f,
+                EffectType = "Buff",
+                EffectValue = 3f, // +3 armor
+                SecondaryValue = 0f,
+                Description = "+3 armor to buildings in area for 20s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_Shroud",
+                SectId = SectConfig.VeiledMemory,
+                Name = "Shroud",
+                Cooldown = 55f,
+                Range = 30f,
+                AreaRadius = 12f,
+                Duration = 15f,
+                EffectType = "Vision",
+                EffectValue = 0f,
+                SecondaryValue = 0f,
+                Description = "Block enemy vision in area for 15s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_Embargo",
+                SectId = SectConfig.StillFlame,
+                Name = "Embargo",
+                Cooldown = 60f,
+                Range = 30f,
+                AreaRadius = 20f,
+                Duration = 20f,
+                EffectType = "Disable",
+                EffectValue = 0f,
+                SecondaryValue = 0f,
+                Description = "Disable enemy trade in area for 20s",
+                TargetsFriendly = false
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_LockdownVault",
+                SectId = SectConfig.QuietVault,
+                Name = "Lockdown Vault",
+                Cooldown = 70f,
+                Range = 20f,
+                AreaRadius = 10f,
+                Duration = 15f,
+                EffectType = "Invulnerable",
+                EffectValue = 0f,
+                SecondaryValue = 0f,
+                Description = "Buildings invulnerable for 15s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_ReflectiveWard",
+                SectId = SectConfig.MirrorRite,
+                Name = "Reflective Ward",
+                Cooldown = 60f,
+                Range = 25f,
+                AreaRadius = 12f,
+                Duration = 10f,
+                EffectType = "Buff",
+                EffectValue = 0f,
+                SecondaryValue = 0.25f, // 25% reflect
+                Description = "Reflect 25% damage for 10s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_EdictOfSeizure",
+                SectId = SectConfig.ShardJudgment,
+                Name = "Edict of Seizure",
+                Cooldown = 65f,
+                Range = 30f,
+                AreaRadius = 15f,
+                Duration = 10f,
+                EffectType = "Debuff",
+                EffectValue = 50f, // 50 Supplies drained over duration
+                SecondaryValue = 0f,
+                Description = "Drain 50 Supplies from enemy over 10s",
+                TargetsFriendly = false
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_BattleFervor",
+                SectId = SectConfig.EmberAsh,
+                Name = "Battle Fervor",
+                Cooldown = 55f,
+                Range = 25f,
+                AreaRadius = 10f,
+                Duration = 10f,
+                EffectType = "Buff",
+                EffectValue = 1.25f, // +25% damage
+                SecondaryValue = 1.25f, // +25% speed
+                Description = "+25% attack/speed for units in area for 10s",
+                TargetsFriendly = true
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_ProfaneRally",
+                SectId = SectConfig.HollowBrand,
+                Name = "Profane Rally",
+                Cooldown = 60f,
+                Range = 25f,
+                AreaRadius = 10f,
+                Duration = 5f,
+                EffectType = "Debuff",
+                EffectValue = 0.30f, // 30% slow
+                SecondaryValue = 0f,
+                Description = "Slow enemies 30% for 5s",
+                TargetsFriendly = false
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_BindTheCore",
+                SectId = SectConfig.FlamewroughtChains,
+                Name = "Bind the Core",
+                Cooldown = 90f,
+                Range = 30f,
+                AreaRadius = 0f,
+                Duration = 15f,
+                EffectType = "Disable",
+                EffectValue = 0f,
+                SecondaryValue = 0f,
+                Description = "Pacify Crystal sub-node for 15s",
+                TargetsFriendly = false
+            });
+
+            Register(new SpellDefinition
+            {
+                Id = "Spell_Unravel",
+                SectId = SectConfig.UnmakersGrasp,
+                Name = "Unravel",
+                Cooldown = 80f,
+                Range = 25f,
+                AreaRadius = 0f,
+                Duration = 0f,
+                EffectType = "Damage",
+                EffectValue = 300f, // 300 true damage
+                SecondaryValue = 0f,
+                Description = "Deal 300 true damage to Crystal entity",
+                TargetsFriendly = false
+            });
+        }
+
+        private static void Register(SpellDefinition spell)
+        {
+            _spellsBySect[spell.SectId] = spell;
+            _spellsById[spell.Id] = spell;
+        }
+    }
+}

--- a/Assets/Scripts/Economy/SpellState.cs
+++ b/Assets/Scripts/Economy/SpellState.cs
@@ -1,0 +1,155 @@
+// SpellState.cs
+// Tracks spell cooldowns per faction
+// Location: Assets/Scripts/Economy/SpellState.cs
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// MonoBehaviour singleton that tracks spell cooldowns for each faction.
+    /// Updated every frame to tick down cooldowns.
+    /// Queried by SpellPanel for UI display and SpellCastSystem for cast validation.
+    /// </summary>
+    public class SpellState : MonoBehaviour
+    {
+        // ═══════════════════════════════════════════════════════════════════
+        // SINGLETON
+        // ═══════════════════════════════════════════════════════════════════
+
+        public static SpellState Instance { get; private set; }
+
+        void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(this);
+                return;
+            }
+            Instance = this;
+        }
+
+        void OnDestroy()
+        {
+            if (Instance == this) Instance = null;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // DATA
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Cooldown timers per faction. Key = (int)Faction, Value = (spellId -> remainingSeconds).
+        /// Only contains entries for spells currently on cooldown.
+        /// </summary>
+        private readonly Dictionary<int, Dictionary<string, float>> _cooldownsByFaction = new();
+
+        // ═══════════════════════════════════════════════════════════════════
+        // UPDATE
+        // ═══════════════════════════════════════════════════════════════════
+
+        void Update()
+        {
+            float dt = Time.deltaTime;
+            if (dt <= 0f) return;
+
+            // Tick down all active cooldowns
+            var keysToRemove = new List<string>();
+
+            foreach (var factionKvp in _cooldownsByFaction)
+            {
+                keysToRemove.Clear();
+                var cooldowns = factionKvp.Value;
+
+                foreach (var spellKvp in cooldowns)
+                {
+                    float remaining = spellKvp.Value - dt;
+                    if (remaining <= 0f)
+                        keysToRemove.Add(spellKvp.Key);
+                    else
+                        cooldowns[spellKvp.Key] = remaining;
+                }
+
+                foreach (var key in keysToRemove)
+                    cooldowns.Remove(key);
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // PUBLIC API
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Check if a spell is currently on cooldown for a faction.
+        /// </summary>
+        public bool IsOnCooldown(Faction faction, string spellId)
+        {
+            int key = (int)faction;
+            return _cooldownsByFaction.TryGetValue(key, out var cooldowns) &&
+                   cooldowns.ContainsKey(spellId);
+        }
+
+        /// <summary>
+        /// Get the remaining cooldown time for a spell. Returns 0 if not on cooldown.
+        /// </summary>
+        public float GetCooldownRemaining(Faction faction, string spellId)
+        {
+            int key = (int)faction;
+            if (_cooldownsByFaction.TryGetValue(key, out var cooldowns) &&
+                cooldowns.TryGetValue(spellId, out float remaining))
+                return remaining;
+            return 0f;
+        }
+
+        /// <summary>
+        /// Start a cooldown for a spell. Duration is the base cooldown, modified by
+        /// sect tech SpellCooldownReduction if applicable.
+        /// </summary>
+        public void StartCooldown(Faction faction, string spellId, float duration)
+        {
+            // Apply spell cooldown reduction from sect techs
+            var sectState = FactionSectState.Instance;
+            if (sectState != null)
+            {
+                var mults = sectState.GetMultipliers(faction);
+                if (mults.SpellCooldownReduction > 0f)
+                    duration *= (1f - mults.SpellCooldownReduction);
+            }
+
+            int key = (int)faction;
+            if (!_cooldownsByFaction.TryGetValue(key, out var cooldowns))
+            {
+                cooldowns = new Dictionary<string, float>();
+                _cooldownsByFaction[key] = cooldowns;
+            }
+
+            cooldowns[spellId] = duration;
+        }
+
+        /// <summary>
+        /// Get the effective cooldown for a spell definition (with tech reductions applied).
+        /// Used by UI to show total cooldown time.
+        /// </summary>
+        public float GetEffectiveCooldown(Faction faction, SpellDefinition spell)
+        {
+            float cd = spell.Cooldown;
+            var sectState = FactionSectState.Instance;
+            if (sectState != null)
+            {
+                var mults = sectState.GetMultipliers(faction);
+                if (mults.SpellCooldownReduction > 0f)
+                    cd *= (1f - mults.SpellCooldownReduction);
+            }
+            return cd;
+        }
+
+        /// <summary>
+        /// Reset all cooldowns (for new game).
+        /// </summary>
+        public void ResetAll()
+        {
+            _cooldownsByFaction.Clear();
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
+++ b/Assets/Scripts/Entities/Buildings/BuildingFactory.cs
@@ -56,6 +56,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Longhouse" => CreateFeraldisLonghouse(em, position, faction),
                 "Feraldis_TotemTower" => CreateFeraldisTotemTower(em, position, faction),
                 "Feraldis_SiegeYard" => CreateFeraldisSiegeYard(em, position, faction),
+                // Sect chapel buildings
+                "Chapel_Sect_Renewal" => CreateChapel(em, SectConfig.Renewal, position, faction),
+                "Chapel_Sect_Antiquity" => CreateChapel(em, SectConfig.Antiquity, position, faction),
+                "Chapel_Sect_LivingStone" => CreateChapel(em, SectConfig.LivingStone, position, faction),
+                "Chapel_Sect_VeiledMemory" => CreateChapel(em, SectConfig.VeiledMemory, position, faction),
+                "Chapel_Sect_StillFlame" => CreateChapel(em, SectConfig.StillFlame, position, faction),
+                "Chapel_Sect_QuietVault" => CreateChapel(em, SectConfig.QuietVault, position, faction),
+                "Chapel_Sect_MirrorRite" => CreateChapel(em, SectConfig.MirrorRite, position, faction),
+                "Chapel_Sect_ShardJudgment" => CreateChapel(em, SectConfig.ShardJudgment, position, faction),
+                "Chapel_Sect_EmberAsh" => CreateChapel(em, SectConfig.EmberAsh, position, faction),
+                "Chapel_Sect_HollowBrand" => CreateChapel(em, SectConfig.HollowBrand, position, faction),
+                "Chapel_Sect_FlamewroughtChains" => CreateChapel(em, SectConfig.FlamewroughtChains, position, faction),
+                "Chapel_Sect_UnmakersGrasp" => CreateChapel(em, SectConfig.UnmakersGrasp, position, faction),
                 _ => CreateDefault(em, buildingId, position, faction)
             };
         }
@@ -91,6 +104,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Longhouse" => CreateFeraldisLonghouseECB(ecb, position, faction),
                 "Feraldis_TotemTower" => CreateFeraldisTotemTowerECB(ecb, position, faction),
                 "Feraldis_SiegeYard" => CreateFeraldisSiegeYardECB(ecb, position, faction),
+                // Sect chapel buildings
+                "Chapel_Sect_Renewal" => CreateChapelECB(ecb, SectConfig.Renewal, position, faction),
+                "Chapel_Sect_Antiquity" => CreateChapelECB(ecb, SectConfig.Antiquity, position, faction),
+                "Chapel_Sect_LivingStone" => CreateChapelECB(ecb, SectConfig.LivingStone, position, faction),
+                "Chapel_Sect_VeiledMemory" => CreateChapelECB(ecb, SectConfig.VeiledMemory, position, faction),
+                "Chapel_Sect_StillFlame" => CreateChapelECB(ecb, SectConfig.StillFlame, position, faction),
+                "Chapel_Sect_QuietVault" => CreateChapelECB(ecb, SectConfig.QuietVault, position, faction),
+                "Chapel_Sect_MirrorRite" => CreateChapelECB(ecb, SectConfig.MirrorRite, position, faction),
+                "Chapel_Sect_ShardJudgment" => CreateChapelECB(ecb, SectConfig.ShardJudgment, position, faction),
+                "Chapel_Sect_EmberAsh" => CreateChapelECB(ecb, SectConfig.EmberAsh, position, faction),
+                "Chapel_Sect_HollowBrand" => CreateChapelECB(ecb, SectConfig.HollowBrand, position, faction),
+                "Chapel_Sect_FlamewroughtChains" => CreateChapelECB(ecb, SectConfig.FlamewroughtChains, position, faction),
+                "Chapel_Sect_UnmakersGrasp" => CreateChapelECB(ecb, SectConfig.UnmakersGrasp, position, faction),
                 _ => CreateDefault(ecb, buildingId, position, faction)
             };
         }
@@ -127,6 +153,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Longhouse" => 360,
                 "Feraldis_TotemTower" => 361,
                 "Feraldis_SiegeYard" => 362,
+                // Sect chapel buildings
+                "Chapel_Sect_Renewal" => 390,
+                "Chapel_Sect_Antiquity" => 391,
+                "Chapel_Sect_LivingStone" => 392,
+                "Chapel_Sect_VeiledMemory" => 393,
+                "Chapel_Sect_StillFlame" => 394,
+                "Chapel_Sect_QuietVault" => 395,
+                "Chapel_Sect_MirrorRite" => 396,
+                "Chapel_Sect_ShardJudgment" => 397,
+                "Chapel_Sect_EmberAsh" => 398,
+                "Chapel_Sect_HollowBrand" => 399,
+                "Chapel_Sect_FlamewroughtChains" => 400,
+                "Chapel_Sect_UnmakersGrasp" => 401,
                 _ => 100
             };
         }
@@ -166,6 +205,13 @@ namespace TheWaningBorder.Entities
                 "Alanthor_SiegeYard" => true,
                 "Feraldis_Longhouse" => true,
                 "Feraldis_SiegeYard" => true,
+                // Sect chapels can train their unique unit
+                "Chapel_Sect_Renewal" or "Chapel_Sect_Antiquity" or
+                "Chapel_Sect_LivingStone" or "Chapel_Sect_VeiledMemory" or
+                "Chapel_Sect_StillFlame" or "Chapel_Sect_QuietVault" or
+                "Chapel_Sect_MirrorRite" or "Chapel_Sect_ShardJudgment" or
+                "Chapel_Sect_EmberAsh" or "Chapel_Sect_HollowBrand" or
+                "Chapel_Sect_FlamewroughtChains" or "Chapel_Sect_UnmakersGrasp" => true,
                 _ => false
             };
         }
@@ -752,6 +798,102 @@ namespace TheWaningBorder.Entities
             em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
             return entity;
         }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // SECT CHAPEL BUILDINGS
+        // ═══════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Get the chapel presentation ID for a sect.
+        /// Maps sect index in AllSectIds to PID 390-401.
+        /// </summary>
+        private static int GetChapelPresentationId(string sectId)
+        {
+            for (int i = 0; i < SectConfig.AllSectIds.Length; i++)
+            {
+                if (SectConfig.AllSectIds[i] == sectId) return 390 + i;
+            }
+            return 390;
+        }
+
+        /// <summary>
+        /// Create a sect chapel building. All chapels share the same base stats.
+        /// 600 HP, Radius 1.0, LOS 12, ArmorType StructureHuman.
+        /// Trains the sect's unique unit and researches the sect's tech.
+        /// </summary>
+        private static Entity CreateChapel(EntityManager em, string sectId, float3 position, Faction faction)
+        {
+            float hp = 600f;
+            float los = 12f;
+            float radius = 1.0f;
+            int pid = GetChapelPresentationId(sectId);
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(BuildingTag),
+                typeof(Health),
+                typeof(LineOfSight),
+                typeof(Radius),
+                typeof(TrainingState)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = pid });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new TrainingState { Busy = 0, Remaining = 0 });
+
+            em.AddComponentData(entity, new ChapelTag { SectId = new Unity.Collections.FixedString64Bytes(sectId) });
+            em.AddBuffer<TrainQueueItem>(entity);
+            em.AddComponentData(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+
+            // Combat type tags
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        /// <summary>
+        /// Create a sect chapel building using EntityCommandBuffer.
+        /// </summary>
+        private static Entity CreateChapelECB(EntityCommandBuffer ecb, string sectId, float3 position, Faction faction)
+        {
+            float hp = 600f;
+            float los = 12f;
+            float radius = 1.0f;
+            int pid = GetChapelPresentationId(sectId);
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = pid });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new BuildingTag { IsBase = 0 });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new TrainingState { Busy = 0, Remaining = 0 });
+
+            ecb.AddComponent(entity, new ChapelTag { SectId = new Unity.Collections.FixedString64Bytes(sectId) });
+            ecb.AddBuffer<TrainQueueItem>(entity);
+            ecb.AddComponent(entity, new RallyPoint { Position = position + new float3(3f, 0, 3f), Has = 1 });
+
+            // Combat type tags
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+
+            return entity;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════
+        // DEFAULT
+        // ═══════════════════════════════════════════════════════════════════
 
         /// <summary>
         /// Default building creation for unknown types.

--- a/Assets/Scripts/Entities/Units/ArchivistAdept.cs
+++ b/Assets/Scripts/Entities/Units/ArchivistAdept.cs
@@ -1,0 +1,146 @@
+// File: Assets/Scripts/Entities/Units/ArchivistAdept.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// ArchivistAdept unit - Veiled Memory sect ranged magic unit.
+    /// Fragile long-range caster with good damage output.
+    /// Uses ArcherState for ranged attack behavior with Magic damage type.
+    /// </summary>
+    public static class ArchivistAdept
+    {
+        private const float DefaultHP = 110f;
+        private const float DefaultSpeed = 3.5f;
+        private const float DefaultDamage = 14f;
+        private const float DefaultLoS = 18f;
+        private const float DefaultMinRange = 0f;
+        private const float DefaultMaxRange = 14f;
+        private const float DefaultCooldown = 1.6f;
+        private const float DefaultAimTime = 0.4f;
+        private const int PresentationID = 373;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_ArchivistAdept", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(ArcherTag), typeof(Health), typeof(MoveSpeed),
+                typeof(Damage), typeof(LineOfSight), typeof(ArcherState), typeof(Target),
+                typeof(Radius), typeof(AttackCooldown), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Magic });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Magic });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 2 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_ArchivistAdept", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Magic });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Magic });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 2 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Ashblade.cs
+++ b/Assets/Scripts/Entities/Units/Ashblade.cs
@@ -1,0 +1,108 @@
+// File: Assets/Scripts/Entities/Units/Ashblade.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Ashblade unit - Ember Ash sect light melee infantry.
+    /// Very fast raider with light armor. Excels at hit-and-run.
+    /// </summary>
+    public static class Ashblade
+    {
+        private const float DefaultHP = 155f;
+        private const float DefaultSpeed = 5.0f;
+        private const float DefaultDamage = 14f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.0f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 378;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Ashblade", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Ashblade", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Brandbreaker.cs
+++ b/Assets/Scripts/Entities/Units/Brandbreaker.cs
@@ -1,0 +1,110 @@
+// File: Assets/Scripts/Entities/Units/Brandbreaker.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Brandbreaker unit - Hollow Brand sect siege infantry.
+    /// Anti-structure melee unit with heavy armor and siege damage type.
+    /// </summary>
+    public static class Brandbreaker
+    {
+        private const float DefaultHP = 150f;
+        private const float DefaultSpeed = 4.0f;
+        private const float DefaultDamage = 12f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.5f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 379;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Brandbreaker", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Siege });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Siege });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 1, Ranged = 1, Siege = 0, Magic = 0 });
+            em.AddComponent<SiegeTag>(entity);
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Brandbreaker", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Siege });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Siege });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 1, Ranged = 1, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SiegeTag>(entity);
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Chaincaster.cs
+++ b/Assets/Scripts/Entities/Units/Chaincaster.cs
@@ -1,0 +1,146 @@
+// File: Assets/Scripts/Entities/Units/Chaincaster.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Chaincaster unit - Flamewrought Chains sect ranged magic unit.
+    /// Control-oriented caster with moderate range and lower damage.
+    /// Uses ArcherState for ranged attack behavior with Magic damage type.
+    /// </summary>
+    public static class Chaincaster
+    {
+        private const float DefaultHP = 105f;
+        private const float DefaultSpeed = 3.5f;
+        private const float DefaultDamage = 10f;
+        private const float DefaultLoS = 18f;
+        private const float DefaultMinRange = 0f;
+        private const float DefaultMaxRange = 14f;
+        private const float DefaultCooldown = 1.8f;
+        private const float DefaultAimTime = 0.5f;
+        private const int PresentationID = 380;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Chaincaster", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(ArcherTag), typeof(Health), typeof(MoveSpeed),
+                typeof(Damage), typeof(LineOfSight), typeof(ArcherState), typeof(Target),
+                typeof(Radius), typeof(AttackCooldown), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Magic });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Magic });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Chaincaster", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Magic });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Magic });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/FlameWarden.cs
+++ b/Assets/Scripts/Entities/Units/FlameWarden.cs
@@ -1,0 +1,108 @@
+// File: Assets/Scripts/Entities/Units/FlameWarden.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// FlameWarden unit - Still Flame sect melee infantry.
+    /// Fast melee fighter with moderate stats across the board.
+    /// </summary>
+    public static class FlameWarden
+    {
+        private const float DefaultHP = 150f;
+        private const float DefaultSpeed = 3.8f;
+        private const float DefaultDamage = 15f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.1f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 374;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_FlameWarden", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 1, Ranged = 1, Siege = 0, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_FlameWarden", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 1, Ranged = 1, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/GlassmarkArcanist.cs
+++ b/Assets/Scripts/Entities/Units/GlassmarkArcanist.cs
@@ -1,0 +1,146 @@
+// File: Assets/Scripts/Entities/Units/GlassmarkArcanist.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// GlassmarkArcanist unit - Mirror Rite sect ranged magic unit.
+    /// Glass cannon with highest magic damage but lowest HP among sect units.
+    /// Uses ArcherState for ranged attack behavior with Magic damage type.
+    /// </summary>
+    public static class GlassmarkArcanist
+    {
+        private const float DefaultHP = 100f;
+        private const float DefaultSpeed = 3.5f;
+        private const float DefaultDamage = 18f;
+        private const float DefaultLoS = 19f;
+        private const float DefaultMinRange = 0f;
+        private const float DefaultMaxRange = 15f;
+        private const float DefaultCooldown = 1.5f;
+        private const float DefaultAimTime = 0.4f;
+        private const int PresentationID = 376;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_GlassmarkArcanist", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(ArcherTag), typeof(Health), typeof(MoveSpeed),
+                typeof(Damage), typeof(LineOfSight), typeof(ArcherState), typeof(Target),
+                typeof(Radius), typeof(AttackCooldown), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Magic });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = 0.5f });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Magic });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_GlassmarkArcanist", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Magic });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = 0.5f });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Magic });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.Ranged });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/GolemAutark.cs
+++ b/Assets/Scripts/Entities/Units/GolemAutark.cs
@@ -1,0 +1,147 @@
+// File: Assets/Scripts/Entities/Units/GolemAutark.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// GolemAutark unit - Antiquity sect ranged magic unit.
+    /// Heavily armored magical construct with high HP and moderate range.
+    /// Uses ArcherState for ranged attack behavior with Magic damage type.
+    /// </summary>
+    public static class GolemAutark
+    {
+        private const float DefaultHP = 320f;
+        private const float DefaultSpeed = 2.0f;
+        private const float DefaultDamage = 22f;
+        private const float DefaultLoS = 14f;
+        private const float DefaultMinRange = 0f;
+        private const float DefaultMaxRange = 10f;
+        private const float DefaultCooldown = 2.0f;
+        private const float DefaultAimTime = 0.6f;
+        private const float DefaultRadius = 0.6f;
+        private const int PresentationID = 371;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_GolemAutark", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(ArcherTag), typeof(Health), typeof(MoveSpeed),
+                typeof(Damage), typeof(LineOfSight), typeof(ArcherState), typeof(Target),
+                typeof(Radius), typeof(AttackCooldown), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Magic });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = DefaultRadius });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.SetComponentData(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Magic });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 3, Ranged = 2, Siege = 1, Magic = 2 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float minRange = DefaultMinRange;
+            float maxRange = DefaultMaxRange;
+            float cooldown = DefaultCooldown;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_GolemAutark", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+                if (def.minAttackRange > 0) minRange = def.minAttackRange;
+                if (def.attackRange > 0) maxRange = def.attackRange;
+                if (def.attackCooldown > 0) cooldown = def.attackCooldown;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Magic });
+            ecb.AddComponent<ArcherTag>(entity);
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = DefaultRadius });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new ArcherState
+            {
+                CurrentTarget = Entity.Null,
+                AimTimer = 0,
+                AimTimeRequired = DefaultAimTime,
+                CooldownTimer = 0,
+                MinRange = minRange,
+                MaxRange = maxRange,
+                HeightRangeMod = 4f,
+                IsRetreating = 0,
+                IsFiring = 0
+            });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Magic });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 3, Ranged = 2, Siege = 1, Magic = 2 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Judicator.cs
+++ b/Assets/Scripts/Entities/Units/Judicator.cs
@@ -1,0 +1,108 @@
+// File: Assets/Scripts/Entities/Units/Judicator.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Judicator unit - Shard Judgment sect melee infantry.
+    /// Balanced heavy melee fighter that enforces trade route security.
+    /// </summary>
+    public static class Judicator
+    {
+        private const float DefaultHP = 160f;
+        private const float DefaultSpeed = 3.4f;
+        private const float DefaultDamage = 16f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.2f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 377;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Judicator", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Judicator", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/Nullblade.cs
+++ b/Assets/Scripts/Entities/Units/Nullblade.cs
@@ -1,0 +1,108 @@
+// File: Assets/Scripts/Entities/Units/Nullblade.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// Nullblade unit - Unmaker's Grasp sect light melee infantry.
+    /// Fast anti-Crystal melee fighter with light armor.
+    /// </summary>
+    public static class Nullblade
+    {
+        private const float DefaultHP = 150f;
+        private const float DefaultSpeed = 4.2f;
+        private const float DefaultDamage = 14f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.1f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 381;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Nullblade", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            em.AddComponentData(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_Nullblade", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryLight });
+            ecb.AddComponent(entity, new Defense { Melee = 0, Ranged = 0, Siege = 0, Magic = 1 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/ScarGuard.cs
+++ b/Assets/Scripts/Entities/Units/ScarGuard.cs
@@ -1,0 +1,116 @@
+// File: Assets/Scripts/Entities/Units/ScarGuard.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// ScarGuard unit - Renewal sect melee infantry.
+    /// Tough frontline fighter with high HP and solid damage.
+    /// </summary>
+    public static class ScarGuard
+    {
+        private const float DefaultHP = 170f;
+        private const float DefaultSpeed = 3.2f;
+        private const float DefaultDamage = 16f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.2f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 370;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_ScarGuard", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_ScarGuard", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/StoneWarden.cs
+++ b/Assets/Scripts/Entities/Units/StoneWarden.cs
@@ -1,0 +1,116 @@
+// File: Assets/Scripts/Entities/Units/StoneWarden.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// StoneWarden unit - Living Stone sect melee infantry.
+    /// High HP tank with lower damage. Excels at absorbing hits.
+    /// </summary>
+    public static class StoneWarden
+    {
+        private const float DefaultHP = 200f;
+        private const float DefaultSpeed = 2.8f;
+        private const float DefaultDamage = 10f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.4f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 372;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_StoneWarden", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId),
+                typeof(LocalTransform),
+                typeof(FactionTag),
+                typeof(UnitTag),
+                typeof(Health),
+                typeof(MoveSpeed),
+                typeof(Damage),
+                typeof(AttackCooldown),
+                typeof(LineOfSight),
+                typeof(Target),
+                typeof(Radius),
+                typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 3, Ranged = 2, Siege = 1, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_StoneWarden", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 3, Ranged = 2, Siege = 1, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Units/UnitFactory.cs
+++ b/Assets/Scripts/Entities/Units/UnitFactory.cs
@@ -54,6 +54,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Hunter" => Hunter.Create(em, position, faction),
                 "Feraldis_WarboarRider" => WarboarRider.Create(em, position, faction),
                 "Feraldis_SiegeRam" => SiegeRam.Create(em, position, faction),
+                // Sect unique units
+                "Sect_ScarGuard" => ScarGuard.Create(em, position, faction),
+                "Sect_GolemAutark" => GolemAutark.Create(em, position, faction),
+                "Sect_StoneWarden" => StoneWarden.Create(em, position, faction),
+                "Sect_ArchivistAdept" => ArchivistAdept.Create(em, position, faction),
+                "Sect_FlameWarden" => FlameWarden.Create(em, position, faction),
+                "Sect_VaultKeeper" => VaultKeeper.Create(em, position, faction),
+                "Sect_GlassmarkArcanist" => GlassmarkArcanist.Create(em, position, faction),
+                "Sect_Judicator" => Judicator.Create(em, position, faction),
+                "Sect_Ashblade" => Ashblade.Create(em, position, faction),
+                "Sect_Brandbreaker" => Brandbreaker.Create(em, position, faction),
+                "Sect_Chaincaster" => Chaincaster.Create(em, position, faction),
+                "Sect_Nullblade" => Nullblade.Create(em, position, faction),
                 _ => CreateDefault(em, unitId, position, faction)
             };
         }
@@ -90,6 +103,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Hunter" => Hunter.Create(ecb, position, faction),
                 "Feraldis_WarboarRider" => WarboarRider.Create(ecb, position, faction),
                 "Feraldis_SiegeRam" => SiegeRam.Create(ecb, position, faction),
+                // Sect unique units
+                "Sect_ScarGuard" => ScarGuard.Create(ecb, position, faction),
+                "Sect_GolemAutark" => GolemAutark.Create(ecb, position, faction),
+                "Sect_StoneWarden" => StoneWarden.Create(ecb, position, faction),
+                "Sect_ArchivistAdept" => ArchivistAdept.Create(ecb, position, faction),
+                "Sect_FlameWarden" => FlameWarden.Create(ecb, position, faction),
+                "Sect_VaultKeeper" => VaultKeeper.Create(ecb, position, faction),
+                "Sect_GlassmarkArcanist" => GlassmarkArcanist.Create(ecb, position, faction),
+                "Sect_Judicator" => Judicator.Create(ecb, position, faction),
+                "Sect_Ashblade" => Ashblade.Create(ecb, position, faction),
+                "Sect_Brandbreaker" => Brandbreaker.Create(ecb, position, faction),
+                "Sect_Chaincaster" => Chaincaster.Create(ecb, position, faction),
+                "Sect_Nullblade" => Nullblade.Create(ecb, position, faction),
                 _ => CreateDefault(ecb, unitId, position, faction)
             };
         }
@@ -134,6 +160,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Hunter" => UnitClass.Ranged,
                 "Feraldis_WarboarRider" => UnitClass.Melee,
                 "Feraldis_SiegeRam" => UnitClass.Siege,
+                // Sect unique units
+                "Sect_ScarGuard" => UnitClass.Melee,
+                "Sect_GolemAutark" => UnitClass.Magic,
+                "Sect_StoneWarden" => UnitClass.Melee,
+                "Sect_ArchivistAdept" => UnitClass.Magic,
+                "Sect_FlameWarden" => UnitClass.Melee,
+                "Sect_VaultKeeper" => UnitClass.Melee,
+                "Sect_GlassmarkArcanist" => UnitClass.Magic,
+                "Sect_Judicator" => UnitClass.Melee,
+                "Sect_Ashblade" => UnitClass.Melee,
+                "Sect_Brandbreaker" => UnitClass.Siege,
+                "Sect_Chaincaster" => UnitClass.Magic,
+                "Sect_Nullblade" => UnitClass.Melee,
                 _ => UnitClass.Melee
             };
         }
@@ -169,6 +208,19 @@ namespace TheWaningBorder.Entities
                 "Feraldis_Hunter" => 338,
                 "Feraldis_WarboarRider" => 339,
                 "Feraldis_SiegeRam" => 340,
+                // Sect unique units
+                "Sect_ScarGuard" => 370,
+                "Sect_GolemAutark" => 371,
+                "Sect_StoneWarden" => 372,
+                "Sect_ArchivistAdept" => 373,
+                "Sect_FlameWarden" => 374,
+                "Sect_VaultKeeper" => 375,
+                "Sect_GlassmarkArcanist" => 376,
+                "Sect_Judicator" => 377,
+                "Sect_Ashblade" => 378,
+                "Sect_Brandbreaker" => 379,
+                "Sect_Chaincaster" => 380,
+                "Sect_Nullblade" => 381,
                 _ => 201
             };
         }

--- a/Assets/Scripts/Entities/Units/VaultKeeper.cs
+++ b/Assets/Scripts/Entities/Units/VaultKeeper.cs
@@ -1,0 +1,108 @@
+// File: Assets/Scripts/Entities/Units/VaultKeeper.cs
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Entities
+{
+    /// <summary>
+    /// VaultKeeper unit - Quiet Vault sect melee infantry.
+    /// Defensive melee unit that guards trade routes and vaults.
+    /// </summary>
+    public static class VaultKeeper
+    {
+        private const float DefaultHP = 140f;
+        private const float DefaultSpeed = 3.5f;
+        private const float DefaultDamage = 12f;
+        private const float DefaultLoS = 10f;
+        private const float DefaultAttackCooldown = 1.3f;
+        private const float DefaultRadius = 0.5f;
+        private const int PresentationID = 375;
+
+        public static Entity Create(EntityManager em, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_VaultKeeper", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = em.CreateEntity(
+                typeof(PresentationId), typeof(LocalTransform), typeof(FactionTag),
+                typeof(UnitTag), typeof(Health), typeof(MoveSpeed), typeof(Damage),
+                typeof(AttackCooldown), typeof(LineOfSight), typeof(Target),
+                typeof(Radius), typeof(PopulationCost)
+            );
+
+            em.SetComponentData(entity, new PresentationId { Id = PresentationID });
+            em.SetComponentData(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            em.SetComponentData(entity, new FactionTag { Value = faction });
+            em.SetComponentData(entity, new UnitTag { Class = UnitClass.Melee });
+            em.SetComponentData(entity, new Health { Value = (int)hp, Max = (int)hp });
+            em.SetComponentData(entity, new MoveSpeed { Value = speed });
+            em.SetComponentData(entity, new Damage { Value = (int)damage });
+            em.SetComponentData(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            em.SetComponentData(entity, new LineOfSight { Radius = los });
+            em.SetComponentData(entity, new Target { Value = Entity.Null });
+            em.SetComponentData(entity, new Radius { Value = radius });
+            em.SetComponentData(entity, new PopulationCost { Amount = 1 });
+
+            em.AddComponentData(entity, new DamageTypeData { Value = DamageType.Melee });
+            em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            em.AddComponentData(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            em.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction)
+        {
+            float hp = DefaultHP;
+            float speed = DefaultSpeed;
+            float damage = DefaultDamage;
+            float los = DefaultLoS;
+            float cooldown = DefaultAttackCooldown;
+            float radius = DefaultRadius;
+
+            if (TechTreeDB.Instance != null && TechTreeDB.Instance.TryGetUnit("Sect_VaultKeeper", out var def))
+            {
+                if (def.hp > 0) hp = def.hp;
+                if (def.speed > 0) speed = def.speed;
+                if (def.damage > 0) damage = def.damage;
+                if (def.lineOfSight > 0) los = def.lineOfSight;
+            }
+
+            var entity = ecb.CreateEntity();
+
+            ecb.AddComponent(entity, new PresentationId { Id = PresentationID });
+            ecb.AddComponent(entity, LocalTransform.FromPositionRotationScale(position, quaternion.identity, 1f));
+            ecb.AddComponent(entity, new FactionTag { Value = faction });
+            ecb.AddComponent(entity, new UnitTag { Class = UnitClass.Melee });
+            ecb.AddComponent(entity, new Health { Value = (int)hp, Max = (int)hp });
+            ecb.AddComponent(entity, new MoveSpeed { Value = speed });
+            ecb.AddComponent(entity, new Damage { Value = (int)damage });
+            ecb.AddComponent(entity, new AttackCooldown { Cooldown = cooldown, Timer = 0f });
+            ecb.AddComponent(entity, new LineOfSight { Radius = los });
+            ecb.AddComponent(entity, new Target { Value = Entity.Null });
+            ecb.AddComponent(entity, new Radius { Value = radius });
+            ecb.AddComponent(entity, new PopulationCost { Amount = 1 });
+
+            ecb.AddComponent(entity, new DamageTypeData { Value = DamageType.Melee });
+            ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.InfantryHeavy });
+            ecb.AddComponent(entity, new Defense { Melee = 2, Ranged = 1, Siege = 0, Magic = 0 });
+            ecb.AddComponent<SectUniqueUnitTag>(entity);
+
+            return entity;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/SpellBuffSystem.cs
+++ b/Assets/Scripts/Systems/Combat/SpellBuffSystem.cs
@@ -1,0 +1,65 @@
+// SpellBuffSystem.cs
+// Ticks SpellBuff, SpellDebuff, and Invulnerable timers, removing expired components
+// Location: Assets/Scripts/Systems/Combat/SpellBuffSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+
+namespace TheWaningBorder.Systems.Combat
+{
+    /// <summary>
+    /// Ticks down all temporary spell buff/debuff timers each frame.
+    /// Removes the component when the timer expires.
+    ///
+    /// Handles:
+    /// - SpellBuff: armor bonus, damage/speed multiplier, damage reflect
+    /// - SpellDebuff: speed reduction, supplies drain
+    /// - Invulnerable: building invulnerability
+    ///
+    /// NOTE: Not BurstCompiled because it uses structural changes (remove component).
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SpellBuffSystem : ISystem
+    {
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            if (dt <= 0f) return;
+
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            // ── Tick SpellBuff timers ──
+            foreach (var (buff, entity) in SystemAPI.Query<RefRW<SpellBuff>>().WithEntityAccess())
+            {
+                buff.ValueRW.TimeRemaining -= dt;
+                if (buff.ValueRO.TimeRemaining <= 0f)
+                {
+                    ecb.RemoveComponent<SpellBuff>(entity);
+                }
+            }
+
+            // ── Tick SpellDebuff timers ──
+            foreach (var (debuff, entity) in SystemAPI.Query<RefRW<SpellDebuff>>().WithEntityAccess())
+            {
+                debuff.ValueRW.TimeRemaining -= dt;
+                if (debuff.ValueRO.TimeRemaining <= 0f)
+                {
+                    ecb.RemoveComponent<SpellDebuff>(entity);
+                }
+            }
+
+            // ── Tick Invulnerable timers ──
+            foreach (var (invuln, entity) in SystemAPI.Query<RefRW<Invulnerable>>().WithEntityAccess())
+            {
+                invuln.ValueRW.TimeRemaining -= dt;
+                if (invuln.ValueRO.TimeRemaining <= 0f)
+                {
+                    ecb.RemoveComponent<Invulnerable>(entity);
+                }
+            }
+
+            ecb.Playback(state.EntityManager);
+            ecb.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/UI/HUD/SpellPanel.cs
+++ b/Assets/Scripts/UI/HUD/SpellPanel.cs
@@ -1,0 +1,250 @@
+// SpellPanel.cs
+// IMGUI panel showing available spells with cooldown indicators
+// Location: Assets/Scripts/UI/HUD/SpellPanel.cs
+
+using System.Collections.Generic;
+using UnityEngine;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.UI.HUD
+{
+    /// <summary>
+    /// IMGUI panel that displays available spells for the local player's adopted sects.
+    /// Shows spell buttons with cooldown overlays. Clicking a spell enters targeting mode.
+    ///
+    /// Positioned at bottom-right of screen, above the minimap area.
+    /// Only visible when the faction has adopted at least one sect.
+    /// </summary>
+    public class SpellPanel : MonoBehaviour
+    {
+        [Header("Config")]
+        [SerializeField] private Faction humanFaction = GameSettings.LocalPlayerFaction;
+
+        // Layout constants
+        private const float PanelWidth = 260f;
+        private const float PanelHeight = 320f;
+        private const float ButtonSize = 50f;
+        private const float ButtonSpacing = 6f;
+        private const float Margin = 8f;
+
+        // Styles
+        private GUIStyle _panelBg;
+        private GUIStyle _headerStyle;
+        private GUIStyle _buttonStyle;
+        private GUIStyle _cooldownStyle;
+        private GUIStyle _tooltipStyle;
+        private GUIStyle _targetingStyle;
+        private Texture2D _texPanel;
+        private Texture2D _texButton;
+        private Texture2D _texCooldown;
+        private bool _stylesBuilt;
+
+        // Colors
+        private static readonly Color PanelColor = new Color(0.06f, 0.08f, 0.18f, 0.88f);
+        private static readonly Color ButtonColor = new Color(0.12f, 0.14f, 0.25f, 0.95f);
+        private static readonly Color CooldownColor = new Color(0.0f, 0.0f, 0.0f, 0.65f);
+        private static readonly Color GoldAccent = new Color(0.83f, 0.66f, 0.26f);
+        private static readonly Color DimText = new Color(0.6f, 0.58f, 0.50f);
+
+        // Cached spell list
+        private readonly List<SpellDefinition> _availableSpells = new();
+        private float _refreshTimer;
+
+        /// <summary>Returns true if the mouse is over the spell panel.</summary>
+        public static bool IsPointerOverPanel { get; private set; }
+
+        void OnGUI()
+        {
+            BuildStyles();
+
+            var sectState = FactionSectState.Instance;
+            var spellState = SpellState.Instance;
+            var castSystem = SpellCastSystem.Instance;
+            if (sectState == null || spellState == null) return;
+
+            // Refresh available spells periodically
+            _refreshTimer -= Time.deltaTime;
+            if (_refreshTimer <= 0f)
+            {
+                RefreshAvailableSpells(sectState);
+                _refreshTimer = 1.0f;
+            }
+
+            if (_availableSpells.Count == 0) return;
+
+            // Panel position: bottom-right
+            float panelX = Screen.width - PanelWidth - 10f;
+            float panelY = Screen.height - PanelHeight - 180f; // Above minimap area
+
+            Rect panelRect = new Rect(panelX, panelY, PanelWidth, PanelHeight);
+            IsPointerOverPanel = panelRect.Contains(Event.current.mousePosition);
+
+            // Draw panel background
+            GUI.Box(panelRect, GUIContent.none, _panelBg);
+
+            GUILayout.BeginArea(new Rect(panelX + Margin, panelY + Margin,
+                PanelWidth - Margin * 2, PanelHeight - Margin * 2));
+
+            // Header
+            GUILayout.Label("SPELLS", _headerStyle);
+            GUILayout.Space(4);
+
+            // Targeting indicator
+            if (castSystem != null && castSystem.IsTargeting)
+            {
+                GUILayout.Label($"Targeting: {castSystem.ActiveSpell.Name}", _targetingStyle);
+                GUILayout.Label("Click target location (Right-click to cancel)", _tooltipStyle);
+                GUILayout.Space(4);
+            }
+
+            // Spell buttons in a grid (4 per row)
+            int col = 0;
+            GUILayout.BeginHorizontal();
+
+            foreach (var spell in _availableSpells)
+            {
+                if (col >= 4)
+                {
+                    GUILayout.EndHorizontal();
+                    GUILayout.Space(ButtonSpacing);
+                    GUILayout.BeginHorizontal();
+                    col = 0;
+                }
+
+                DrawSpellButton(spell, spellState, castSystem);
+                GUILayout.Space(ButtonSpacing);
+                col++;
+            }
+
+            GUILayout.EndHorizontal();
+
+            GUILayout.EndArea();
+        }
+
+        private void DrawSpellButton(SpellDefinition spell, SpellState spellState, SpellCastSystem castSystem)
+        {
+            bool onCooldown = spellState.IsOnCooldown(humanFaction, spell.Id);
+            float remaining = spellState.GetCooldownRemaining(humanFaction, spell.Id);
+            bool isActive = castSystem != null && castSystem.IsTargeting &&
+                            castSystem.ActiveSpell?.Id == spell.Id;
+
+            // Button rect
+            Rect btnRect = GUILayoutUtility.GetRect(ButtonSize, ButtonSize, GUILayout.Width(ButtonSize));
+
+            // Draw button background
+            Color oldColor = GUI.color;
+            GUI.color = isActive ? GoldAccent : Color.white;
+            GUI.Box(btnRect, GUIContent.none, _buttonStyle);
+            GUI.color = oldColor;
+
+            // Draw spell name abbreviation (first 3 chars)
+            string abbrev = spell.Name.Length > 3 ? spell.Name.Substring(0, 3) : spell.Name;
+            GUI.Label(new Rect(btnRect.x + 4, btnRect.y + 4, ButtonSize - 8, 20f), abbrev, _headerStyle);
+
+            // Draw cooldown overlay
+            if (onCooldown)
+            {
+                GUI.Box(btnRect, GUIContent.none, _cooldownStyle);
+                string cdText = remaining > 1f ? $"{remaining:F0}s" : $"{remaining:F1}s";
+                GUI.Label(new Rect(btnRect.x, btnRect.y + ButtonSize * 0.35f, ButtonSize, 20f),
+                    cdText, _cooldownStyle);
+            }
+
+            // Tooltip on hover
+            if (btnRect.Contains(Event.current.mousePosition))
+            {
+                float tipX = btnRect.x;
+                float tipY = btnRect.y - 45f;
+                GUI.Label(new Rect(tipX, tipY, 200f, 40f),
+                    $"{spell.Name}\n{spell.Description}", _tooltipStyle);
+            }
+
+            // Click handler
+            if (!onCooldown && GUI.Button(btnRect, GUIContent.none, GUIStyle.none))
+            {
+                if (castSystem != null)
+                {
+                    if (isActive)
+                        castSystem.CancelTargeting();
+                    else
+                        castSystem.BeginTargeting(humanFaction, spell);
+                }
+            }
+        }
+
+        private void RefreshAvailableSpells(FactionSectState sectState)
+        {
+            _availableSpells.Clear();
+
+            var adopted = sectState.GetAdoptedSects(humanFaction);
+            foreach (var sectId in adopted)
+            {
+                var spell = SpellDatabase.GetSpellForSect(sectId);
+                if (spell != null)
+                    _availableSpells.Add(spell);
+            }
+        }
+
+        private void BuildStyles()
+        {
+            if (_stylesBuilt) return;
+            _stylesBuilt = true;
+
+            _texPanel = MakeTex(2, 2, PanelColor);
+            _texButton = MakeTex(2, 2, ButtonColor);
+            _texCooldown = MakeTex(2, 2, CooldownColor);
+
+            _panelBg = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _texPanel }
+            };
+
+            _headerStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = GoldAccent }
+            };
+
+            _buttonStyle = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _texButton },
+                border = new RectOffset(2, 2, 2, 2)
+            };
+
+            _cooldownStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 12,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = Color.white, background = _texCooldown }
+            };
+
+            _tooltipStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 10,
+                wordWrap = true,
+                normal = { textColor = DimText }
+            };
+
+            _targetingStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(1f, 0.8f, 0.2f) }
+            };
+        }
+
+        private static Texture2D MakeTex(int w, int h, Color col)
+        {
+            var pix = new Color[w * h];
+            for (int i = 0; i < pix.Length; i++) pix[i] = col;
+            var tex = new Texture2D(w, h);
+            tex.SetPixels(pix);
+            tex.Apply();
+            return tex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements all sect content for issue #79:
- 12 sect unit factory files (PID 370-381)
- 12 chapel buildings via generic CreateChapel factory (PID 390-401)
- 12 sect technologies with SectTechFlags on FactionSectState
- Active spell framework with 12 spells (SpellDefinition, SpellCastSystem, SpellState, SpellBuffSystem, SpellPanel)

## Changes
### New Files (18)
- 12 unit factories: ScarGuard, GolemAutark, StoneWarden, ArchivistAdept, FlameWarden, VaultKeeper, GlassmarkArcanist, Judicator, Ashblade, Brandbreaker, Chaincaster, Nullblade
- SpellComponents.cs (SpellBuff, SpellDebuff, Invulnerable)
- SpellDefinition.cs (data class + SpellDatabase)
- SpellState.cs (cooldown tracker)
- SpellCastSystem.cs (cast + effect application)
- SpellBuffSystem.cs (timer tick ISystem)
- SpellPanel.cs (IMGUI HUD)

### Modified Files (5)
- BuildingComponents.cs: Added ChapelTag with SectId field
- BuildingFactory.cs: 12 chapel entries + CreateChapel/CreateChapelECB methods
- UnitFactory.cs: 12 sect unit entries in Create, GetUnitClass, GetPresentationId
- FactionSectState.cs: SectTechFlags struct + SetTechFlag/HasTechFlag API + tech multipliers
- SectConfig.cs: Tech IDs, display names, descriptions, unit ID mappings

## Test Plan
- [ ] Verify unit factories compile with correct stats (HP, Speed, Dmg, Armor, PID)
- [ ] Verify chapel buildings can be created via BuildingFactory
- [ ] Verify UnitFactory routes all 12 sect unit IDs correctly
- [ ] Verify sect tech flags can be set and queried
- [ ] Verify spell definitions load with correct cooldowns and areas
- [ ] Verify SpellBuffSystem removes expired buff/debuff components
- [ ] Verify SpellPanel renders for adopted sects

Closes #79