### PR TITLE
fix(input): add SpellPanel and CultureChoicePopup to input blocking

### DIFF
--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -12,6 +12,7 @@ using TheWaningBorder.Core.Commands;
 using TheWaningBorder.Core.Commands.Types;
 using EntityWorld = Unity.Entities.World;
 using TheWaningBorder.UI.Panels;
+using TheWaningBorder.UI.HUD;
 using TheWaningBorder.Entities;
 
 namespace TheWaningBorder.Input
@@ -107,6 +108,14 @@ namespace TheWaningBorder.Input
 
             // Block if mouse is over UI panels
             if (EntityActionPanel.IsPointerOver() || EntityInfoPanel.IsPointerOver())
+                return true;
+
+            // Block if mouse is over spell panel
+            if (SpellPanel.IsPointerOverPanel)
+                return true;
+
+            // Block if culture choice popup is visible (modal dialog)
+            if (CultureChoicePopup.IsVisible)
                 return true;
 
             // Block during building placement

--- a/Assets/Scripts/Input/SelectionSystem.cs
+++ b/Assets/Scripts/Input/SelectionSystem.cs
@@ -10,6 +10,7 @@ using Unity.Transforms;
 using Unity.Collections;
 using EntityWorld = Unity.Entities.World;
 using TheWaningBorder.UI.Panels;
+using TheWaningBorder.UI.HUD;
 using TheWaningBorder.Systems.Visibility;
 using TheWaningBorder.World.Terrain;
 
@@ -163,6 +164,14 @@ namespace TheWaningBorder.Input
 
             // Block if mouse is over UI panels
             if (EntityInfoPanel.IsPointerOver() || EntityActionPanel.IsPointerOver())
+                return true;
+
+            // Block if mouse is over spell panel
+            if (SpellPanel.IsPointerOverPanel)
+                return true;
+
+            // Block if culture choice popup is visible (modal dialog)
+            if (CultureChoicePopup.IsVisible)
                 return true;
 
             // Block during building placement

--- a/Assets/Scripts/UI/Common/UIHelpers.cs
+++ b/Assets/Scripts/UI/Common/UIHelpers.cs
@@ -289,7 +289,8 @@ namespace TheWaningBorder.UI.Common
         {
             return Panels.EntityInfoPanel.IsPointerOver()
                 || Panels.EntityActionPanel.IsPointerOver()
-                || Panels.CultureChoicePopup.IsPointerOver();
+                || Panels.CultureChoicePopup.IsPointerOver()
+                || SpellPanel.IsPointerOverPanel;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Closes #92

- Add SpellPanel.IsPointerOverPanel check to ShouldBlockInput() and ShouldBlockSelection()
- Add CultureChoicePopup.IsVisible check to both methods
- Update UIHelpers.IsPointerOverAnyPanel() for consistency

## Changes

### RTSInputManager.cs
- Added using TheWaningBorder.UI.HUD for SpellPanel access
- Added SpellPanel.IsPointerOverPanel check in ShouldBlockInput()
- Added CultureChoicePopup.IsVisible check in ShouldBlockInput()

### SelectionSystem.cs
- Added using TheWaningBorder.UI.HUD for SpellPanel access
- Added SpellPanel.IsPointerOverPanel check in ShouldBlockSelection()
- Added CultureChoicePopup.IsVisible check in ShouldBlockSelection()

### UIHelpers.cs
- Added SpellPanel.IsPointerOverPanel to IsPointerOverAnyPanel()

## Test plan
- Open the SpellPanel and click on spell buttons -- verify no move/attack commands are issued to selected units
- Open the CultureChoicePopup -- verify clicking inside does not trigger selection or commands
- Verify existing input blocking (EntityInfoPanel, EntityActionPanel, BuilderCommandPanel) still works