### PR TITLE
fix(mining): use XZ distance in GatheringSystem for terrain consistency

### DIFF
--- a/Assets/Scripts/Systems/Work/GatheringSystem.cs
+++ b/Assets/Scripts/Systems/Work/GatheringSystem.cs
@@ -71,7 +71,7 @@ namespace TheWaningBorder.Systems.Work
                 {
                     // Move to resource node
                     var nodePos = em.GetComponentData<LocalTransform>(resourceNode).Position;
-                    var dist = math.distance(myPos, nodePos);
+                    var dist = DistXZ(myPos, nodePos);
 
                     if (dist > GatherRange)
                     {
@@ -128,6 +128,11 @@ namespace TheWaningBorder.Systems.Work
                     // Keep the GatherCommand for when they're done
                 }
             }
+        }
+
+        private static float DistXZ(float3 a, float3 b)
+        {
+            return math.distance(new float2(a.x, a.z), new float2(b.x, b.z));
         }
     }
 }


### PR DESCRIPTION
## Summary
Closes #85

- Replaced `math.distance(myPos, nodePos)` with `DistXZ(myPos, nodePos)` in GatheringSystem range check (line 74)
- Added `DistXZ` helper method matching MiningSystem/CrystalMiningSystem pattern

## Why
The previous 3D distance calculation included Y-axis (elevation) differences, which inflated the measured distance between miners and resource nodes on uneven terrain. This caused miners to fail the `GatherRange` check when they were close enough on the XZ plane but at a different elevation. Using XZ-only distance matches the approach already used in MiningSystem and CrystalMiningSystem.

## Test plan
- [ ] Right-click miner onto a resource node on sloped terrain; verify miner reaches and starts gathering
- [ ] Verify flat-terrain gathering still works normally
- [ ] Confirm MiningSystem autonomous mining is unaffected