### PR TITLE
feat(movement): add trees/rocks as flow field obstacles

### DIFF
--- a/Assets/Scripts/Bootstrap/ObstacleBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/ObstacleBootstrap.cs
@@ -102,7 +102,11 @@ namespace TheWaningBorder.Bootstrap
 
             placedPositions.Dispose();
 
-            Debug.Log($"[ObstacleBootstrap] Spawned {forestsSpawned} forests + {rocksSpawned} rock formations");
+            // Invalidate flow fields now that obstacles have been registered on the passability grid
+            var ffm = TheWaningBorder.Systems.Movement.FlowFieldManager.Instance;
+            if (ffm != null) ffm.InvalidateAll();
+
+            Debug.Log($"[ObstacleBootstrap] Spawned {forestsSpawned} forests + {rocksSpawned} rock formations (passability grid updated)");
         }
 
         /// <summary>
@@ -202,6 +206,11 @@ namespace TheWaningBorder.Bootstrap
             em.SetComponentData(entity, LocalTransform.FromPosition(position));
             em.SetComponentData(entity, new Radius { Value = radius });
             em.SetComponentData(entity, new PresentationId { Id = presentationId });
+
+            // Block passability grid cells so flow fields route around this obstacle
+            var grid = PassabilityGrid.Instance;
+            if (grid != null)
+                grid.BlockObstacle(position, radius);
 
             return entity;
         }

--- a/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
+++ b/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
@@ -13,9 +13,10 @@ using TheWaningBorder.Systems.Movement;
 namespace TheWaningBorder.Systems.Work
 {
     /// <summary>
-    /// Periodically scans all buildings and syncs their footprints with PassabilityGrid.
+    /// Periodically scans all buildings and obstacles, syncing their footprints with PassabilityGrid.
     /// - New buildings: calls BlockBuilding() to mark cells as building-blocked.
     /// - Destroyed buildings: calls UnblockBuilding() to restore cells to passable.
+    /// - Destroyed obstacles: calls UnblockObstacle() to restore cells to passable.
     /// Polls every 0.5 seconds to avoid per-frame overhead.
     /// </summary>
     // NOTE: No [BurstCompile] — accesses managed singleton (PassabilityGrid.Instance)
@@ -26,10 +27,11 @@ namespace TheWaningBorder.Systems.Work
 
         private float _timer;
         private NativeHashMap<Entity, BuildingRecord> _knownBuildings;
+        private NativeHashMap<Entity, BuildingRecord> _knownObstacles;
 
         /// <summary>
-        /// Cached position and radius for a known building, used to unblock
-        /// the correct cells when the building is destroyed.
+        /// Cached position and radius for a known building/obstacle, used to unblock
+        /// the correct cells when the entity is destroyed.
         /// </summary>
         private struct BuildingRecord
         {
@@ -41,12 +43,15 @@ namespace TheWaningBorder.Systems.Work
         {
             _timer = 0f;
             _knownBuildings = new NativeHashMap<Entity, BuildingRecord>(128, Allocator.Persistent);
+            _knownObstacles = new NativeHashMap<Entity, BuildingRecord>(32, Allocator.Persistent);
         }
 
         public void OnDestroy(ref SystemState state)
         {
             if (_knownBuildings.IsCreated)
                 _knownBuildings.Dispose();
+            if (_knownObstacles.IsCreated)
+                _knownObstacles.Dispose();
         }
 
         public void OnUpdate(ref SystemState state)
@@ -107,14 +112,68 @@ namespace TheWaningBorder.Systems.Work
 
             currentBuildings.Dispose();
 
-            // If any buildings changed, invalidate stale flow fields so units re-route
-            if (toRemove.Length > 0 || newBuildingsAdded)
+            bool gridChanged = toRemove.Length > 0 || newBuildingsAdded;
+            toRemove.Dispose();
+
+            // ─────────────────────────────────────────────────────────────────
+            // OBSTACLE TRACKING (trees, rocks — detect destroyed obstacles)
+            // ─────────────────────────────────────────────────────────────────
+
+            // Collect current obstacles
+            var currentObstacles = new NativeHashMap<Entity, BuildingRecord>(32, Allocator.Temp);
+
+            foreach (var (transform, radius, entity) in SystemAPI
+                         .Query<RefRO<LocalTransform>, RefRO<Radius>>()
+                         .WithAll<ObstacleTag>()
+                         .WithEntityAccess())
+            {
+                currentObstacles.Add(entity, new BuildingRecord
+                {
+                    Position = transform.ValueRO.Position,
+                    Radius = radius.ValueRO.Value
+                });
+            }
+
+            // Detect destroyed obstacles: known but no longer present
+            var obstacleToRemove = new NativeList<Entity>(8, Allocator.Temp);
+
+            foreach (var kvp in _knownObstacles)
+            {
+                if (!currentObstacles.ContainsKey(kvp.Key))
+                {
+                    grid.UnblockObstacle(kvp.Value.Position, kvp.Value.Radius);
+                    obstacleToRemove.Add(kvp.Key);
+                }
+            }
+
+            for (int i = 0; i < obstacleToRemove.Length; i++)
+            {
+                _knownObstacles.Remove(obstacleToRemove[i]);
+            }
+
+            // Register new obstacles we haven't tracked yet
+            // (ObstacleBootstrap already blocked them, but we need to track for cleanup)
+            foreach (var kvp in currentObstacles)
+            {
+                if (!_knownObstacles.ContainsKey(kvp.Key))
+                {
+                    _knownObstacles.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            currentObstacles.Dispose();
+
+            if (obstacleToRemove.Length > 0)
+                gridChanged = true;
+
+            obstacleToRemove.Dispose();
+
+            // If anything changed, invalidate stale flow fields so units re-route
+            if (gridChanged)
             {
                 var ffm = FlowFieldManager.Instance;
                 if (ffm != null) ffm.InvalidateAll();
             }
-
-            toRemove.Dispose();
         }
     }
 }

--- a/Assets/Scripts/World/Terrain/PassabilityGrid.cs
+++ b/Assets/Scripts/World/Terrain/PassabilityGrid.cs
@@ -12,7 +12,7 @@ namespace TheWaningBorder.World.Terrain
 {
     /// <summary>
     /// Grid-based passability map generated from terrain.
-    /// Cell values: 0 = passable, 1 = terrain-blocked (slope/water), 2 = building-blocked.
+    /// Cell values: 0 = passable, 1 = terrain-blocked (slope/water), 2 = building-blocked, 3 = obstacle-blocked (trees/rocks).
     /// Runs after ProceduralTerrain (-100) to ensure terrain exists.
     /// </summary>
     [DefaultExecutionOrder(-50)]
@@ -39,6 +39,7 @@ namespace TheWaningBorder.World.Terrain
         public const byte Passable = 0;
         public const byte TerrainBlocked = 1;
         public const byte BuildingBlocked = 2;
+        public const byte ObstacleBlocked = 3;
 
         // ═══════════════════════════════════════════════════════════════════════
         // GRID DATA
@@ -251,6 +252,44 @@ namespace TheWaningBorder.World.Terrain
                     _cells[index] = Passable;
             });
         }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // OBSTACLE BLOCKING (trees, rocks)
