### PR TITLE
fix(ui): sync FactionColors after age-up to fix sect selection

### DIFF
--- a/Assets/Scripts/UI/Panels/CultureChoicePopup.cs
+++ b/Assets/Scripts/UI/Panels/CultureChoicePopup.cs
@@ -246,6 +246,7 @@ namespace TheWaningBorder.UI.Panels
                 var progress = em.GetComponentData<FactionProgress>(_hallEntity);
                 progress.Culture = culture;
                 em.SetComponentData(_hallEntity, progress);
+                FactionColors.SetFactionCulture(_faction, culture);
             }
 
             // 3. Scale the Hall 1.3x


### PR DESCRIPTION
## Summary
Closes #107

- \ writes culture to the ECS \ component but never updates the managed \ singleton
- \ reads \ which returns \, blocking sect selection after age-up
- Added \ immediately after the ECS component write inside the same guard block

## Changes
- \ - 1 line added at line 249

## Test Plan
- [ ] Start game, build Hall, gather resources, trigger age-up
- [ ] Select any culture in the popup
- [ ] Verify SectAdoptionPanel shows available sects afterward
- [ ] Verify FactionColors.GetFactionCulture(faction) returns the chosen culture