### PR TITLE
feat(ui): integrate in-game menu, options, tech tree, HUD improvements

### DIFF
--- a/Assets/Scripts/Bootstrap/GameBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/GameBootstrap.cs
@@ -170,6 +170,7 @@ namespace TheWaningBorder.Bootstrap
             managersGO.AddComponent<TechEffectSystem>();            // Tech effect application on research completion
             managersGO.AddComponent<FactionSectState>();            // Sect adoption tracking per faction
             managersGO.AddComponent<SectEffectSystem>();            // Sect passive effect application
+            managersGO.AddComponent<InGameMenuPanel>();              // In-game menu (ESC key)
             Object.DontDestroyOnLoad(managersGO);
             Debug.Log("[GameBootstrap] Created RuntimeManagers");
         }

--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -39,9 +39,6 @@ namespace TheWaningBorder.Input
         [Header("Formation")]
         [SerializeField] private float formationSpacing = 2.0f;
         
-        [Header("Debug")]
-        [SerializeField] private bool showHelp = true;
-        
         // ═══════════════════════════════════════════════════════════════════════
         // STATE
         // ═══════════════════════════════════════════════════════════════════════
@@ -126,6 +123,10 @@ namespace TheWaningBorder.Input
             if (BuilderCommandPanel.IsPlacingBuilding)
                 return true;
 
+            // Block if in-game menu is open
+            if (InGameMenuPanel.IsOpen)
+                return true;
+
             return false;
         }
         
@@ -135,12 +136,26 @@ namespace TheWaningBorder.Input
         
         private void HandleHotkeys()
         {
-            // ESC - Clear selection and cancel attack-move/patrol mode
+            // ESC - cascading: close menu > cancel modes > clear selection > open menu
             if (UnityEngine.Input.GetKeyDown(KeyCode.Escape))
             {
-                _attackMoveMode = false;
-                _patrolMode = false;
-                SelectionSystem.ClearSelection();
+                if (InGameMenuPanel.IsOpen)
+                {
+                    InGameMenuPanel.Toggle();
+                }
+                else if (_attackMoveMode || _patrolMode)
+                {
+                    _attackMoveMode = false;
+                    _patrolMode = false;
+                }
+                else if (SelectionSystem.HasSelection())
+                {
+                    SelectionSystem.ClearSelection();
+                }
+                else
+                {
+                    InGameMenuPanel.Toggle();
+                }
             }
 
             // A - Enter attack-move mode
@@ -1026,39 +1041,28 @@ namespace TheWaningBorder.Input
 
         void OnGUI()
         {
-            if (!showHelp) return;
-            
-            GUILayout.BeginArea(new Rect(10, 10, 300, 300));
-            GUILayout.Label("Controls:");
-            GUILayout.Label("Left-click: Select unit");
-            GUILayout.Label("Double-click: Select all of type on screen");
-            GUILayout.Label("Ctrl+Double-click: Select all of type (map)");
-            GUILayout.Label("Left-drag: Box select");
-            GUILayout.Label("Right-click: Move/Attack/Gather");
-            GUILayout.Label("A + Right-click: Attack-move");
-            GUILayout.Label("P + Right-click: Patrol");
-            GUILayout.Label("S: Stop");
-            GUILayout.Label("H: Hold position");
-            GUILayout.Label("Ctrl+1-9: Save control group");
-            GUILayout.Label("1-9: Recall group (2x: center cam)");
-            GUILayout.Label("Shift+1-9: Add to group");
-            GUILayout.Label("ESC: Clear selection");
+            // Mode indicators as centered banner at top of screen
+            if (_attackMoveMode || _patrolMode)
+            {
+                string modeText = _attackMoveMode ? "ATTACK-MOVE MODE" : "PATROL MODE";
+                float bannerW = 250f;
+                float bannerH = 30f;
+                float bannerX = (Screen.width - bannerW) * 0.5f;
+                float bannerY = 50f;
 
-            if (_attackMoveMode)
-            {
-                GUILayout.Label("<b>[ATTACK-MOVE MODE]</b>");
+                GUI.color = new Color(0f, 0f, 0f, 0.7f);
+                GUI.DrawTexture(new Rect(bannerX, bannerY, bannerW, bannerH), Texture2D.whiteTexture);
+                GUI.color = new Color(1f, 0.85f, 0.3f);
+                var style = new GUIStyle(GUI.skin.label)
+                {
+                    alignment = TextAnchor.MiddleCenter,
+                    fontStyle = FontStyle.Bold,
+                    fontSize = 14
+                };
+                style.normal.textColor = new Color(1f, 0.85f, 0.3f);
+                GUI.Label(new Rect(bannerX, bannerY, bannerW, bannerH), modeText, style);
+                GUI.color = Color.white;
             }
-            if (_patrolMode)
-            {
-                GUILayout.Label("<b>[PATROL MODE]</b>");
-            }
-
-            if (GameSettings.IsMultiplayer)
-            {
-                GUILayout.Label($"Faction: {GameSettings.LocalPlayerFaction}");
-                GUILayout.Label("Multiplayer: Active");
-            }
-            GUILayout.EndArea();
         }
     }
     

--- a/Assets/Scripts/UI/Common/UIHelpers.cs
+++ b/Assets/Scripts/UI/Common/UIHelpers.cs
@@ -229,6 +229,7 @@ namespace TheWaningBorder.UI.Common
             gameObject.AddComponent<Panels.EntityInfoPanel>();
             gameObject.AddComponent<Panels.EntityActionPanel>();
             gameObject.AddComponent<Panels.CultureChoicePopup>();
+            gameObject.AddComponent<Panels.TechTreePanel>();
             gameObject.AddComponent<HUD.FloatingHealthBars>();
             gameObject.AddComponent<HUD.PlayerNotificationSystem>();
         }
@@ -290,6 +291,7 @@ namespace TheWaningBorder.UI.Common
             return Panels.EntityInfoPanel.IsPointerOver()
                 || Panels.EntityActionPanel.IsPointerOver()
                 || Panels.CultureChoicePopup.IsPointerOver()
+                || Panels.TechTreePanel.IsPointerOver()
                 || SpellPanel.IsPointerOverPanel;
         }
 
@@ -306,6 +308,55 @@ namespace TheWaningBorder.UI.Common
                 return world.EntityManager;
 
             return default;
