### PR TITLE
fix(economy): exclude enemy huts, walled areas, impassable terrain from gatherer income

### DIFF
--- a/Assets/Scripts/Core/Components/BuildingComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingComponents.cs
@@ -84,6 +84,16 @@ public struct WallEnclosureIncomeTag : IComponentData
     public byte FactionIndex;
 }
 
+/// <summary>
+/// Buffer element storing the XZ vertices of a wall enclosure polygon.
+/// Added to enclosure income entities by WallEnclosureIncomeSystem so that
+/// GathererHutIncomeSystem can do point-in-polygon tests without re-walking the hub graph.
+/// </summary>
+public struct WallEnclosureVertex : IBufferElementData
+{
+    public float2 Position;
+}
+
 /// <summary>Resource vault building.</summary>
 public struct VaultTag : IComponentData { }
 

--- a/Assets/Scripts/Economy/GathererHutIncomeSystem.cs
+++ b/Assets/Scripts/Economy/GathererHutIncomeSystem.cs
@@ -2,11 +2,17 @@
 // Calculates area-based income for GathererHuts (BFME2-style farms)
 // Uses first-come-first-served priority: older farms keep full yield,
 // newer farms only earn from unclaimed area.
+//
+// Grid-sampling approach: iterates PassabilityGrid cells within the
+// gather radius and excludes cells that are terrain-blocked, inside
+// enemy hut circles, inside older same-faction hut circles, or inside
+// wall enclosure polygons.
 
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
+using TheWaningBorder.World.Terrain;
 
 namespace TheWaningBorder.Economy
 {
@@ -40,7 +46,6 @@ namespace TheWaningBorder.Economy
             _lastUpdateTime = currentTime;
 
             var em = state.EntityManager;
-            float totalArea = math.PI * GatherRadius * GatherRadius;
 
             // =========================================================
             // Pre-pass: assign build orders to newly completed huts
@@ -73,77 +78,42 @@ namespace TheWaningBorder.Economy
             var hutBuildOrders = hutQuery.ToComponentDataArray<FarmBuildOrder>(Allocator.Temp);
 
             // =========================================================
-            // Snapshot all buildings (obstacles) — excluding under-construction
+            // Snapshot wall enclosure polygons for point-in-polygon tests (Bug B)
             // =========================================================
-            var buildingQuery = SystemAPI.QueryBuilder()
-                .WithAll<BuildingTag, LocalTransform, Radius>()
-                .WithNone<UnderConstruction>()
+            var enclosureQuery = SystemAPI.QueryBuilder()
+                .WithAll<WallEnclosureIncomeTag>()
                 .Build();
 
-            var bldgEntities = buildingQuery.ToEntityArray(Allocator.Temp);
-            var bldgTransforms = buildingQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
-            var bldgRadii = buildingQuery.ToComponentDataArray<Radius>(Allocator.Temp);
+            var enclosureEntities = enclosureQuery.ToEntityArray(Allocator.Temp);
 
             // =========================================================
-            // Calculate income for each GathererHut
+            // Calculate income for each GathererHut using grid sampling
             // =========================================================
+            var grid = PassabilityGrid.Instance;
+            float totalArea = math.PI * GatherRadius * GatherRadius;
+
             for (int h = 0; h < hutEntities.Length; h++)
             {
-                var hutPos = hutTransforms[h].Position;
-                float occupiedArea = 0f;
+                float ratio;
 
-                // --- Subtract building footprints within circle ---
-                // Skip other GathererHuts here; they are handled in the farm overlap loop.
-                for (int b = 0; b < bldgEntities.Length; b++)
+                if (grid != null)
                 {
-                    if (bldgEntities[b] == hutEntities[h]) continue;
-                    if (em.HasComponent<GathererHutTag>(bldgEntities[b])) continue;
-
-                    var bldgPos = bldgTransforms[b].Position;
-                    float dist = math.distance(
-                        new float2(hutPos.x, hutPos.z),
-                        new float2(bldgPos.x, bldgPos.z));
-
-                    float bldgRadius = bldgRadii[b].Value;
-
-                    if (dist < GatherRadius + bldgRadius)
-                    {
-                        if (dist + bldgRadius <= GatherRadius)
-                        {
-                            occupiedArea += math.PI * bldgRadius * bldgRadius;
-                        }
-                        else
-                        {
-                            occupiedArea += CircleCircleIntersection(GatherRadius, bldgRadius, dist);
-                        }
-                    }
+                    ratio = CalculateRatioGridSampling(
+                        em, grid, hutEntities[h], hutTransforms[h].Position,
+                        hutFactions[h].Value, hutBuildOrders[h].Value,
+                        hutEntities, hutTransforms, hutFactions, hutBuildOrders,
+                        enclosureEntities);
+                }
+                else
+                {
+                    // Fallback: no PassabilityGrid available (e.g. during bootstrap)
+                    ratio = CalculateRatioFallback(
+                        em, hutEntities[h], hutTransforms[h].Position,
+                        hutFactions[h].Value, hutBuildOrders[h].Value,
+                        hutEntities, hutTransforms, hutFactions, hutBuildOrders,
+                        totalArea);
                 }
 
-                // --- Subtract overlap with OLDER same-faction GathererHut circles ---
-                // Only farms built BEFORE this one reduce its area (first-come-first-served).
-                var hutFaction = hutFactions[h].Value;
-                int myOrder = hutBuildOrders[h].Value;
-                for (int other = 0; other < hutEntities.Length; other++)
-                {
-                    if (other == h) continue;
-                    if (hutFactions[other].Value != hutFaction) continue;
-                    if (hutBuildOrders[other].Value >= myOrder) continue;
-
-                    var otherPos = hutTransforms[other].Position;
-                    float dist = math.distance(
-                        new float2(hutPos.x, hutPos.z),
-                        new float2(otherPos.x, otherPos.z));
-
-                    if (dist < GatherRadius * 2f)
-                    {
-                        float overlap = CircleCircleIntersection(GatherRadius, GatherRadius, dist);
-                        occupiedArea += overlap;
-                    }
-                }
-
-                // --- Clamp and calculate ratio ---
-                float freeArea = math.max(0f, totalArea - occupiedArea);
-                float ratio = freeArea / totalArea;
                 float effectivePerTick = BasePerTick * ratio;
 
                 // --- Update the component (preserve Elapsed timer) ---
@@ -161,14 +131,210 @@ namespace TheWaningBorder.Economy
             hutTransforms.Dispose();
             hutFactions.Dispose();
             hutBuildOrders.Dispose();
-            bldgEntities.Dispose();
-            bldgTransforms.Dispose();
-            bldgRadii.Dispose();
+            enclosureEntities.Dispose();
+        }
+
+        /// <summary>
+        /// Grid-sampling area calculation. Iterates PassabilityGrid cells within
+        /// GatherRadius and checks each cell against all exclusion criteria.
+        /// </summary>
+        private static float CalculateRatioGridSampling(
+            EntityManager em,
+            PassabilityGrid grid,
+            Entity hutEntity,
+            float3 hutPos,
+            Faction hutFaction,
+            int myOrder,
+            NativeArray<Entity> hutEntities,
+            NativeArray<LocalTransform> hutTransforms,
+            NativeArray<FactionTag> hutFactions,
+            NativeArray<FarmBuildOrder> hutBuildOrders,
+            NativeArray<Entity> enclosureEntities)
+        {
+            float radiusSq = GatherRadius * GatherRadius;
+            float2 hutPos2D = new float2(hutPos.x, hutPos.z);
+
+            // Determine cell scan bounds
+            int2 minCell = grid.WorldToCell(new float3(hutPos.x - GatherRadius, 0f, hutPos.z - GatherRadius));
+            int2 maxCell = grid.WorldToCell(new float3(hutPos.x + GatherRadius, 0f, hutPos.z + GatherRadius));
+            minCell = math.max(minCell, int2.zero);
+            maxCell = math.min(maxCell, new int2(grid.Width - 1, grid.Height - 1));
+
+            int totalCells = 0;
+            int freeCells = 0;
+
+            for (int cy = minCell.y; cy <= maxCell.y; cy++)
+            {
+                for (int cx = minCell.x; cx <= maxCell.x; cx++)
+                {
+                    var cell = new int2(cx, cy);
+                    float3 cellWorld = grid.CellToWorld(cell);
+                    float2 cellPos = new float2(cellWorld.x, cellWorld.z);
+
+                    // Check if cell is within the gather circle
+                    float dx = cellPos.x - hutPos2D.x;
+                    float dz = cellPos.y - hutPos2D.y;
+                    if (dx * dx + dz * dz > radiusSq)
+                        continue;
+
+                    totalCells++;
+
+                    // --- Exclusion 1: Terrain-blocked or building-blocked (Bug C) ---
+                    byte cellValue = grid.GetCell(cell);
+                    if (cellValue != PassabilityGrid.Passable)
+                    {
+                        continue;
+                    }
+
+                    // --- Exclusion 2: Inside older same-faction GathererHut circle ---
+                    bool excluded = false;
+                    for (int other = 0; other < hutEntities.Length; other++)
+                    {
+                        if (hutEntities[other] == hutEntity) continue;
+                        if (hutFactions[other].Value != hutFaction) continue;
+                        if (hutBuildOrders[other].Value >= myOrder) continue;
+
+                        var otherPos = new float2(
+                            hutTransforms[other].Position.x,
+                            hutTransforms[other].Position.z);
+                        float odx = cellPos.x - otherPos.x;
+                        float odz = cellPos.y - otherPos.y;
+                        if (odx * odx + odz * odz <= radiusSq)
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    // --- Exclusion 3: Inside ANY enemy GathererHut circle (Bug A) ---
+                    for (int other = 0; other < hutEntities.Length; other++)
+                    {
+                        if (hutEntities[other] == hutEntity) continue;
+                        if (hutFactions[other].Value == hutFaction) continue;
+
+                        var otherPos = new float2(
+                            hutTransforms[other].Position.x,
+                            hutTransforms[other].Position.z);
+                        float odx = cellPos.x - otherPos.x;
+                        float odz = cellPos.y - otherPos.y;
+                        if (odx * odx + odz * odz <= radiusSq)
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    // --- Exclusion 4: Inside any wall enclosure polygon (Bug B) ---
+                    for (int e = 0; e < enclosureEntities.Length; e++)
+                    {
+                        if (!em.HasBuffer<WallEnclosureVertex>(enclosureEntities[e]))
+                            continue;
+
+                        var vertices = em.GetBuffer<WallEnclosureVertex>(enclosureEntities[e]);
+                        if (vertices.Length < 3) continue;
+
+                        if (PointInPolygon(cellPos, vertices))
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    freeCells++;
+                }
+            }
+
+            if (totalCells == 0) return 0f;
+            return (float)freeCells / totalCells;
+        }
+
+        /// <summary>
+        /// Fallback geometric area calculation when PassabilityGrid is not available.
+        /// Uses same-faction overlap only (original logic minus enemy hut skip bug).
+        /// </summary>
+        private static float CalculateRatioFallback(
+            EntityManager em,
+            Entity hutEntity,
+            float3 hutPos,
+            Faction hutFaction,
+            int myOrder,
+            NativeArray<Entity> hutEntities,
+            NativeArray<LocalTransform> hutTransforms,
+            NativeArray<FactionTag> hutFactions,
+            NativeArray<FarmBuildOrder> hutBuildOrders,
+            float totalArea)
+        {
+            float occupiedArea = 0f;
+
+            // Subtract overlap with older same-faction GathererHut circles
+            for (int other = 0; other < hutEntities.Length; other++)
+            {
+                if (hutEntities[other] == hutEntity) continue;
+                if (hutFactions[other].Value != hutFaction) continue;
+                if (hutBuildOrders[other].Value >= myOrder) continue;
+
+                var otherPos = hutTransforms[other].Position;
+                float dist = math.distance(
+                    new float2(hutPos.x, hutPos.z),
+                    new float2(otherPos.x, otherPos.z));
+
+                if (dist < GatherRadius * 2f)
+                {
+                    occupiedArea += CircleCircleIntersection(GatherRadius, GatherRadius, dist);
+                }
+            }
+
+            // Also subtract enemy GathererHut circles (Bug A fix in fallback)
+            for (int other = 0; other < hutEntities.Length; other++)
+            {
+                if (hutEntities[other] == hutEntity) continue;
+                if (hutFactions[other].Value == hutFaction) continue;
+
+                var otherPos = hutTransforms[other].Position;
+                float dist = math.distance(
+                    new float2(hutPos.x, hutPos.z),
+                    new float2(otherPos.x, otherPos.z));
+
+                if (dist < GatherRadius * 2f)
+                {
+                    occupiedArea += CircleCircleIntersection(GatherRadius, GatherRadius, dist);
+                }
+            }
+
+            float freeArea = math.max(0f, totalArea - occupiedArea);
+            return freeArea / totalArea;
+        }
+
+        /// <summary>
+        /// Ray-casting point-in-polygon test on the XZ plane.
+        /// Returns true if the point lies inside the polygon defined by the vertex buffer.
+        /// </summary>
+        public static bool PointInPolygon(float2 point, DynamicBuffer<WallEnclosureVertex> vertices)
+        {
+            int n = vertices.Length;
+            bool inside = false;
+
+            for (int i = 0, j = n - 1; i < n; j = i++)
+            {
+                float2 vi = vertices[i].Position;
+                float2 vj = vertices[j].Position;
+
+                if (((vi.y > point.y) != (vj.y > point.y)) &&
+                    (point.x < (vj.x - vi.x) * (point.y - vi.y) / (vj.y - vi.y) + vi.x))
+                {
+                    inside = !inside;
+                }
+            }
+
+            return inside;
         }
 
         /// <summary>
         /// Calculate the intersection area of two circles with radii r1, r2
-        /// separated by distance d.
+        /// separated by distance d. Used by the fallback path.
         /// </summary>
         private static float CircleCircleIntersection(float r1, float r2, float d)
         {

--- a/Assets/Scripts/Economy/WallEnclosureIncomeSystem.cs
+++ b/Assets/Scripts/Economy/WallEnclosureIncomeSystem.cs
@@ -215,6 +215,19 @@ namespace TheWaningBorder.Economy
                                 Elapsed = 0f
                             });
 
+                            // Store polygon vertices so GathererHutIncomeSystem can
+                            // perform point-in-polygon tests without re-walking the graph.
+                            em.AddBuffer<WallEnclosureVertex>(incomeEntity);
+                            var vertexBuf = em.GetBuffer<WallEnclosureVertex>(incomeEntity);
+                            for (int ci = 0; ci < cycle.Length; ci++)
+                            {
+                                var hubPos = hubTransforms[cycle[ci]].Position;
+                                vertexBuf.Add(new WallEnclosureVertex
+                                {
+                                    Position = new float2(hubPos.x, hubPos.z)
+                                });
+                            }
+
                             // Mark all hubs in this cycle so we don't recount them
                             for (int ci = 0; ci < cycle.Length; ci++)
                                 usedInCycle.Add(cycle[ci]);

--- a/Assets/Scripts/UI/HUD/GathererHutAreaDisplay.cs
+++ b/Assets/Scripts/UI/HUD/GathererHutAreaDisplay.cs
@@ -162,48 +162,26 @@ namespace TheWaningBorder.UI.HUD
 
         /// <summary>
         /// Calculate what income ratio a new farm would get at this position.
-        /// Uses the same logic as GathererHutIncomeSystem but from the perspective
-        /// of a brand-new farm (all existing farms are "older" and claim priority).
+        /// Uses grid-sampling: iterates PassabilityGrid cells within GatherRadius
+        /// and excludes cells that are terrain/building-blocked, inside existing
+        /// same-faction or enemy hut circles, or inside wall enclosure polygons.
+        /// Since this is a new farm, all existing farms have priority.
         /// </summary>
         private float CalculatePlacementRatio(float2 placementPos)
         {
-            float totalArea = math.PI * GatherRadius * GatherRadius;
-            float occupiedArea = 0f;
+            var grid = PassabilityGrid.Instance;
+            if (grid == null)
+                return CalculatePlacementRatioFallback(placementPos);
 
-            // --- Subtract building footprints (non-farm buildings) ---
-            var bldgQuery = _em.CreateEntityQuery(
-                ComponentType.ReadOnly<BuildingTag>(),
-                ComponentType.ReadOnly<LocalTransform>(),
-                ComponentType.ReadOnly<Radius>());
+            float radiusSq = GatherRadius * GatherRadius;
 
-            var bldgEntities = bldgQuery.ToEntityArray(Allocator.Temp);
-            var bldgTransforms = bldgQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
-            var bldgRadii = bldgQuery.ToComponentDataArray<Radius>(Allocator.Temp);
+            // Determine cell scan bounds
+            int2 minCell = grid.WorldToCell(new float3(placementPos.x - GatherRadius, 0f, placementPos.y - GatherRadius));
+            int2 maxCell = grid.WorldToCell(new float3(placementPos.x + GatherRadius, 0f, placementPos.y + GatherRadius));
+            minCell = math.max(minCell, int2.zero);
+            maxCell = math.min(maxCell, new int2(grid.Width - 1, grid.Height - 1));
 
-            for (int b = 0; b < bldgEntities.Length; b++)
-            {
-                // Skip other GathererHuts (handled in farm overlap loop)
-                if (_em.HasComponent<GathererHutTag>(bldgEntities[b])) continue;
-
-                var bPos = new float2(bldgTransforms[b].Position.x, bldgTransforms[b].Position.z);
-                float dist = math.distance(placementPos, bPos);
-                float bldgRadius = bldgRadii[b].Value;
-
-                if (dist < GatherRadius + bldgRadius)
-                {
-                    if (dist + bldgRadius <= GatherRadius)
-                        occupiedArea += math.PI * bldgRadius * bldgRadius;
-                    else
-                        occupiedArea += CircleCircleIntersection(GatherRadius, bldgRadius, dist);
-                }
-            }
-
-            bldgEntities.Dispose();
-            bldgTransforms.Dispose();
-            bldgRadii.Dispose();
-
-            // --- Subtract overlap with ALL same-faction GathererHut circles ---
-            // Since this is a new farm, all existing farms have priority.
+            // Snapshot existing GathererHuts
             var hutQuery = _em.CreateEntityQuery(
                 ComponentType.ReadOnly<GathererHutTag>(),
                 ComponentType.ReadOnly<LocalTransform>(),
@@ -212,10 +190,119 @@ namespace TheWaningBorder.UI.HUD
             var hutTransforms = hutQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
             var hutFactions = hutQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
 
+            // Snapshot wall enclosure polygons
+            var enclosureQuery = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<WallEnclosureIncomeTag>());
+            var enclosureEntities = enclosureQuery.ToEntityArray(Allocator.Temp);
+
+            int totalCells = 0;
+            int freeCells = 0;
+
+            for (int cy = minCell.y; cy <= maxCell.y; cy++)
+            {
+                for (int cx = minCell.x; cx <= maxCell.x; cx++)
+                {
+                    var cell = new int2(cx, cy);
+                    float3 cellWorld = grid.CellToWorld(cell);
+                    float2 cellPos = new float2(cellWorld.x, cellWorld.z);
+
+                    // Check if cell is within the gather circle
+                    float dx = cellPos.x - placementPos.x;
+                    float dz = cellPos.y - placementPos.y;
+                    if (dx * dx + dz * dz > radiusSq)
+                        continue;
+
+                    totalCells++;
+
+                    // Exclusion 1: Terrain-blocked or building-blocked
+                    byte cellValue = grid.GetCell(cell);
+                    if (cellValue != PassabilityGrid.Passable)
+                        continue;
+
+                    // Exclusion 2: Inside any same-faction GathererHut circle
+                    // (all existing are "older" since this is a new placement)
+                    bool excluded = false;
+                    for (int i = 0; i < hutTransforms.Length; i++)
+                    {
+                        if (hutFactions[i].Value != GameSettings.LocalPlayerFaction) continue;
+
+                        var hPos = new float2(hutTransforms[i].Position.x, hutTransforms[i].Position.z);
+                        float hdx = cellPos.x - hPos.x;
+                        float hdz = cellPos.y - hPos.y;
+                        if (hdx * hdx + hdz * hdz <= radiusSq)
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    // Exclusion 3: Inside any enemy GathererHut circle
+                    for (int i = 0; i < hutTransforms.Length; i++)
+                    {
+                        if (hutFactions[i].Value == GameSettings.LocalPlayerFaction) continue;
+
+                        var hPos = new float2(hutTransforms[i].Position.x, hutTransforms[i].Position.z);
+                        float hdx = cellPos.x - hPos.x;
+                        float hdz = cellPos.y - hPos.y;
+                        if (hdx * hdx + hdz * hdz <= radiusSq)
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    // Exclusion 4: Inside any wall enclosure polygon
+                    for (int e = 0; e < enclosureEntities.Length; e++)
+                    {
+                        if (!_em.HasBuffer<WallEnclosureVertex>(enclosureEntities[e]))
+                            continue;
+
+                        var vertices = _em.GetBuffer<WallEnclosureVertex>(enclosureEntities[e]);
+                        if (vertices.Length < 3) continue;
+
+                        if (GathererHutIncomeSystem.PointInPolygon(cellPos, vertices))
+                        {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (excluded) continue;
+
+                    freeCells++;
+                }
+            }
+
+            hutTransforms.Dispose();
+            hutFactions.Dispose();
+            enclosureEntities.Dispose();
+
+            if (totalCells == 0) return 0f;
+            return (float)freeCells / totalCells;
+        }
+
+        /// <summary>
+        /// Fallback geometric calculation when PassabilityGrid is not available.
+        /// </summary>
+        private float CalculatePlacementRatioFallback(float2 placementPos)
+        {
+            float totalArea = math.PI * GatherRadius * GatherRadius;
+            float occupiedArea = 0f;
+
+            var hutQuery = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<GathererHutTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>());
+
+            var hutTransforms = hutQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
+            var hutFactions = hutQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
+
+            // Subtract overlap with ALL existing GathererHut circles (same-faction
+            // and enemy). Since this is a new farm, all existing farms have priority
+            // for same-faction, and enemy huts always exclude.
             for (int i = 0; i < hutTransforms.Length; i++)
             {
-                if (hutFactions[i].Value != GameSettings.LocalPlayerFaction) continue;
-
                 var hPos = new float2(hutTransforms[i].Position.x, hutTransforms[i].Position.z);
                 float dist = math.distance(placementPos, hPos);
 


### PR DESCRIPTION
## Summary
Closes #134

Replaces the geometric circle-intersection math in `GathererHutIncomeSystem` with a **grid-sampling approach** that iterates `PassabilityGrid` cells within the gather radius and checks each cell against all exclusion criteria.

### Bug Fixes
- **Bug A** — Enemy GathererHut circles now reduce effective area (previously skipped entirely)
- **Bug B** — Wall enclosure polygons (any faction) exclude area via point-in-polygon test
- **Bug C** — Terrain-blocked and building-blocked cells excluded via PassabilityGrid

### Changes
| File | Change |
|------|--------|
| `BuildingComponents.cs` | Add `WallEnclosureVertex : IBufferElementData` |
| `WallEnclosureIncomeSystem.cs` | Populate vertex buffer when creating enclosure income entities |
| `GathererHutIncomeSystem.cs` | Rewrite area calc with grid-sampling + fallback path |
| `GathererHutAreaDisplay.cs` | Update `CalculatePlacementRatio()` with matching grid-sampling logic |

### Design Decisions
- **Unified grid-sampling**: Single pass over ~176 cells (at 2-unit cell size for 15-unit radius) checks passability, friendly/enemy hut overlap, and wall enclosure polygons in one loop
- **Fallback path**: When `PassabilityGrid.Instance` is null (bootstrap), uses geometric circle-circle intersection with enemy hut fix applied
- **`PointInPolygon` is public static**: Shared between `GathererHutIncomeSystem` and `GathererHutAreaDisplay` to avoid duplication

## Spec Reference
Implements spec from #134