### PR TITLE
fix(combat): guard against division by zero in RangedCombatSystem aim time

### DIFF
--- a/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
@@ -146,7 +146,10 @@ namespace TheWaningBorder.Systems.Combat
                     var minAimTime = 0.3f;
                     var maxAimTime = 1.2f;
                     var aimRange = maxAimTime - minAimTime;
-                    var distRatio = (dist - minRange) / (maxRange - minRange);
+                    float rangeDelta = maxRange - minRange;
+                    float distRatio = rangeDelta > 0.001f
+                        ? math.saturate((dist - minRange) / rangeDelta)
+                        : 0.5f;
                     archer.AimTimeRequired = minAimTime + (aimRange * distRatio);
 
                     // Accumulate aim time


### PR DESCRIPTION
## Summary
Closes #83

- Guard division by `(maxRange - minRange)` with epsilon check (`> 0.001f`)
- Default `distRatio` to `0.5f` when range delta is near zero
- Clamp `distRatio` to [0,1] with `math.saturate()`

## Details
In `RangedCombatSystem`, the aim time calculation computes `distRatio = (dist - minRange) / (maxRange - minRange)`. When `maxRange == minRange` (e.g., a unit with identical min/max range configured), this produces a division by zero, resulting in NaN propagating through `AimTimeRequired`. The archer would never fire because `AimTimer >= NaN` is always false.

The fix extracts the denominator into `rangeDelta`, checks it against an epsilon of `0.001f`, and falls back to a neutral `0.5f` ratio. Additionally, `math.saturate()` clamps the ratio to [0,1] to prevent any out-of-range aim times even with valid inputs.

## Test plan
- [ ] Spawn archer with equal min/max range values and verify it fires correctly
- [ ] Spawn archer with normal range spread and verify aim time still scales with distance
- [ ] Verify no NaN warnings in Unity console during ranged combat