+        }
+
+        /// <summary>
+        /// Get all currently selected entities (valid and existing).
+        /// </summary>
+        public static System.Collections.Generic.List<Entity> GetAllSelectedEntities()
+        {
+            var sel = SelectionSystem.CurrentSelection;
+            if (sel == null) return new System.Collections.Generic.List<Entity>();
+
+            var manager = GetEntityManager();
+            if (manager.Equals(default(EntityManager))) return new System.Collections.Generic.List<Entity>();
+
+            var result = new System.Collections.Generic.List<Entity>(sel.Count);
+            for (int i = 0; i < sel.Count; i++)
+            {
+                var e = sel[i];
+                if (manager.Exists(e) && manager.HasComponent<FactionTag>(e))
+                    result.Add(e);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Get count of valid selected entities.
+        /// </summary>
+        public static int GetSelectionCount()
+        {
+            var sel = SelectionSystem.CurrentSelection;
+            if (sel == null) return 0;
+
+            var manager = GetEntityManager();
+            if (manager.Equals(default(EntityManager))) return 0;
+
+            int count = 0;
+            for (int i = 0; i < sel.Count; i++)
+            {
+                if (manager.Exists(sel[i]) && manager.HasComponent<FactionTag>(sel[i]))
+                    count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Returns true if more than one entity is selected.
+        /// </summary>
+        public static bool IsMultiSelection()
+        {
+            return GetSelectionCount() > 1;
         }
     }
 }

--- a/Assets/Scripts/UI/HUD/EndGameButton.cs
+++ b/Assets/Scripts/UI/HUD/EndGameButton.cs
@@ -36,6 +36,9 @@ namespace TheWaningBorder.UI.HUD
             // Don't show if post-game stats are visible
             if (PostGameStatsUI.IsVisible) return;
 
+            // Don't show if in-game menu is open
+            if (InGameMenuPanel.IsOpen) return;
+
             InitStyles();
 
             float x = Screen.width - ButtonWidth - Margin;

--- a/Assets/Scripts/UI/HUD/InGameMenuPanel.cs
+++ b/Assets/Scripts/UI/HUD/InGameMenuPanel.cs
@@ -1,0 +1,467 @@
+// InGameMenuPanel.cs
+// In-game menu panel with Resume, Keybinds, Surrender, Quit to Menu
+// Location: Assets/Scripts/UI/HUD/InGameMenuPanel.cs
+
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using TheWaningBorder.Bootstrap;
+
+namespace TheWaningBorder.UI.HUD
+{
+    /// <summary>
+    /// Modal in-game menu panel toggled by ESC or the Menu button in the resource bar.
+    /// Pauses the game in singleplayer mode. Contains Resume, Keybinds, Surrender,
+    /// and Quit to Menu buttons.
+    /// </summary>
+    public class InGameMenuPanel : MonoBehaviour
+    {
+        // ================================================================
+        // PUBLIC STATE
+        // ================================================================
+
+        /// <summary>True when the menu panel is visible (blocks game input).</summary>
+        public static bool IsOpen { get; private set; }
+
+        // ================================================================
+        // PRIVATE STATE
+        // ================================================================
+
+        private enum SubView { Main, Keybinds }
+        private SubView _currentView = SubView.Main;
+        private bool _showSurrenderConfirm;
+
+        // Styles
+        private GUIStyle _overlayBg;
+        private GUIStyle _panelBg;
+        private GUIStyle _titleStyle;
+        private GUIStyle _buttonStyle;
+        private GUIStyle _keybindLabelStyle;
+        private GUIStyle _keybindKeyStyle;
+        private GUIStyle _keybindHeaderStyle;
+        private Texture2D _texOverlay;
+        private Texture2D _texPanel;
+        private Texture2D _texButton;
+        private Texture2D _texButtonHover;
+        private bool _stylesBuilt;
+
+        // Layout constants
+        private const float PanelWidth = 340f;
+        private const float PanelMinHeight = 320f;
+        private const float ButtonWidth = 260f;
+        private const float ButtonHeight = 38f;
+        private const float ButtonSpacing = 10f;
+        private const float TitleHeight = 40f;
+
+        // Keybinds scroll
+        private Vector2 _keybindsScroll;
+
+        // ================================================================
+        // PUBLIC API
+        // ================================================================
+
+        /// <summary>Toggle menu open/closed.</summary>
+        public static void Toggle()
+        {
+            if (IsOpen)
+                Close();
+            else
+                Open();
+        }
+
+        /// <summary>Open the menu panel.</summary>
+        public static void Open()
+        {
+            if (IsOpen) return;
+            if (PostGameStatsUI.IsVisible) return; // Don't open over post-game stats
+
+            IsOpen = true;
+
+            // Pause in singleplayer
+            if (!GameSettings.IsMultiplayer)
+            {
+                Time.timeScale = 0f;
+            }
+        }
+
+        /// <summary>Close the menu panel and resume.</summary>
+        public static void Close()
+        {
+            if (!IsOpen) return;
+
+            IsOpen = false;
+
+            // Resume time (only if post-game stats aren't showing)
+            if (!PostGameStatsUI.IsVisible)
+            {
+                Time.timeScale = 1f;
+            }
+
+            // Reset sub-view state
+            var instance = Object.FindFirstObjectByType<InGameMenuPanel>();
+            if (instance != null)
+            {
+                instance._currentView = SubView.Main;
+                instance._showSurrenderConfirm = false;
+            }
+        }
+
+        // ================================================================
+        // LIFECYCLE
+        // ================================================================
+
+        void Awake()
+        {
+            IsOpen = false;
+        }
+
+        void OnDestroy()
+        {
+            // Ensure time is restored if we're destroyed while open
+            if (IsOpen)
+            {
+                IsOpen = false;
+                Time.timeScale = 1f;
+            }
+        }
+
+        // ================================================================
+        // RENDERING
+        // ================================================================
+
+        void OnGUI()
+        {
+            if (!IsOpen) return;
+            if (!_stylesBuilt) BuildStyles();
+
+            // Semi-transparent dark overlay covering the whole screen
+            GUI.color = Color.white;
+            GUI.Box(new Rect(0, 0, Screen.width, Screen.height), "", _overlayBg);
+
+            // Draw the appropriate view
+            switch (_currentView)
+            {
+                case SubView.Main:
+                    DrawMainMenu();
+                    break;
+                case SubView.Keybinds:
+                    DrawKeybindsView();
+                    break;
+            }
+        }
+
+        // ================================================================
+        // MAIN MENU VIEW
+        // ================================================================
+
+        private void DrawMainMenu()
+        {
+            float panelHeight = PanelMinHeight;
+            if (_showSurrenderConfirm) panelHeight += 60f;
+
+            float px = (Screen.width - PanelWidth) * 0.5f;
+            float py = (Screen.height - panelHeight) * 0.5f;
+            var panelRect = new Rect(px, py, PanelWidth, panelHeight);
+
+            // Panel background
+            GUI.Box(panelRect, "", _panelBg);
+
+            // Title
+            var titleRect = new Rect(px, py + 15f, PanelWidth, TitleHeight);
+            GUI.Label(titleRect, "MENU", _titleStyle);
+
+            // Pause indicator for singleplayer
+            if (!GameSettings.IsMultiplayer)
+            {
+                var pauseStyle = new GUIStyle(_titleStyle)
+                {
+                    fontSize = 12,
+                    fontStyle = FontStyle.Italic,
+                    normal = { textColor = new Color(0.7f, 0.7f, 0.7f) }
+                };
+                GUI.Label(new Rect(px, py + 48f, PanelWidth, 20f), "Game Paused", pauseStyle);
+            }
+
+            float buttonY = py + 75f;
+            float buttonX = px + (PanelWidth - ButtonWidth) * 0.5f;
+
+            // Resume button
+            if (GUI.Button(new Rect(buttonX, buttonY, ButtonWidth, ButtonHeight), "Resume", _buttonStyle))
+            {
+                Close();
+            }
+            buttonY += ButtonHeight + ButtonSpacing;
+
+            // Keybinds button
+            if (GUI.Button(new Rect(buttonX, buttonY, ButtonWidth, ButtonHeight), "Keybinds", _buttonStyle))
+            {
+                _currentView = SubView.Keybinds;
+            }
+            buttonY += ButtonHeight + ButtonSpacing;
+
+            // Surrender button
+            if (!_showSurrenderConfirm)
+            {
+                if (GUI.Button(new Rect(buttonX, buttonY, ButtonWidth, ButtonHeight), "Surrender", _buttonStyle))
+                {
+                    _showSurrenderConfirm = true;
+                }
+                buttonY += ButtonHeight + ButtonSpacing;
+            }
+            else
+            {
+                // Confirmation row
+                var confirmLabelStyle = new GUIStyle(_titleStyle)
+                {
+                    fontSize = 13,
+                    normal = { textColor = new Color(1f, 0.5f, 0.5f) }
+                };
+                GUI.Label(new Rect(buttonX, buttonY, ButtonWidth, 22f), "Are you sure?", confirmLabelStyle);
+                buttonY += 24f;
+
+                float halfBtn = (ButtonWidth - 10f) * 0.5f;
+                if (GUI.Button(new Rect(buttonX, buttonY, halfBtn, ButtonHeight), "Yes, Surrender", _buttonStyle))
+                {
+                    _showSurrenderConfirm = false;
+                    DoSurrender();
+                    return;
+                }
+                if (GUI.Button(new Rect(buttonX + halfBtn + 10f, buttonY, halfBtn, ButtonHeight), "Cancel", _buttonStyle))
+                {
+                    _showSurrenderConfirm = false;
+                }
+                buttonY += ButtonHeight + ButtonSpacing;
+            }
+
+            // Quit to Menu button
+            if (GUI.Button(new Rect(buttonX, buttonY, ButtonWidth, ButtonHeight), "Quit to Menu", _buttonStyle))
+            {
+                DoQuitToMenu();
+            }
+        }
+
+        // ================================================================
+        // KEYBINDS VIEW
+        // ================================================================
+
+        private void DrawKeybindsView()
+        {
+            float panelHeight = 480f;
+            float px = (Screen.width - PanelWidth) * 0.5f;
+            float py = (Screen.height - panelHeight) * 0.5f;
+            var panelRect = new Rect(px, py, PanelWidth, panelHeight);
+
+            // Panel background
+            GUI.Box(panelRect, "", _panelBg);
+
+            // Title
+            var titleRect = new Rect(px, py + 15f, PanelWidth, TitleHeight);
+            GUI.Label(titleRect, "KEYBINDS", _titleStyle);
+
+            // Back button (top-left of panel)
+            var backStyle = new GUIStyle(_buttonStyle) { fontSize = 12 };
+            if (GUI.Button(new Rect(px + 10f, py + 18f, 60f, 28f), "< Back", backStyle))
+            {
+                _currentView = SubView.Main;
+            }
+
+            // Keybinds list (scrollable)
+            float listY = py + 65f;
+            float listHeight = panelHeight - 80f;
+            var listRect = new Rect(px + 15f, listY, PanelWidth - 30f, listHeight);
+
+            // Content height calculation
+            float contentHeight = 520f; // enough for all keybinds
+            var viewRect = new Rect(0, 0, PanelWidth - 50f, contentHeight);
+
+            _keybindsScroll = GUI.BeginScrollView(listRect, _keybindsScroll, viewRect);
+
+            float y = 5f;
+            float col1 = 0f;        // Key column
+            float col2 = 140f;      // Description column
+            float rowH = 22f;
+
+            // Selection
+            DrawKeybindHeader(ref y, "Selection");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Left-click", "Select unit");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Double-click", "Select all of type on screen");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Ctrl+Dbl-click", "Select all of type (map)");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Left-drag", "Box select");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Shift+click", "Add to selection");
+
+            y += 8f;
+
+            // Commands
+            DrawKeybindHeader(ref y, "Commands");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Right-click", "Move / Attack / Gather");
+            DrawKeybindRow(ref y, col1, col2, rowH, "A + Right-click", "Attack-move");
+            DrawKeybindRow(ref y, col1, col2, rowH, "P + Right-click", "Patrol");
+            DrawKeybindRow(ref y, col1, col2, rowH, "S", "Stop");
+            DrawKeybindRow(ref y, col1, col2, rowH, "H", "Hold position");
+
+            y += 8f;
+
+            // Control Groups
+            DrawKeybindHeader(ref y, "Control Groups");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Ctrl+1-9", "Save control group");
+            DrawKeybindRow(ref y, col1, col2, rowH, "1-9", "Recall group (2x: center cam)");
+            DrawKeybindRow(ref y, col1, col2, rowH, "Shift+1-9", "Add to group");
+
+            y += 8f;
+
+            // General
+            DrawKeybindHeader(ref y, "General");
+            DrawKeybindRow(ref y, col1, col2, rowH, "ESC", "Open / close menu");
+
+            GUI.EndScrollView();
+        }
+
+        private void DrawKeybindHeader(ref float y, string header)
+        {
+            GUI.Label(new Rect(0, y, 300f, 22f), header, _keybindHeaderStyle);
+            y += 26f;
+        }
+
+        private void DrawKeybindRow(ref float y, float col1, float col2, float rowH,
+                                      string key, string description)
+        {
+            GUI.Label(new Rect(col1, y, 135f, rowH), key, _keybindKeyStyle);
+            GUI.Label(new Rect(col2, y, 160f, rowH), description, _keybindLabelStyle);
+            y += rowH;
+        }
+
+        // ================================================================
+        // ACTIONS
+        // ================================================================
+
+        private void DoSurrender()
+        {
+            // Restore time before transitioning
+            Time.timeScale = 1f;
+            IsOpen = false;
+
+            // Route through VictoryConditionSystem for proper elimination tracking
+            if (VictoryConditionSystem.Instance != null)
+            {
+                VictoryConditionSystem.Instance.Surrender();
+                return;
+            }
+
+            // Fallback: show post-game stats directly
+            if (GameStatsTracker.Instance != null)
+                GameStatsTracker.Instance.EndGame();
+
+            var statsUI = PostGameStatsUI.Instance;
+            if (statsUI == null)
+            {
+                var go = new GameObject("PostGameStatsUI");
+                statsUI = go.AddComponent<PostGameStatsUI>();
+            }
+            statsUI.Show();
+        }
+
+        private void DoQuitToMenu()
+        {
+            // Restore time before transitioning
+            Time.timeScale = 1f;
+            IsOpen = false;
+
+            // Reset bootstrap state so a new game can start fresh
+            GameBootstrap.Reset();
+
+            // Destroy all DontDestroyOnLoad managers
+            var managers = Object.FindFirstObjectByType<RuntimeManagers>();
+            if (managers != null)
+                Destroy(managers.gameObject);
+
+            // Clean up ECS world
+            var world = Unity.Entities.World.DefaultGameObjectInjectionWorld;
+            if (world != null && world.IsCreated)
+            {
+                world.Dispose();
+            }
+
+            SceneManager.LoadScene("MainMenu");
+        }
+
+        // ================================================================
+        // STYLES
+        // ================================================================
+
+        private void BuildStyles()
+        {
+            // Semi-transparent dark overlay
+            _texOverlay = MakeTex(2, 2, new Color(0f, 0f, 0f, 0.65f));
+            _overlayBg = new GUIStyle { normal = { background = _texOverlay } };
+
+            // Dark navy panel background (matches resource bar theme)
+            _texPanel = MakeTex(2, 2, new Color(0.06f, 0.08f, 0.18f, 0.96f));
+            _panelBg = new GUIStyle
+            {
+                normal = { background = _texPanel },
+                border = new RectOffset(4, 4, 4, 4)
+            };
+
+            // Button textures
+            _texButton = MakeTex(2, 2, new Color(0.10f, 0.12f, 0.28f, 0.9f));
+            _texButtonHover = MakeTex(2, 2, new Color(0.15f, 0.18f, 0.38f, 0.95f));
+
+            // Title style (golden, centered)
+            _titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 20,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            // Button style (golden text on dark background)
+            _buttonStyle = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 14,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f), background = _texButton },
+                hover = { textColor = new Color(1f, 0.85f, 0.4f), background = _texButtonHover },
+                active = { textColor = Color.white, background = _texButtonHover },
+                border = new RectOffset(2, 2, 2, 2),
+                padding = new RectOffset(8, 8, 6, 6)
+            };
+
+            // Keybind styles
+            _keybindKeyStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fontSize = 12,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            _keybindLabelStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fontSize = 12,
+                normal = { textColor = new Color(0.9f, 0.88f, 0.82f) }
+            };
+
+            _keybindHeaderStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fontSize = 13,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.6f, 0.8f, 1f) }
+            };
+
+            _stylesBuilt = true;
+        }
+
+        private static Texture2D MakeTex(int w, int h, Color c)
+        {
+            var pix = new Color[w * h];
+            for (int i = 0; i < pix.Length; i++) pix[i] = c;
+            var t = new Texture2D(w, h);
+            t.SetPixels(pix);
+            t.Apply();
+            return t;
+        }
+    }
+}