+        // ═══════════════════════════════════════════════════════════════════════
+
+        /// <summary>
+        /// Mark all cells within the given radius of a world position as obstacle-blocked.
+        /// Only overwrites cells that are currently passable (terrain-blocked and building-blocked stay).
+        /// </summary>
+        public void BlockObstacle(float3 center, float radius)
+        {
+            if (!_cells.IsCreated) return;
+
+            IterateCellsInRadius(center, radius, (int index, byte current) =>
+            {
+                if (current == Passable)
+                    _cells[index] = ObstacleBlocked;
+            });
+        }
+
+        /// <summary>
+        /// Unblock all cells within the given radius of a world position.
+        /// Only clears cells that are obstacle-blocked (terrain-blocked and building-blocked stay).
+        /// </summary>
+        public void UnblockObstacle(float3 center, float radius)
+        {
+            if (!_cells.IsCreated) return;
+
+            IterateCellsInRadius(center, radius, (int index, byte current) =>
+            {
+                if (current == ObstacleBlocked)
+                    _cells[index] = Passable;
+            });
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════
+        // ITERATION HELPERS
+        // ═══════════════════════════════════════════════════════════════════════
 
         /// <summary>
         /// Iterate all cells within a circular radius around a world position.


### PR DESCRIPTION
## Summary
- Trees and rock formations now block flow field pathfinding
- Added ObstacleBlocked cell type to PassabilityGrid
- ObstacleBootstrap marks cells blocked at spawn time
- PassabilityBuildingSync tracks obstacles for cleanup on destroy

Closes #108

## Test plan
- [ ] Units path around forests/rocks
- [ ] Flow field cache invalidates on obstacle change
- [ ] Building blocking still works alongside obstacles