### PR TITLE
feat(ui): add Crystal, Veilsteel, Glow income display

### DIFF
--- a/Assets/Scripts/UI/Common/UITypes.cs
+++ b/Assets/Scripts/UI/Common/UITypes.cs
@@ -31,6 +31,9 @@ public struct EntityDisplayInfo
     public bool HasResourceGeneration;
     public float? SuppliesPerMinute;
     public int? IronPerMinute;
+    public int? CrystalPerMinute;
+    public int? VeilsteelPerMinute;
+    public int? GlowPerMinute;
 
     // Miner info
     public bool HasMinerInfo;

--- a/Assets/Scripts/UI/Panels/EntityExtractors.cs
+++ b/Assets/Scripts/UI/Panels/EntityExtractors.cs
@@ -33,7 +33,10 @@ namespace TheWaningBorder.UI
                 Speed = 0,
                 HasResourceGeneration = false,
                 SuppliesPerMinute = 0,
-                IronPerMinute = 0
+                IronPerMinute = 0,
+                CrystalPerMinute = 0,
+                VeilsteelPerMinute = 0,
+                GlowPerMinute = 0
             };
 
             if (!em.Exists(entity)) return info;
@@ -77,6 +80,21 @@ namespace TheWaningBorder.UI
             {
                 info.HasResourceGeneration = true;
                 info.IronPerMinute = em.GetComponentData<IronIncome>(entity).PerMinute;
+            }
+            if (em.HasComponent<CrystalIncome>(entity))
+            {
+                info.HasResourceGeneration = true;
+                info.CrystalPerMinute = em.GetComponentData<CrystalIncome>(entity).PerMinute;
+            }
+            if (em.HasComponent<VeilsteelIncome>(entity))
+            {
+                info.HasResourceGeneration = true;
+                info.VeilsteelPerMinute = em.GetComponentData<VeilsteelIncome>(entity).PerMinute;
+            }
+            if (em.HasComponent<GlowIncome>(entity))
+            {
+                info.HasResourceGeneration = true;
+                info.GlowPerMinute = em.GetComponentData<GlowIncome>(entity).PerMinute;
             }
 
             // Type and name

--- a/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
@@ -177,6 +177,14 @@ namespace TheWaningBorder.UI.Panels
                 if (info.IronPerMinute.HasValue && info.IronPerMinute.Value > 0)
                     GUILayout.Label($"Iron: {info.IronPerMinute}/min", _labelStyle, GUILayout.Width(120));
                 GUILayout.EndHorizontal();
+                GUILayout.BeginHorizontal();
+                if (info.CrystalPerMinute.HasValue && info.CrystalPerMinute.Value > 0)
+                    GUILayout.Label($"Crystal: {info.CrystalPerMinute}/min", _labelStyle, GUILayout.Width(130));
+                if (info.VeilsteelPerMinute.HasValue && info.VeilsteelPerMinute.Value > 0)
+                    GUILayout.Label($"Veilsteel: {info.VeilsteelPerMinute}/min", _labelStyle, GUILayout.Width(130));
+                if (info.GlowPerMinute.HasValue && info.GlowPerMinute.Value > 0)
+                    GUILayout.Label($"Glow: {info.GlowPerMinute}/min", _labelStyle, GUILayout.Width(120));
+                GUILayout.EndHorizontal();
             }
 
             // Miner info (no carry bar — just rate and status)


### PR DESCRIPTION
## Summary
Closes #90

- Add CrystalPerMinute, VeilsteelPerMinute, GlowPerMinute fields to EntityDisplayInfo
- Extract CrystalIncome, VeilsteelIncome, GlowIncome in EntityExtractors
- Render all 5 income types in EntityInfoPanel (Supplies/Iron row + Crystal/Veilsteel/Glow row)

## Changes
- **UITypes.cs**: 3 new int? fields following existing IronPerMinute pattern
- **EntityExtractors.cs**: 3 extraction blocks checking for income components on entity, matching the IronIncome pattern
- **EntityInfoPanel.cs**: Second horizontal row for Crystal/Veilsteel/Glow below existing Supplies/Iron row

## Test plan
- [ ] Select a building with CrystalIncome component - verify Crystal income displays
- [ ] Select a building with VeilsteelIncome component - verify Veilsteel income displays
- [ ] Select a building with GlowIncome component - verify Glow income displays
- [ ] Select a building with only Supplies/Iron - verify no extra row appears
- [ ] Verify panel layout is not broken with all 5 income types showing