--- a/Assets/Scripts/UI/HUD/ResourceHUD.cs
+++ b/Assets/Scripts/UI/HUD/ResourceHUD.cs
@@ -7,6 +7,7 @@ using Unity.Entities;
 using Unity.Mathematics;
 using UnityEngine;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Core.Settings;
 using EntityWorld = Unity.Entities.World;
 
 
@@ -50,13 +51,23 @@ namespace TheWaningBorder.UI.HUD
         private readonly Dictionary<Faction, int> _rpCache = new();
         private float _timer;
 
+        // Menu button constants
+        private const float MenuBtnWidth = 80f;
+        private const float MenuBtnHeight = 30f;
+        private const float MenuBtnMargin = 10f;
+
+        // Alanthor wall income
+        private EntityQuery _wallIncomeQuery;
+        private float _wallIncome;
+
         // Styles
         private GUIStyle _panelBg;
         private GUIStyle _rowBg;
         private GUIStyle _labelStyle;
         private GUIStyle _valueStyle;
         private GUIStyle _headerStyle;
-        private Texture2D _texPanel, _texRow;
+        private GUIStyle _menuButtonStyle;
+        private Texture2D _texPanel, _texRow, _texMenuBtn, _texMenuBtnHover;
         private bool _stylesBuilt = false;
 
         // Cached panel rect for pointer detection
@@ -82,6 +93,14 @@ namespace TheWaningBorder.UI.HUD
 
             _texPanel = MakeTex(2, 2, new Color(0.06f, 0.08f, 0.18f, 0.92f));
             _texRow = MakeTex(2, 2, new Color(0.08f, 0.10f, 0.22f, 0.4f));
+            _texMenuBtn = MakeTex(2, 2, new Color(0.06f, 0.08f, 0.18f, 0.85f));
+            _texMenuBtnHover = MakeTex(2, 2, new Color(0.12f, 0.14f, 0.28f, 0.9f));
+
+            // Alanthor wall income query
+            _wallIncomeQuery = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<WallEnclosureIncomeTag>(),
+                ComponentType.ReadOnly<SuppliesIncome>(),
+                ComponentType.ReadOnly<FactionTag>());
 
             RefreshNow();
         }
@@ -135,14 +154,37 @@ namespace TheWaningBorder.UI.HUD
             {
                 _rpCache[rpTags[i].Value] = rpData[i].Value;
             }
+
+            // Get Alanthor wall enclosure income
+            _wallIncome = 0f;
+            var localFaction = GameSettings.LocalPlayerFaction;
+            if (CultureConfig.GetFactionCulture(localFaction) == Cultures.Alanthor)
+            {
+                using var wallEntities = _wallIncomeQuery.ToEntityArray(Allocator.Temp);
+                using var wallTags = _wallIncomeQuery.ToComponentDataArray<FactionTag>(Allocator.Temp);
+                using var wallIncomes = _wallIncomeQuery.ToComponentDataArray<SuppliesIncome>(Allocator.Temp);
+                for (int i = 0; i < wallEntities.Length; i++)
+                {
+                    if (wallTags[i].Value == localFaction)
+                        _wallIncome += wallIncomes[i].PerMinute;
+                }
+            }
         }
 
         private void OnGUI()
         {
             if (!_stylesBuilt) BuildStyles();
+
+            // Always draw Menu button in top-left
+            DrawMenuButton();
+
             if (_cache.Count == 0) return;
 
             DrawResourcePanel();
+
+            // Alanthor wall income sub-bar
+            if (_wallIncome > 0f)
+                DrawWallIncomeBar();
         }
 
         private void BuildStyles()
@@ -171,6 +213,16 @@ namespace TheWaningBorder.UI.HUD
                 fontSize = 13,
                 fontStyle = FontStyle.Bold,
                 normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            _menuButtonStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontStyle = FontStyle.Bold,
+                fontSize = 13,
+                alignment = TextAnchor.MiddleCenter,
+                normal = { background = _texMenuBtn, textColor = new Color(0.83f, 0.66f, 0.26f) },
+                hover = { background = _texMenuBtnHover, textColor = new Color(0.93f, 0.76f, 0.36f) },
+                active = { background = _texMenuBtnHover, textColor = Color.white }
             };
 
             _stylesBuilt = true;
@@ -272,6 +324,37 @@ namespace TheWaningBorder.UI.HUD
             GUI.Label(new Rect(rowX + rowWidth * 0.4f, yPos, rowWidth * 0.55f, RowHeight), value, _valueStyle);
 
             yPos += RowHeight + RowSpacing;
+        }
+
+        private void DrawMenuButton()
+        {
+            var btnRect = new Rect(MenuBtnMargin, MenuBtnMargin, MenuBtnWidth, MenuBtnHeight);
+            if (GUI.Button(btnRect, "Menu", _menuButtonStyle))
+            {
+                InGameMenuPanel.Toggle();
+            }
+        }
+
+        private void DrawWallIncomeBar()
+        {
+            // Small sub-bar below the resource panel
+            float barX = LeftMargin;
+            float barY = _panelRect.yMax + 4f;
+            float barW = PanelWidth;
+            float barH = 24f;
+
+            GUI.Box(new Rect(barX, barY, barW, barH), "", _panelBg);
+            Color alanthorGreen = CultureConfig.AlanthorPrimary;
+            var wallStyle = new GUIStyle(_labelStyle)
+            {
+                fontSize = 11,
+                normal = { textColor = alanthorGreen }
+            };
+            GUI.Label(new Rect(barX + PanelPadding, barY, barW * 0.6f, barH),
+                      "Wall Income", wallStyle);
+            var wallValStyle = new GUIStyle(_valueStyle) { fontSize = 11 };
+            GUI.Label(new Rect(barX + barW * 0.4f, barY, barW * 0.55f, barH),
+                      $"+{_wallIncome:F0}/min", wallValStyle);
         }
     }
 }

--- a/Assets/Scripts/UI/Menus/MainMenuUI.cs
+++ b/Assets/Scripts/UI/Menus/MainMenuUI.cs
@@ -17,7 +17,8 @@ namespace TheWaningBorder.UI.Menus
         {
             MainMenu,
             SkirmishLobby,
-            MultiplayerLobby
+            MultiplayerLobby,
+            Options
         }
 
         private MenuState _currentState = MenuState.MainMenu;
@@ -25,6 +26,7 @@ namespace TheWaningBorder.UI.Menus
         // Sub-components
         private SkirmishLobbyUI _skirmishLobby;
         private MultiplayerLobbyUI _multiplayerLobby;
