### PR TITLE
fix(core): add missing safety checks in EntityExtractors, TempleChapelBuildSystem, BuildingRepairSystem

### DIFF
--- a/Assets/Scripts/Systems/Work/BuildingRepairSystem.cs
+++ b/Assets/Scripts/Systems/Work/BuildingRepairSystem.cs
@@ -199,6 +199,9 @@ namespace TheWaningBorder.Systems.Work
             if (!TechTreeDB.Instance.TryGetBuilding(buildingId, out var def)) return true;
             if (def.cost == null) return true; // No cost defined - repair for free
 
+            // Guard against division by zero (hp.Max should never be 0, but be safe)
+            if (hp.Max <= 0) return true;
+
             // Calculate damage ratio
             float damageRatio = 1f - ((float)hp.Value / hp.Max);
             if (damageRatio <= 0f) return true; // Not damaged

--- a/Assets/Scripts/Systems/Work/TempleChapelBuildSystem.cs
+++ b/Assets/Scripts/Systems/Work/TempleChapelBuildSystem.cs
@@ -86,6 +86,14 @@ namespace TheWaningBorder.Systems.Building
             for (int i = 0; i < deferredSpawns.Length; i++)
             {
                 var spawn = deferredSpawns[i];
+
+                // Safety: temple entity may have been destroyed between iteration and deferred spawn
+                if (!em.Exists(spawn.Temple)) continue;
+                if (!em.HasBuffer<TempleChapelSlot>(spawn.Temple)) continue;
+
+                var slots = em.GetBuffer<TempleChapelSlot>(spawn.Temple);
+                if (spawn.SlotIndex >= slots.Length) continue;
+
                 string sectId = spawn.SectId.ToString();
                 var faction = em.GetComponentData<FactionTag>(spawn.Temple).Value;
 
@@ -94,7 +102,8 @@ namespace TheWaningBorder.Systems.Building
                     em, sectId, spawn.Temple, spawn.SlotIndex, faction);
 
                 // Update the slot buffer to reference the created chapel entity
-                var slots = em.GetBuffer<TempleChapelSlot>(spawn.Temple);
+                // Re-fetch buffer in case CreateChapelAtSlot caused a structural change
+                slots = em.GetBuffer<TempleChapelSlot>(spawn.Temple);
                 var slot = slots[spawn.SlotIndex];
                 slot.Chapel = chapel;
                 slots[spawn.SlotIndex] = slot;

--- a/Assets/Scripts/UI/Panels/EntityExtractors.cs
+++ b/Assets/Scripts/UI/Panels/EntityExtractors.cs
@@ -257,6 +257,11 @@ namespace TheWaningBorder.UI
         /// </summary>
         public static int GetFactionEra(EntityManager em, Faction faction)
         {
+            if (World.DefaultGameObjectInjectionWorld == null || !World.DefaultGameObjectInjectionWorld.IsCreated)
+                return 1;
+            if (em.Equals(default(EntityManager)))
+                return 1;
+
             var query = em.CreateEntityQuery(
                 ComponentType.ReadOnly<FactionTag>(),
                 ComponentType.ReadOnly<FactionEra>()
@@ -281,6 +286,11 @@ namespace TheWaningBorder.UI
         /// </summary>
         public static int GetFactionReligionPoints(EntityManager em, Faction faction)
         {
+            if (World.DefaultGameObjectInjectionWorld == null || !World.DefaultGameObjectInjectionWorld.IsCreated)
+                return 0;
+            if (em.Equals(default(EntityManager)))
+                return 0;
+
             var query = em.CreateEntityQuery(
                 ComponentType.ReadOnly<FactionTag>(),
                 ComponentType.ReadOnly<ReligionPoints>()


### PR DESCRIPTION
## Summary
Closes #93

- **EntityExtractors**: Guard GetFactionEra() and GetFactionReligionPoints() against default EntityManager and destroyed World - returns safe fallback values (1 for era, 0 for RP) instead of crashing
- **TempleChapelBuildSystem**: Validate temple entity existence (em.Exists), buffer presence (em.HasBuffer), and slot index bounds (spawn.SlotIndex < slots.Length) before deferred chapel spawn; also re-fetch buffer after CreateChapelAtSlot in case of structural changes
- **BuildingRepairSystem**: Guard against hp.Max <= 0 before the hp.Value / hp.Max division in repair cost calculation to prevent divide-by-zero

## Test plan
- [ ] Verify temple chapels still build correctly when slots complete
- [ ] Verify building repair cost calculation works with damaged buildings
- [ ] Verify UI info panel displays era and RP correctly during normal gameplay
- [ ] Destroy a temple mid-chapel-build and confirm no crash
- [ ] Open entity info panel during scene transitions (World teardown) and confirm no crash