+        private OptionsMenuUI _optionsMenu;
 
         // Window styling
         private Rect _mainMenuRect;
@@ -43,9 +45,13 @@ namespace TheWaningBorder.UI.Menus
             _multiplayerLobby = gameObject.AddComponent<MultiplayerLobbyUI>();
             _multiplayerLobby.enabled = false;
 
+            _optionsMenu = gameObject.AddComponent<OptionsMenuUI>();
+            _optionsMenu.enabled = false;
+
             // Subscribe to back events
             _skirmishLobby.OnBackPressed += () => SetState(MenuState.MainMenu);
             _multiplayerLobby.OnBackPressed += () => SetState(MenuState.MainMenu);
+            _optionsMenu.OnBackPressed += () => SetState(MenuState.MainMenu);
         }
 
         void OnGUI()
@@ -101,13 +107,11 @@ namespace TheWaningBorder.UI.Menus
             GUI.enabled = true;
             GUILayout.Space(6);
 
-            // Options button (placeholder - disabled)
-            GUI.enabled = false;
-            if (GUILayout.Button("Options (Coming Soon)", GUILayout.Height(36)))
+            // Options button
+            if (GUILayout.Button("Options", GUILayout.Height(36)))
             {
-                // Placeholder
+                SetState(MenuState.Options);
             }
-            GUI.enabled = true;
             GUILayout.Space(6);
 
             // Exit button
@@ -126,6 +130,7 @@ namespace TheWaningBorder.UI.Menus
             // Enable/disable sub-components
             _skirmishLobby.enabled = (newState == MenuState.SkirmishLobby);
             _multiplayerLobby.enabled = (newState == MenuState.MultiplayerLobby);
+            _optionsMenu.enabled = (newState == MenuState.Options);
 
             // Initialize lobbies
             if (newState == MenuState.SkirmishLobby)

--- a/Assets/Scripts/UI/Menus/OptionsMenuUI.cs
+++ b/Assets/Scripts/UI/Menus/OptionsMenuUI.cs
@@ -1,0 +1,589 @@
+// File: Assets/Scripts/UI/Menus/OptionsMenuUI.cs
+// Options menu panel with graphics, resolution, fullscreen, and volume settings.
+// Persists settings via PlayerPrefs and applies them to Unity APIs.
+
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+namespace TheWaningBorder.UI.Menus
+{
+    /// <summary>
+    /// Options menu accessible from the main menu.
+    /// Provides settings for graphics quality, resolution, fullscreen mode,
+    /// and master volume. All settings persist via PlayerPrefs.
+    /// </summary>
+    public class OptionsMenuUI : MonoBehaviour
+    {
+        // ================================================================
+        // EVENTS
+        // ================================================================
+
+        public event Action OnBackPressed;
+
+        // ================================================================
+        // PLAYERPREFS KEYS
+        // ================================================================
+
+        private const string PrefGraphicsQuality = "graphics_quality";
+        private const string PrefResolutionWidth = "resolution_width";
+        private const string PrefResolutionHeight = "resolution_height";
+        private const string PrefFullscreen = "fullscreen";
+        private const string PrefMasterVolume = "master_volume";
+
+        // ================================================================
+        // UI STATE
+        // ================================================================
+
+        // Graphics quality - labels derived from project QualitySettings
+        private int _qualityLevel;
+        private string[] _qualityLabels;
+
+        // Resolution
+        private Resolution[] _availableResolutions;
+        private string[] _resolutionLabels;
+        private int _selectedResolutionIndex;
+        private bool _showResolutionDropdown;
+        private Vector2 _resolutionScrollPos;
+
+        // Fullscreen
+        private bool _fullscreen;
+
+        // Volume (0-100)
+        private float _masterVolume;
+
+        // Layout
+        private Rect _windowRect;
+        private const float PanelWidth = 400f;
+        private const float PanelHeight = 500f;
+
+        // Styles
+        private GUIStyle _panelBg;
+        private GUIStyle _titleStyle;
+        private GUIStyle _sectionHeaderStyle;
+        private GUIStyle _labelStyle;
+        private GUIStyle _buttonStyle;
+        private GUIStyle _activeButtonStyle;
+        private GUIStyle _dropdownButtonStyle;
+        private GUIStyle _dropdownItemStyle;
+        private GUIStyle _dropdownItemHoverStyle;
+        private GUIStyle _applyButtonStyle;
+        private GUIStyle _sliderStyle;
+        private GUIStyle _sliderThumbStyle;
+        private GUIStyle _statusStyle;
+        private Texture2D _texPanel;
+        private Texture2D _texButton;
+        private Texture2D _texButtonHover;
+        private Texture2D _texButtonActive;
+        private Texture2D _texDropdownItem;
+        private Texture2D _texDropdownItemHover;
+        private Texture2D _texApply;
+        private Texture2D _texApplyHover;
+        private bool _stylesBuilt;
+
+        // Status message
+        private string _statusMessage;
+        private float _statusTimer;
+
+        // ================================================================
+        // PUBLIC API - Boot-time settings loader
+        // ================================================================
+
+        /// <summary>
+        /// Load persisted settings from PlayerPrefs and apply them to Unity APIs.
+        /// Call this once at startup (e.g., from MainMenuUI.Awake) so that
+        /// saved settings take effect before the player opens the Options panel.
+        /// </summary>
+        public static void LoadAndApplySettings()
+        {
+            // Graphics quality
+            if (PlayerPrefs.HasKey(PrefGraphicsQuality))
+            {
+                int quality = PlayerPrefs.GetInt(PrefGraphicsQuality);
+                quality = Mathf.Clamp(quality, 0, QualitySettings.names.Length - 1);
+                QualitySettings.SetQualityLevel(quality, true);
+            }
+
+            // Resolution & fullscreen
+            bool hasResolution = PlayerPrefs.HasKey(PrefResolutionWidth) &&
+                                 PlayerPrefs.HasKey(PrefResolutionHeight);
+            bool fullscreen = PlayerPrefs.GetInt(PrefFullscreen, Screen.fullScreen ? 1 : 0) == 1;
+
+            if (hasResolution)
+            {
+                int w = PlayerPrefs.GetInt(PrefResolutionWidth);
+                int h = PlayerPrefs.GetInt(PrefResolutionHeight);
+                if (w > 0 && h > 0)
+                {
+                    Screen.SetResolution(w, h, fullscreen);
+                }
+            }
+            else
+            {
+                Screen.fullScreen = fullscreen;
+            }
+
+            // Master volume
+            if (PlayerPrefs.HasKey(PrefMasterVolume))
+            {
+                float vol = PlayerPrefs.GetFloat(PrefMasterVolume, 100f);
+                AudioListener.volume = Mathf.Clamp01(vol / 100f);
+            }
+        }
+
+        // ================================================================
+        // LIFECYCLE
+        // ================================================================
+
+        void OnEnable()
+        {
+            LoadSettingsToUI();
+            _showResolutionDropdown = false;
+            _statusMessage = null;
+            _statusTimer = 0f;
+        }
+
+        void Update()
+        {
+            if (_statusTimer > 0f)
+            {
+                _statusTimer -= Time.unscaledDeltaTime;
+                if (_statusTimer <= 0f)
+                    _statusMessage = null;
+            }
+        }
+
+        void OnDestroy()
+        {
+            DestroyTexture(_texPanel);
+            DestroyTexture(_texButton);
+            DestroyTexture(_texButtonHover);
+            DestroyTexture(_texButtonActive);
+            DestroyTexture(_texDropdownItem);
+            DestroyTexture(_texDropdownItemHover);
+            DestroyTexture(_texApply);
+            DestroyTexture(_texApplyHover);
+        }
+
+        private static void DestroyTexture(Texture2D tex)
+        {
+            if (tex != null) Destroy(tex);
+        }
+
+        void OnGUI()
+        {
+            if (!_stylesBuilt) BuildStyles();
+
+            // Center the window
+            float x = (Screen.width - PanelWidth) * 0.5f;
+            float y = (Screen.height - PanelHeight) * 0.5f;
+            _windowRect = new Rect(x, y, PanelWidth, PanelHeight);
+
+            _windowRect = GUI.Window(10005, _windowRect, DrawOptionsWindow, "", _panelBg);
+        }
+
+        // ================================================================
+        // DRAWING
+        // ================================================================
+
+        private void DrawOptionsWindow(int windowId)
+        {
+            float pad = 20f;
+            float contentWidth = PanelWidth - pad * 2;
+
+            GUILayout.BeginArea(new Rect(pad, 15f, contentWidth, PanelHeight - 30f));
+
+            // Title
+            GUILayout.Label("OPTIONS", _titleStyle);
+            GUILayout.Space(8f);
+            DrawSeparator(contentWidth);
+            GUILayout.Space(10f);
+
+            // ---- Graphics Quality ----
+            GUILayout.Label("Graphics Quality", _sectionHeaderStyle);
+            GUILayout.Space(4f);
+
+            GUILayout.BeginHorizontal();
+            for (int i = 0; i < _qualityLabels.Length; i++)
+            {
+                var style = (i == _qualityLevel) ? _activeButtonStyle : _buttonStyle;
+                if (GUILayout.Button(_qualityLabels[i], style, GUILayout.Height(30f)))
+                {
+                    _qualityLevel = i;
+                }
+                if (i < _qualityLabels.Length - 1)
+                    GUILayout.Space(4f);
+            }
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(14f);
+
+            // ---- Resolution ----
+            GUILayout.Label("Resolution", _sectionHeaderStyle);
+            GUILayout.Space(4f);
+
+            string currentResLabel = _selectedResolutionIndex >= 0 && _selectedResolutionIndex < _resolutionLabels.Length
+                ? _resolutionLabels[_selectedResolutionIndex]
+                : "Unknown";
+
+            if (GUILayout.Button(currentResLabel, _dropdownButtonStyle, GUILayout.Height(28f)))
+            {
+                _showResolutionDropdown = !_showResolutionDropdown;
+            }
+
+            if (_showResolutionDropdown)
+            {
+                float dropHeight = Mathf.Min(_resolutionLabels.Length * 24f, 160f);
+
+                _resolutionScrollPos = GUILayout.BeginScrollView(
+                    _resolutionScrollPos, GUILayout.Height(dropHeight));
+
+                for (int i = 0; i < _resolutionLabels.Length; i++)
+                {
+                    var itemStyle = (i == _selectedResolutionIndex)
+                        ? _dropdownItemHoverStyle : _dropdownItemStyle;
+
+                    if (GUILayout.Button(_resolutionLabels[i], itemStyle, GUILayout.Height(22f)))
+                    {
+                        _selectedResolutionIndex = i;
+                        _showResolutionDropdown = false;
+                    }
+                }
+
+                GUILayout.EndScrollView();
+            }
+
+            GUILayout.Space(14f);
+
+            // ---- Fullscreen ----
+            GUILayout.Label("Display Mode", _sectionHeaderStyle);
+            GUILayout.Space(4f);
+
+            GUILayout.BeginHorizontal();
+            var windowedStyle = _fullscreen ? _buttonStyle : _activeButtonStyle;
+            var fullscreenStyle = _fullscreen ? _activeButtonStyle : _buttonStyle;
+
+            if (GUILayout.Button("Windowed", windowedStyle, GUILayout.Height(30f)))
+                _fullscreen = false;
+            GUILayout.Space(4f);
+            if (GUILayout.Button("Fullscreen", fullscreenStyle, GUILayout.Height(30f)))
+                _fullscreen = true;
+
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(14f);
+
+            // ---- Master Volume ----
+            GUILayout.Label("Master Volume", _sectionHeaderStyle);
+            GUILayout.Space(4f);
+
+            GUILayout.BeginHorizontal();
+            _masterVolume = GUILayout.HorizontalSlider(
+                _masterVolume, 0f, 100f, _sliderStyle, _sliderThumbStyle,
+                GUILayout.Height(20f));
+            GUILayout.Space(8f);
+            GUILayout.Label($"{Mathf.RoundToInt(_masterVolume)}%", _labelStyle, GUILayout.Width(40f));
+            GUILayout.EndHorizontal();
+
+            GUILayout.FlexibleSpace();
+
+            // ---- Status message ----
+            if (!string.IsNullOrEmpty(_statusMessage))
+            {
+                GUILayout.Label(_statusMessage, _statusStyle);
+                GUILayout.Space(6f);
+            }
+
+            // ---- Action Buttons ----
+            DrawSeparator(contentWidth);
+            GUILayout.Space(8f);
+
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Back", _buttonStyle, GUILayout.Height(36f), GUILayout.Width(100f)))
+            {
+                OnBackPressed?.Invoke();
+            }
+
+            GUILayout.FlexibleSpace();
+
+            if (GUILayout.Button("Apply", _applyButtonStyle, GUILayout.Height(36f), GUILayout.Width(120f)))
+            {
+                ApplySettings();
+            }
+
+            GUILayout.EndHorizontal();
+
+            GUILayout.Space(10f);
+            GUILayout.EndArea();
+
+            // Draggable title bar
+            GUI.DragWindow(new Rect(0, 0, 10000, 25));
+        }
+
+        private void DrawSeparator(float width)
+        {
+            var rect = GUILayoutUtility.GetRect(width, 2f);
+            var oldColor = GUI.color;
+            GUI.color = new Color(0.83f, 0.66f, 0.26f, 0.5f);
+            GUI.DrawTexture(rect, Texture2D.whiteTexture);
+            GUI.color = oldColor;
+        }
+
+        // ================================================================
+        // SETTINGS LOGIC
+        // ================================================================
+
+        private void LoadSettingsToUI()
+        {
+            // Build quality labels from project QualitySettings
+            _qualityLabels = QualitySettings.names;
+
+            // Build resolution list
+            BuildResolutionList();
+
+            // Graphics quality
+            _qualityLevel = PlayerPrefs.GetInt(PrefGraphicsQuality, QualitySettings.GetQualityLevel());
+            _qualityLevel = Mathf.Clamp(_qualityLevel, 0, _qualityLabels.Length - 1);
+
+            // Resolution - find current
+            int curW = PlayerPrefs.GetInt(PrefResolutionWidth, Screen.width);
+            int curH = PlayerPrefs.GetInt(PrefResolutionHeight, Screen.height);
+            _selectedResolutionIndex = FindResolutionIndex(curW, curH);
+
+            // Fullscreen
+            _fullscreen = PlayerPrefs.GetInt(PrefFullscreen, Screen.fullScreen ? 1 : 0) == 1;
+
+            // Volume
+            _masterVolume = PlayerPrefs.GetFloat(PrefMasterVolume, AudioListener.volume * 100f);
+        }
+
+        private void BuildResolutionList()
+        {
+            var resolutions = Screen.resolutions;
+
+            // De-duplicate (ignore refresh rate) and sort descending
+            var seen = new HashSet<string>();
+            var unique = new List<Resolution>();
+
+            // Iterate in reverse so we get highest refresh rate first for each resolution
+            for (int i = resolutions.Length - 1; i >= 0; i--)
+            {
+                string key = $"{resolutions[i].width}x{resolutions[i].height}";
+                if (seen.Add(key))
+                    unique.Add(resolutions[i]);
+            }
+
+            // Sort by width descending, then height descending
+            unique.Sort((a, b) =>
+            {
+                int cmp = b.width.CompareTo(a.width);
+                return cmp != 0 ? cmp : b.height.CompareTo(a.height);
+            });
+
+            _availableResolutions = unique.ToArray();
+            _resolutionLabels = new string[_availableResolutions.Length];
+
+            for (int i = 0; i < _availableResolutions.Length; i++)
+            {
+                var r = _availableResolutions[i];
+                _resolutionLabels[i] = $"{r.width} x {r.height}";
+            }
+        }
+
+        private int FindResolutionIndex(int width, int height)
+        {
+            for (int i = 0; i < _availableResolutions.Length; i++)
+            {
+                if (_availableResolutions[i].width == width &&
+                    _availableResolutions[i].height == height)
+                    return i;
+            }
+            // Fallback: first resolution
+            return 0;
+        }
+
+        private void ApplySettings()
+        {
+            // Graphics quality (clamp to valid range in case labels changed)
+            _qualityLevel = Mathf.Clamp(_qualityLevel, 0, QualitySettings.names.Length - 1);
+            QualitySettings.SetQualityLevel(_qualityLevel, true);
+            PlayerPrefs.SetInt(PrefGraphicsQuality, _qualityLevel);
+
+            // Resolution & fullscreen
+            if (_selectedResolutionIndex >= 0 && _selectedResolutionIndex < _availableResolutions.Length)
+            {
+                var res = _availableResolutions[_selectedResolutionIndex];
+                Screen.SetResolution(res.width, res.height, _fullscreen);
+                PlayerPrefs.SetInt(PrefResolutionWidth, res.width);
+                PlayerPrefs.SetInt(PrefResolutionHeight, res.height);
+            }
+            PlayerPrefs.SetInt(PrefFullscreen, _fullscreen ? 1 : 0);
+
+            // Volume
+            AudioListener.volume = Mathf.Clamp01(_masterVolume / 100f);
+            PlayerPrefs.SetFloat(PrefMasterVolume, _masterVolume);
+
+            PlayerPrefs.Save();
+
+            // Show status
+            _statusMessage = "Settings applied!";
+            _statusTimer = 2f;
+
+            Debug.Log($"[OptionsMenu] Applied: Quality={_qualityLabels[_qualityLevel]}, " +
+                      $"Resolution={Screen.width}x{Screen.height}, " +
+                      $"Fullscreen={_fullscreen}, Volume={Mathf.RoundToInt(_masterVolume)}%");
+        }
+
+        // ================================================================
+        // STYLES
+        // ================================================================
+
+        private void BuildStyles()
+        {
+            // Panel background - dark navy with golden border
+            _texPanel = MakeBorderedTex(64, 64,
+                new Color(0.06f, 0.08f, 0.18f, 0.96f),
+                new Color(0.83f, 0.66f, 0.26f, 0.8f), 2);
+
+            _panelBg = new GUIStyle
+            {
+                normal = { background = _texPanel },
+                border = new RectOffset(4, 4, 4, 4)
+            };
+
+            // Title style (golden, centered)
+            _titleStyle = new GUIStyle(GUI.skin.label)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 20,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            // Section headers (light blue)
+            _sectionHeaderStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.6f, 0.8f, 1f) }
+            };
+
+            // Regular label
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                normal = { textColor = new Color(0.9f, 0.88f, 0.82f) }
+            };
+
+            // Button textures
+            _texButton = MakeTex(2, 2, new Color(0.10f, 0.12f, 0.28f, 0.9f));
+            _texButtonHover = MakeTex(2, 2, new Color(0.15f, 0.18f, 0.38f, 0.95f));
+            _texButtonActive = MakeTex(2, 2, new Color(0.20f, 0.24f, 0.50f, 0.95f));
+
+            // Normal button
+            _buttonStyle = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 13,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f), background = _texButton },
+                hover = { textColor = new Color(1f, 0.85f, 0.4f), background = _texButtonHover },
+                active = { textColor = Color.white, background = _texButtonHover },
+                border = new RectOffset(2, 2, 2, 2),
+                padding = new RectOffset(8, 8, 6, 6)
+            };
+
+            // Active/selected button (highlighted)
+            _activeButtonStyle = new GUIStyle(_buttonStyle)
+            {
+                normal = { textColor = Color.white, background = _texButtonActive },
+                hover = { textColor = Color.white, background = _texButtonActive }
+            };
+
+            // Dropdown button
+            _dropdownButtonStyle = new GUIStyle(_buttonStyle)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                padding = new RectOffset(12, 8, 6, 6)
+            };
+
+            // Dropdown items
+            _texDropdownItem = MakeTex(2, 2, new Color(0.08f, 0.10f, 0.22f, 0.95f));
+            _texDropdownItemHover = MakeTex(2, 2, new Color(0.15f, 0.18f, 0.38f, 0.95f));
+
+            _dropdownItemStyle = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleLeft,
+                fontSize = 12,
+                normal = { textColor = new Color(0.9f, 0.88f, 0.82f), background = _texDropdownItem },
+                hover = { textColor = new Color(1f, 0.85f, 0.4f), background = _texDropdownItemHover },
+                active = { textColor = Color.white, background = _texDropdownItemHover },
+                padding = new RectOffset(10, 6, 3, 3),
+                margin = new RectOffset(0, 0, 0, 0)
+            };
+
+            _dropdownItemHoverStyle = new GUIStyle(_dropdownItemStyle)
+            {
+                normal = { textColor = Color.white, background = _texDropdownItemHover }
+            };
+
+            // Apply button (slightly different - green-gold)
+            _texApply = MakeTex(2, 2, new Color(0.12f, 0.18f, 0.10f, 0.9f));
+            _texApplyHover = MakeTex(2, 2, new Color(0.18f, 0.26f, 0.14f, 0.95f));
+
+            _applyButtonStyle = new GUIStyle(_buttonStyle)
+            {
+                normal = { textColor = new Color(0.4f, 1f, 0.4f), background = _texApply },
+                hover = { textColor = new Color(0.5f, 1f, 0.5f), background = _texApplyHover },
+                active = { textColor = Color.white, background = _texApplyHover }
+            };
+
+            // Slider styles
+            _sliderStyle = new GUIStyle(GUI.skin.horizontalSlider)
+            {
+                fixedHeight = 12f
+            };
+            _sliderThumbStyle = new GUIStyle(GUI.skin.horizontalSliderThumb)
+            {
+                fixedWidth = 16f,
+                fixedHeight = 16f
+            };
+
+            // Status message style (green, centered)
+            _statusStyle = new GUIStyle(_labelStyle)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                normal = { textColor = new Color(0.3f, 1f, 0.3f) }
+            };
+
+            _stylesBuilt = true;
+        }
+
+        private static Texture2D MakeTex(int w, int h, Color c)
+        {
+            var pix = new Color[w * h];
+            for (int i = 0; i < pix.Length; i++) pix[i] = c;
+            var t = new Texture2D(w, h);
+            t.SetPixels(pix);
+            t.Apply();
+            return t;
+        }
+
+        private static Texture2D MakeBorderedTex(int w, int h, Color fill, Color border, int borderWidth)
+        {
+            var tex = new Texture2D(w, h);
+            for (int y = 0; y < h; y++)
+            {
+                for (int x = 0; x < w; x++)
+                {
+                    bool isBorder = x < borderWidth || x >= w - borderWidth ||
+                                    y < borderWidth || y >= h - borderWidth;
+                    tex.SetPixel(x, y, isBorder ? border : fill);
+                }
+            }
+            tex.Apply();
+            return tex;
+        }
+    }
+}

--- a/Assets/Scripts/UI/Panels/EntityActionPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityActionPanel.cs
@@ -160,7 +160,7 @@ namespace TheWaningBorder.UI.Panels
             PanelVisible = true;
 
             var panelRect = new Rect(
-                PanelPadding + 300f + PanelPadding,
+                Screen.width - PanelWidth - PanelPadding,
                 Screen.height - PanelHeight - PanelPadding,
                 PanelWidth,
                 PanelHeight
@@ -202,7 +202,7 @@ namespace TheWaningBorder.UI.Panels
             PanelVisible = true;
 
             var panelRect = new Rect(
-                PanelPadding + 300f + PanelPadding,
+                Screen.width - PanelWidth - PanelPadding,
                 Screen.height - PanelHeight - PanelPadding,
                 PanelWidth,
                 PanelHeight
@@ -302,7 +302,7 @@ namespace TheWaningBorder.UI.Panels
 
             float totalPanelHeight = 900f;
             var panelRect = new Rect(
-                PanelPadding + 300f + PanelPadding,
+                Screen.width - PanelWidth - PanelPadding,
                 Screen.height - totalPanelHeight - PanelPadding,
                 PanelWidth,
                 totalPanelHeight
@@ -913,7 +913,7 @@ namespace TheWaningBorder.UI.Panels
 
             float totalPanelHeight = 420f; // Taller to accommodate both sections
             var panelRect = new Rect(
-                PanelPadding + 300f + PanelPadding,
+                Screen.width - PanelWidth - PanelPadding,
                 Screen.height - totalPanelHeight - PanelPadding,
                 PanelWidth,
                 totalPanelHeight
@@ -1376,7 +1376,7 @@ namespace TheWaningBorder.UI.Panels
 
             float vaultPanelHeight = 320f;
             var panelRect = new Rect(
-                PanelPadding + 300f + PanelPadding,
+                Screen.width - PanelWidth - PanelPadding,
                 Screen.height - vaultPanelHeight - PanelPadding,
                 PanelWidth,
                 vaultPanelHeight

--- a/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
@@ -1,6 +1,8 @@
 // File: Assets/Scripts/UI/Panels/EntityInfoPanel.cs
 // Entity info panel — Dark Navy + Golden theme
+// Bottom-center layout with multi-selection army breakdown.
 
+using System.Collections.Generic;
 using UnityEngine;
 using Unity.Entities;
 using TWB_Input = TheWaningBorder.Input;
@@ -10,24 +12,33 @@ namespace TheWaningBorder.UI.Panels
 {
     /// <summary>
     /// IMGUI panel showing selected entity info — dark navy with golden accents.
+    /// Positioned at bottom-center of screen. Shows army breakdown for multi-select.
     /// </summary>
     public class EntityInfoPanel : MonoBehaviour
     {
         public static bool PanelVisible { get; private set; }
         public static Rect PanelRect { get; private set; }
 
-        private const float PanelWidth = 300f;
-        private const float PanelHeight = 310f;
+        private const float PanelWidth = 320f;
+        private const float SinglePanelHeight = 310f;
         private const float PanelPadding = 10f;
         private const float PortraitSize = 80f;
+        private const float MultiRowHeight = 24f;
+        private const float MultiBaseHeight = 80f;
+        private const float MultiMaxHeight = 400f;
 
         private GUIStyle _boxStyle;
         private GUIStyle _headerStyle;
         private GUIStyle _labelStyle;
         private GUIStyle _smallStyle;
         private GUIStyle _descStyle;
+        private GUIStyle _rowBg;
+        private Texture2D _rowTex;
         private RectOffset _padding;
         private bool _stylesInit = false;
+
+        // Multi-select cache
+        private Vector2 _multiScrollPos;
 
         void Awake()
         {
@@ -44,10 +55,17 @@ namespace TheWaningBorder.UI.Panels
             var em = UnifiedUIManager.GetEntityManager();
             if (em.Equals(default(EntityManager))) return;
 
-            var info = EntityInfoExtractor.GetDisplayInfo(entity, em);
-
             InitStyles();
-            DrawPanel(info);
+
+            if (UnifiedUIManager.IsMultiSelection())
+            {
+                DrawMultiPanel(em);
+            }
+            else
+            {
+                var info = EntityInfoExtractor.GetDisplayInfo(entity, em);
+                DrawSinglePanel(info);
+            }
         }
 
         private void InitStyles()
@@ -87,18 +105,25 @@ namespace TheWaningBorder.UI.Panels
                 normal = { textColor = new Color(0.8f, 0.78f, 0.72f) }
             };
 
+            _rowTex = UIHelpers.MakeTexture(2, 2, new Color(0.08f, 0.10f, 0.22f, 0.4f));
+            _rowBg = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _rowTex },
+                margin = new RectOffset(0, 0, 1, 1)
+            };
+
             _stylesInit = true;
         }
 
-        private void DrawPanel(EntityDisplayInfo info)
+        private void DrawSinglePanel(EntityDisplayInfo info)
         {
             PanelVisible = true;
 
             var panelRect = new Rect(
-                PanelPadding,
-                Screen.height - PanelHeight - PanelPadding,
+                (Screen.width - PanelWidth) * 0.5f,
+                Screen.height - SinglePanelHeight - PanelPadding,
                 PanelWidth,
-                PanelHeight
+                SinglePanelHeight
             );
             PanelRect = panelRect;
 
@@ -211,6 +236,179 @@ namespace TheWaningBorder.UI.Panels
 
             GUILayout.EndArea();
         }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // MULTI-SELECTION PANEL (bottom-center, army breakdown)
+        // ═══════════════════════════════════════════════════════════════════════
+
+        private void DrawMultiPanel(EntityManager em)
+        {
+            var allEntities = UnifiedUIManager.GetAllSelectedEntities();
+            if (allEntities.Count == 0) return;
+
+            PanelVisible = true;
+
+            // Group entities by type name
+            var groups = new Dictionary<string, UnitGroupInfo>();
+            int totalHP = 0, totalMaxHP = 0;
+            bool hasUnits = false;
+            bool hasBuildings = false;
+
+            foreach (var e in allEntities)
+            {
+                if (!em.Exists(e)) continue;
+
+                string name;
+                bool isBuilding = em.HasComponent<BuildingTag>(e);
+                bool isUnit = em.HasComponent<UnitTag>(e);
+
+                if (isBuilding)
+                {
+                    hasBuildings = true;
+                    name = EntityInfoExtractor.GetDisplayInfo(e, em).Name;
+                }
+                else if (isUnit)
+                {
+                    hasUnits = true;
+                    name = EntityInfoExtractor.GetDisplayInfo(e, em).Name;
+                }
+                else
+                {
+                    name = "Other";
+                }
+
+                if (!groups.TryGetValue(name, out var grp))
+                {
+                    grp = new UnitGroupInfo { Name = name };
+                    groups[name] = grp;
+                }
+                grp.Count++;
+
+                if (em.HasComponent<Health>(e))
+                {
+                    var hp = em.GetComponentData<Health>(e);
+                    grp.TotalHP += (int)hp.Value;
+                    grp.TotalMaxHP += (int)hp.Max;
+                    totalHP += (int)hp.Value;
+                    totalMaxHP += (int)hp.Max;
+                }
+            }
+
+            // Calculate panel height based on group count
+            int groupCount = groups.Count;
+            float contentHeight = MultiBaseHeight + (groupCount * MultiRowHeight) + 30f;
+            float panelHeight = Mathf.Min(contentHeight, MultiMaxHeight);
+
+            var panelRect = new Rect(
+                (Screen.width - PanelWidth) * 0.5f,
+                Screen.height - panelHeight - PanelPadding,
+                PanelWidth,
+                panelHeight
+            );
+            PanelRect = panelRect;
+
+            GUI.Box(panelRect, "", _boxStyle);
+
+            var innerRect = new Rect(
+                panelRect.x + _padding.left,
+                panelRect.y + _padding.top,
+                panelRect.width - _padding.horizontal,
+                panelRect.height - _padding.vertical
+            );
+
+            GUILayout.BeginArea(innerRect);
+
+            // Header
+            string headerText;
+            if (hasUnits && !hasBuildings)
+                headerText = $"Army ({allEntities.Count} units)";
+            else if (hasBuildings && !hasUnits)
+                headerText = $"Buildings ({allEntities.Count} selected)";
+            else
+                headerText = $"Selection ({allEntities.Count} entities)";
+
+            GUILayout.Label(headerText, _headerStyle);
+
+            // Total HP summary
+            if (totalMaxHP > 0)
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.Label($"Total HP: {totalHP}/{totalMaxHP}", _smallStyle);
+                GUILayout.EndHorizontal();
+            }
+
+            GUILayout.Space(4f);
+
+            // Golden separator
+            var sepRect = GUILayoutUtility.GetRect(1, 1, GUILayout.ExpandWidth(true));
+            GUI.color = new Color(0.83f, 0.66f, 0.26f, 0.5f);
+            GUI.DrawTexture(sepRect, Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            GUILayout.Space(4f);
+
+            // Scrollable unit type list
+            float scrollHeight = innerRect.height - 80f;
+            _multiScrollPos = GUILayout.BeginScrollView(_multiScrollPos,
+                GUILayout.Height(Mathf.Max(scrollHeight, 60f)));
+
+            foreach (var kvp in groups)
+            {
+                var grp = kvp.Value;
+                var rowRect = GUILayoutUtility.GetRect(PanelWidth - 40f, MultiRowHeight);
+                GUI.Box(rowRect, "", _rowBg);
+
+                // Name x Count
+                var nameStyle = new GUIStyle(_labelStyle) { fontStyle = FontStyle.Bold };
+                GUI.Label(new Rect(rowRect.x + 6f, rowRect.y + 2f, 180f, 20f),
+                    $"{grp.Name} x{grp.Count}", nameStyle);
+
+                // HP bar for group
+                if (grp.TotalMaxHP > 0)
+                {
+                    float hpBarWidth = 80f;
+                    float hpBarX = rowRect.x + rowRect.width - hpBarWidth - 6f;
+                    float hpBarY = rowRect.y + 4f;
+                    float ratio = Mathf.Clamp01((float)grp.TotalHP / grp.TotalMaxHP);
+
+                    // Background
+                    GUI.color = new Color(0.04f, 0.05f, 0.12f, 1f);
+                    GUI.DrawTexture(new Rect(hpBarX, hpBarY, hpBarWidth, 14f), Texture2D.whiteTexture);
+
+                    // Fill
+                    Color fillColor = ratio > 0.5f ? new Color(0.3f, 0.9f, 0.3f) :
+                                      (ratio > 0.25f ? new Color(0.9f, 0.8f, 0.2f) : new Color(1f, 0.3f, 0.3f));
+                    GUI.color = fillColor;
+                    GUI.DrawTexture(new Rect(hpBarX, hpBarY, hpBarWidth * ratio, 14f), Texture2D.whiteTexture);
+                    GUI.color = Color.white;
+
+                    // HP text
+                    var hpStyle = new GUIStyle(_smallStyle)
+                    {
+                        alignment = TextAnchor.MiddleCenter,
+                        fontSize = 10,
+                        normal = { textColor = Color.white }
+                    };
+                    GUI.Label(new Rect(hpBarX, hpBarY, hpBarWidth, 14f),
+                        $"{grp.TotalHP}/{grp.TotalMaxHP}", hpStyle);
+                }
+            }
+
+            GUILayout.EndScrollView();
+            GUILayout.EndArea();
+        }
+
+        private class UnitGroupInfo
+        {
+            public string Name;
+            public int Count;
+            public int TotalHP;
+            public int TotalMaxHP;
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // HEALTH / RESOURCE BARS
+        // ═══════════════════════════════════════════════════════════════════════
 
         private void DrawResourceBar(int current, int max)
         {

--- a/Assets/Scripts/UI/Panels/TechTreePanel.cs
+++ b/Assets/Scripts/UI/Panels/TechTreePanel.cs
@@ -1,0 +1,395 @@
+// File: Assets/Scripts/UI/Panels/TechTreePanel.cs
+// Read-only tech tree viewer accessible from the HUD top-right area.
+// Shows all technologies grouped by category with research status.
+
+using System.Collections.Generic;
+using UnityEngine;
+using TheWaningBorder.Economy;
+using TheWaningBorder.UI.Common;
+
+namespace TheWaningBorder.UI.Panels
+{
+    /// <summary>
+    /// IMGUI panel that displays a read-only tech tree overview.
+    /// Toggled via a button in the top-right HUD area.
+    /// Groups technologies into Era 1, culture-specific, and sect categories.
+    /// </summary>
+    public class TechTreePanel : MonoBehaviour
+    {
+        public static bool IsVisible { get; private set; }
+
+        // Layout
+        private const float PanelWidth = 700f;
+        private const float PanelHeight = 520f;
+        private const float ButtonWidth = 90f;
+        private const float ButtonHeight = 28f;
+        private const float ButtonMargin = 120f; // Offset from right edge (past End Game button)
+        private const float RowHeight = 44f;
+        private const float SectionSpacing = 12f;
+
+        // State
+        private bool _visible;
+        private Vector2 _scrollPos;
+        private float _prevTimeScale = 1f;
+
+        // Styles (lazy init)
+        private GUIStyle _panelBox;
+        private GUIStyle _headerStyle;
+        private GUIStyle _subHeaderStyle;
+        private GUIStyle _labelStyle;
+        private GUIStyle _smallStyle;
+        private GUIStyle _buttonStyle;
+        private GUIStyle _rowBg;
+        private Texture2D _panelTex;
+        private Texture2D _rowTex;
+        private bool _stylesInit;
+
+        // Tech grouping
+        private static readonly string[] Era1Techs =
+        {
+            "ImprovedTools", "StorageCarts", "BasicDrills", "WoodenArmor", "Research_Era2"
+        };
+
+        private static readonly string[] RunaiTechs =
+        {
+            "Runai_LongHaulTariffs", "Runai_PackBazaar", "Runai_EscortedCaravans"
+        };
+
+        void OnGUI()
+        {
+            InitStyles();
+
+            // Draw toggle button in top-right (next to End Game)
+            DrawToggleButton();
+
+            if (!_visible) return;
+
+            DrawPanel();
+
+            // Escape to close
+            if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape)
+            {
+                Close();
+                Event.current.Use();
+            }
+        }
+
+        private void DrawToggleButton()
+        {
+            // Don't show button if post-game stats are visible
+            if (TheWaningBorder.UI.HUD.PostGameStatsUI.IsVisible) return;
+
+            float x = Screen.width - ButtonWidth - ButtonMargin;
+            float y = 10f;
+
+            if (GUI.Button(new Rect(x, y, ButtonWidth, ButtonHeight), "Tech Tree", _buttonStyle))
+            {
+                if (_visible) Close();
+                else Open();
+            }
+        }
+
+        private void Open()
+        {
+            _visible = true;
+            IsVisible = true;
+            _prevTimeScale = Time.timeScale;
+            Time.timeScale = 0f;
+        }
+
+        private void Close()
+        {
+            _visible = false;
+            IsVisible = false;
+            Time.timeScale = _prevTimeScale;
+        }
+
+        private void DrawPanel()
+        {
+            // Centered overlay
+            float x = (Screen.width - PanelWidth) * 0.5f;
+            float y = (Screen.height - PanelHeight) * 0.5f;
+            var panelRect = new Rect(x, y, PanelWidth, PanelHeight);
+
+            GUI.Box(panelRect, "", _panelBox);
+
+            // Inner area
+            var innerRect = new Rect(x + 12f, y + 12f, PanelWidth - 24f, PanelHeight - 24f);
+            GUILayout.BeginArea(innerRect);
+
+            // Header row
+            GUILayout.BeginHorizontal();
+            GUILayout.Label("Technology Overview", _headerStyle);
+            GUILayout.FlexibleSpace();
+
+            var faction = GameSettings.LocalPlayerFaction;
+            var researchState = FactionResearchState.Instance;
+            int completedCount = researchState != null ? researchState.GetCompletedCount(faction) : 0;
+            GUILayout.Label($"Researched: {completedCount}", _labelStyle);
+
+            GUILayout.Space(12f);
+            if (GUILayout.Button("X", GUILayout.Width(28f), GUILayout.Height(24f)))
+            {
+                Close();
+            }
+            GUILayout.EndHorizontal();
+
+            // Golden separator
+            var sepRect = GUILayoutUtility.GetRect(1, 2, GUILayout.ExpandWidth(true));
+            GUI.color = new Color(0.83f, 0.66f, 0.26f, 0.6f);
+            GUI.DrawTexture(sepRect, Texture2D.whiteTexture);
+            GUI.color = Color.white;
+
+            GUILayout.Space(6f);
+
+            // Scrollable content
+            _scrollPos = GUILayout.BeginScrollView(_scrollPos, false, true);
+
+            DrawSection("Era 1 Technologies", Era1Techs, faction, researchState);
+            DrawSection("Runai Technologies", RunaiTechs, faction, researchState);
+            DrawSectTechSection(faction, researchState);
+
+            GUILayout.EndScrollView();
+            GUILayout.EndArea();
+        }
+
+        private void DrawSection(string title, string[] techIds, Faction faction,
+            FactionResearchState researchState)
+        {
+            var db = TechTreeDB.Instance;
+            if (db == null) return;
+
+            GUILayout.Label(title, _subHeaderStyle);
+            GUILayout.Space(4f);
+
+            foreach (var techId in techIds)
+            {
+                if (!db.TryGetTechnology(techId, out var tech)) continue;
+
+                bool researched = researchState != null && researchState.HasResearched(faction, techId);
+                bool meetsPrereqs = researchState != null &&
+                                    researchState.MeetsPrerequisites(faction, tech.prerequisites);
+
+                DrawTechRow(tech.name, tech.effect, tech.cost, researched, meetsPrereqs);
+            }
+
+            GUILayout.Space(SectionSpacing);
+        }
+
+        private void DrawSectTechSection(Faction faction, FactionResearchState researchState)
+        {
+            var sectState = FactionSectState.Instance;
+            if (sectState == null) return;
+
+            GUILayout.Label("Sect Technologies", _subHeaderStyle);
+            GUILayout.Space(4f);
+
+            // Group by culture
+            DrawSectCultureGroup("Alanthor Sects", new[]
+            {
+                SectConfig.Renewal, SectConfig.Antiquity,
+                SectConfig.LivingStone, SectConfig.VeiledMemory
+            }, faction, sectState, CultureConfig.AlanthorPrimary);
+
+            DrawSectCultureGroup("Runai Sects", new[]
+            {
+                SectConfig.StillFlame, SectConfig.QuietVault,
+                SectConfig.MirrorRite, SectConfig.ShardJudgment
+            }, faction, sectState, CultureConfig.RunaiPrimary);
+
+            DrawSectCultureGroup("Feraldis Sects", new[]
+            {
+                SectConfig.EmberAsh, SectConfig.HollowBrand,
+                SectConfig.FlamewroughtChains, SectConfig.UnmakersGrasp
+            }, faction, sectState, CultureConfig.FeraldisPrimary);
+        }
+
+        private void DrawSectCultureGroup(string groupTitle, string[] sectIds,
+            Faction faction, FactionSectState sectState, Color cultureColor)
+        {
+            var cultureLabel = new GUIStyle(_smallStyle)
+            {
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = cultureColor }
+            };
+            GUILayout.Label(groupTitle, cultureLabel);
+            GUILayout.Space(2f);
+
+            foreach (var sectId in sectIds)
+            {
+                bool adopted = sectState.HasAdopted(faction, sectId);
+                bool techResearched = sectState.HasTechFlag(faction, sectId);
+
+                string name = SectConfig.GetTechDisplayName(sectId);
+                string desc = SectConfig.GetTechDescription(sectId);
+                string passive = SectConfig.GetPassiveDescription(sectId);
+
+                // Status: researched > adopted (can research) > not adopted (locked)
+                string status;
+                Color statusColor;
+                if (techResearched)
+                {
+                    status = "RESEARCHED";
+                    statusColor = new Color(0.3f, 1f, 0.3f);
+                }
+                else if (adopted)
+                {
+                    status = "AVAILABLE";
+                    statusColor = new Color(0.83f, 0.66f, 0.26f);
+                }
+                else
+                {
+                    status = "LOCKED";
+                    statusColor = new Color(0.5f, 0.5f, 0.5f);
+                }
+
+                // Row background
+                var rowRect = GUILayoutUtility.GetRect(PanelWidth - 60f, RowHeight);
+                GUI.Box(rowRect, "", _rowBg);
+
+                // Sect display name + passive
+                string sectName = SectConfig.GetDisplayName(sectId);
+                var nameStyle = new GUIStyle(_labelStyle) { fontStyle = FontStyle.Bold };
+                GUI.Label(new Rect(rowRect.x + 8f, rowRect.y + 2f, 180f, 20f), sectName, nameStyle);
+                GUI.Label(new Rect(rowRect.x + 8f, rowRect.y + 20f, 280f, 18f), passive, _smallStyle);
+
+                // Tech description
+                GUI.Label(new Rect(rowRect.x + 300f, rowRect.y + 4f, 240f, 36f), desc, _smallStyle);
+
+                // Status label
+                var statusStyle = new GUIStyle(_labelStyle)
+                {
+                    fontStyle = FontStyle.Bold,
+                    alignment = TextAnchor.MiddleRight,
+                    normal = { textColor = statusColor }
+                };
+                GUI.Label(new Rect(rowRect.x + rowRect.width - 110f, rowRect.y + 10f, 100f, 22f),
+                    status, statusStyle);
+            }
+
+            GUILayout.Space(8f);
+        }
+
+        private void DrawTechRow(string name, string effect, TheWaningBorder.Data.CostBlock cost,
+            bool researched, bool meetsPrereqs)
+        {
+            var rowRect = GUILayoutUtility.GetRect(PanelWidth - 60f, RowHeight);
+            GUI.Box(rowRect, "", _rowBg);
+
+            // Status indicator
+            Color statusColor;
+            string statusText;
+            if (researched)
+            {
+                statusColor = new Color(0.3f, 1f, 0.3f);
+                statusText = "DONE";
+            }
+            else if (meetsPrereqs)
+            {
+                statusColor = new Color(0.83f, 0.66f, 0.26f);
+                statusText = "READY";
+            }
+            else
+            {
+                statusColor = new Color(0.5f, 0.5f, 0.5f);
+                statusText = "LOCKED";
+            }
+
+            // Name
+            var nameStyle = new GUIStyle(_labelStyle) { fontStyle = FontStyle.Bold };
+            GUI.Label(new Rect(rowRect.x + 8f, rowRect.y + 2f, 160f, 20f), name, nameStyle);
+
+            // Effect
+            GUI.Label(new Rect(rowRect.x + 8f, rowRect.y + 22f, 300f, 18f), effect, _smallStyle);
+
+            // Cost
+            if (cost != null && !cost.IsZero)
+            {
+                string costStr = cost.ToString();
+                GUI.Label(new Rect(rowRect.x + 320f, rowRect.y + 10f, 180f, 22f), costStr, _smallStyle);
+            }
+
+            // Status
+            var sStyle = new GUIStyle(_labelStyle)
+            {
+                fontStyle = FontStyle.Bold,
+                alignment = TextAnchor.MiddleRight,
+                normal = { textColor = statusColor }
+            };
+            GUI.Label(new Rect(rowRect.x + rowRect.width - 80f, rowRect.y + 10f, 70f, 22f),
+                statusText, sStyle);
+        }
+
+        private void InitStyles()
+        {
+            if (_stylesInit) return;
+
+            _panelTex = UIHelpers.MakeBorderedTexture(64, 64,
+                new Color(0.06f, 0.08f, 0.18f, 0.97f),
+                new Color(0.83f, 0.66f, 0.26f, 0.8f), 2);
+
+            _rowTex = UIHelpers.MakeTexture(2, 2, new Color(0.08f, 0.10f, 0.22f, 0.5f));
+
+            _panelBox = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _panelTex }
+            };
+
+            _headerStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 20,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            _subHeaderStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 15,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.9f, 0.88f, 0.82f) }
+            };
+
+            _labelStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 13,
+                normal = { textColor = new Color(0.9f, 0.88f, 0.82f) }
+            };
+
+            _smallStyle = new GUIStyle(GUI.skin.label)
+            {
+                fontSize = 11,
+                wordWrap = true,
+                normal = { textColor = new Color(0.7f, 0.68f, 0.60f) }
+            };
+
+            _buttonStyle = new GUIStyle(GUI.skin.button)
+            {
+                fontSize = 12,
+                fontStyle = FontStyle.Bold,
+                normal = { textColor = new Color(0.83f, 0.66f, 0.26f) }
+            };
+
+            _rowBg = new GUIStyle(GUI.skin.box)
+            {
+                normal = { background = _rowTex },
+                margin = new RectOffset(0, 0, 1, 1)
+            };
+
+            _stylesInit = true;
+        }
+
+        /// <summary>
+        /// Check if pointer is over this panel (for input blocking).
+        /// </summary>
+        public static bool IsPointerOver()
+        {
+            if (!IsVisible) return false;
+
+            float x = (Screen.width - PanelWidth) * 0.5f;
+            float y = (Screen.height - PanelHeight) * 0.5f;
+            var panelRect = new Rect(x, y, PanelWidth, PanelHeight);
+
+            return UIHelpers.IsMouseOverRect(panelRect);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces conflicting PRs #141, #142, #145 with a single clean integration
- Adds InGameMenuPanel (ESC key): Resume, Keybinds overlay, Surrender
- Adds OptionsMenuUI accessible from main menu
- Adds TechTreePanel overview panel
- ResourceHUD: Menu button (top-left) + Alanthor wall income bar
- RTSInputManager: ESC cascade (close menu > cancel modes > clear selection > open menu)
- EntityInfoPanel: bottom-center + multi-select army breakdown
- EntityActionPanel: repositioned to bottom-right

Closes #122, #126, #127, #128, #131, #132, #133
Supersedes #141, #142, #145

## Test plan
- [ ] Verify ESC key opens/closes in-game menu
- [ ] Verify Menu button in top-left opens in-game menu
- [ ] Verify Options menu works from main menu
- [ ] Verify Tech Tree panel opens and displays research
- [ ] Verify entity info panel is bottom-center
- [ ] Verify multi-select shows army breakdown
- [ ] Verify action panel is bottom-right
- [ ] Verify Alanthor wall income bar appears when applicable

?? Generated with [Claude Code](https://claude.com/claude-code)