### PR TITLE
feat(building): wire sect/temple data pipeline

### DIFF
--- a/Assets/Resources/TechTree.json
+++ b/Assets/Resources/TechTree.json
@@ -1503,12 +1503,20 @@
                         "magic": 1
                     },
                     "attackRange": 1.7,
+                    "lineOfSight": 14,
+                    "trainingTime": 15,
+                    "cost": {
+                        "Supplies": 100,
+                        "Iron": 40,
+                        "Crystal": 10
+                    },
                     "ActiveAbility": "RapidMend(self, 5s cd, strong regen 3s)",
                     "PassiveAbility": "Heals other units if out of combat"
                 },
                 "tech": {
                     "id": "DietaryMandate",
                     "effect": "All units gain tiny out-of-combat regen.",
+                    "researchTime": 40,
                     "cost": {
                         "Supplies": 150,
                         "Crystal": 10
@@ -1541,11 +1549,19 @@
                         "siege": 1,
                         "magic": 3
                     },
-                    "attackRange": 10.0
+                    "attackRange": 10.0,
+                    "lineOfSight": 16,
+                    "trainingTime": 20,
+                    "cost": {
+                        "Supplies": 150,
+                        "Iron": 60,
+                        "Crystal": 30
+                    }
                 },
                 "tech": {
                     "id": "ClockworkArchives",
                     "effect": "-15% research speed, -5% cooldown speed",
+                    "researchTime": 50,
                     "cost": {
                         "Supplies": 180,
                         "Crystal": 30
@@ -1579,11 +1595,19 @@
                         "siege": 1,
                         "magic": 1
                     },
-                    "attackRange": 1.6
+                    "attackRange": 1.6,
+                    "lineOfSight": 13,
+                    "trainingTime": 16,
+                    "cost": {
+                        "Supplies": 120,
+                        "Iron": 50,
+                        "Crystal": 15
+                    }
                 },
                 "tech": {
                     "id": "TerracePlanning",
                     "effect": "Compartment size yields +20% more Supplies.",
+                    "researchTime": 45,
                     "cost": {
                         "Supplies": 160,
                         "Iron": 40
@@ -1618,11 +1642,19 @@
                         "magic": 1
                     },
                     "attackRange": 14.0,
+                    "lineOfSight": 18,
+                    "trainingTime": 18,
+                    "cost": {
+                        "Supplies": 80,
+                        "Iron": 20,
+                        "Crystal": 30
+                    },
                     "ability": "Dispel (ally/enemy)"
                 },
                 "tech": {
                     "id": "HiddenRecords",
                     "effect": "First time you mine a Crystal Node: -25% retaliation chance.",
+                    "researchTime": 40,
                     "cost": {
                         "Supplies": 120,
                         "Crystal": 20
@@ -1655,11 +1687,19 @@
                         "ranged": 1
                     },
                     "attackRange": 1.6,
+                    "lineOfSight": 14,
+                    "trainingTime": 14,
+                    "cost": {
+                        "Supplies": 100,
+                        "Iron": 40,
+                        "Crystal": 10
+                    },
                     "ability": "Sanction (root target caravan/raider 2s)"
                 },
                 "tech": {
                     "id": "SanctifiedRoutes",
                     "effect": "Trade routes grant +5 armor to nearby caravans.",
+                    "researchTime": 45,
                     "cost": {
                         "Supplies": 150,
                         "Iron": 20
@@ -1691,11 +1731,19 @@
                         "ranged": 2
                     },
                     "attackRange": 1.6,
+                    "lineOfSight": 14,
+                    "trainingTime": 14,
+                    "cost": {
+                        "Supplies": 90,
+                        "Iron": 35,
+                        "Crystal": 10
+                    },
                     "ability": "Safeguard (damage reduction aura 6u, 5s)"
                 },
                 "tech": {
                     "id": "HiddenLedgers",
                     "effect": "Deposits protected; on depot destroyed, retain 50% Crystal/Iron.",
+                    "researchTime": 45,
                     "cost": {
                         "Supplies": 140,
                         "Iron": 30
@@ -1726,11 +1774,19 @@
                     "defense": {
                         "magic": 1
                     },
-                    "attackRange": 15.0
+                    "attackRange": 15.0,
+                    "lineOfSight": 18,
+                    "trainingTime": 18,
+                    "cost": {
+                        "Supplies": 80,
+                        "Iron": 20,
+                        "Crystal": 35
+                    }
                 },
                 "tech": {
                     "id": "RefinedSilverInlays",
                     "effect": "+10% magic attack, -10% spell cooldown.",
+                    "researchTime": 50,
                     "cost": {
                         "Supplies": 170,
                         "Crystal": 25
@@ -1762,11 +1818,19 @@
                         "melee": 3,
                         "ranged": 1
                     },
-                    "attackRange": 1.7
+                    "attackRange": 1.7,
+                    "lineOfSight": 14,
+                    "trainingTime": 16,
+                    "cost": {
+                        "Supplies": 110,
+                        "Iron": 45,
+                        "Crystal": 15
+                    }
                 },
                 "tech": {
                     "id": "IronDecrees",
                     "effect": "Enemy buildings near your trade nodes build -20% slower.",
+                    "researchTime": 50,
                     "cost": {
                         "Supplies": 150,
                         "Iron": 30
@@ -1797,11 +1861,18 @@
                     "defense": {
                         "melee": 2
                     },
-                    "attackRange": 1.6
+                    "attackRange": 1.6,
+                    "lineOfSight": 14,
+                    "trainingTime": 13,
+                    "cost": {
+                        "Supplies": 90,
+                        "Iron": 40
+                    }
                 },
                 "tech": {
                     "id": "WarTithe",
                     "effect": "Each enemy civilian killed refunds 5 Supplies.",
+                    "researchTime": 35,
                     "cost": {
                         "Supplies": 120
                     }
@@ -1833,11 +1904,18 @@
                     "defense": {
                         "melee": 2
                     },
-                    "attackRange": 1.6
+                    "attackRange": 1.6,
+                    "lineOfSight": 13,
+                    "trainingTime": 14,
+                    "cost": {
+                        "Supplies": 100,
+                        "Iron": 45
+                    }
                 },
                 "tech": {
                     "id": "DesecrateStandards",
                     "effect": "Enemy morale auras -20% effectiveness near your units.",
+                    "researchTime": 45,
                     "cost": {
                         "Supplies": 140,
                         "Iron": 30
@@ -1868,11 +1946,19 @@
                         "magic": 1
                     },
                     "attackRange": 14.0,
+                    "lineOfSight": 16,
+                    "trainingTime": 18,
+                    "cost": {
+                        "Supplies": 80,
+                        "Iron": 30,
+                        "Crystal": 25
+                    },
                     "ability": "ChainBind (short root)"
                 },
                 "tech": {
                     "id": "VeilsteelLinks",
                     "effect": "Veilsteel carry bonus also grants +1% DR per ingot.",
+                    "researchTime": 50,
                     "cost": {
                         "Supplies": 160,
                         "Iron": 40,
@@ -1906,11 +1992,19 @@
                     "defense": {
                         "magic": 2
                     },
-                    "attackRange": 1.6
+                    "attackRange": 1.6,
+                    "lineOfSight": 14,
+                    "trainingTime": 14,
+                    "cost": {
+                        "Supplies": 100,
+                        "Iron": 40,
+                        "Crystal": 10
+                    }
                 },
                 "tech": {
                     "id": "ErasureRites",
                     "effect": "Crystal drops yield +20% more resources for you.",
+                    "researchTime": 45,
                     "cost": {
                         "Supplies": 160,
                         "Crystal": 30

--- a/Assets/Scripts/Data/TechTree/TechTreeDB.cs
+++ b/Assets/Scripts/Data/TechTree/TechTreeDB.cs
@@ -433,38 +433,140 @@ public sealed class TechTreeDB : MonoBehaviour
     {
         int sectsIndex = json.IndexOf("\"sects\":");
         if (sectsIndex == -1) return;
-        
+
         int listIndex = json.IndexOf("\"list\":", sectsIndex);
         if (listIndex == -1) return;
-        
+
         int arrayStart = json.IndexOf("[", listIndex);
         if (arrayStart == -1) return;
-        
+
         int searchPos = arrayStart;
         int arrayEnd = json.IndexOf("]", arrayStart);
-        
+
         while (true)
         {
             int sectStart = json.IndexOf("{", searchPos);
             if (sectStart == -1 || sectStart > arrayEnd) break;
-            
+
             int sectEnd = FindMatchingBrace(json, sectStart);
             if (sectEnd == -1) break;
-            
+
             string sectJson = json.Substring(sectStart, sectEnd - sectStart + 1);
-            
+
             var sect = new SectDef
             {
                 id = ParseString(sectJson, "id", ""),
                 order = ParseString(sectJson, "order", ""),
                 affinity = ParseString(sectJson, "affinity", "")
             };
-            
+
             if (!string.IsNullOrEmpty(sect.id))
+            {
                 _sectsById[sect.id] = sect;
-            
+
+                // Parse embedded unit definition (JSON id → "Sect_" + normalized id)
+                ParseSectUnit(sectJson, sect.id);
+
+                // Parse embedded tech definition (JSON id → "Tech_" + id)
+                ParseSectTech(sectJson, sect.id);
+            }
+
             searchPos = sectEnd + 1;
         }
+    }
+
+    /// <summary>
+    /// Parse the "unit" block embedded inside a sect JSON entry.
+    /// Normalizes the ID to "Sect_" + PascalCase (e.g., "Golem_Autark" → "Sect_GolemAutark").
+    /// Registers the unit in _unitsById so chapel training can look it up.
+    /// </summary>
+    void ParseSectUnit(string sectJson, string sectId)
+    {
+        int unitIndex = sectJson.IndexOf("\"unit\":");
+        if (unitIndex == -1) return;
+
+        int blockStart = sectJson.IndexOf("{", unitIndex);
+        if (blockStart == -1) return;
+
+        int blockEnd = FindMatchingBrace(sectJson, blockStart);
+        if (blockEnd == -1) return;
+
+        string unitJson = sectJson.Substring(blockStart, blockEnd - blockStart + 1);
+        string rawId = ParseString(unitJson, "id", "");
+        if (string.IsNullOrEmpty(rawId)) return;
+
+        // Normalize: "Golem_Autark" → "GolemAutark", then prefix with "Sect_"
+        string normalizedId = "Sect_" + rawId.Replace("_", "");
+
+        var unit = new UnitDef
+        {
+            id = normalizedId,
+            unitClass = ParseString(unitJson, "class", ""),
+            name = rawId.Replace("_", " "),  // "Golem_Autark" → "Golem Autark"
+            hp = ParseFloat(unitJson, "hp", 0, 100),
+            speed = ParseFloat(unitJson, "speed", 0, 5),
+            trainingTime = ParseFloat(unitJson, "trainingTime", 0, 15),  // Default 15s
+            damage = ParseFloat(unitJson, "damage", 0, 10),
+            attackRange = ParseFloat(unitJson, "attackRange", 0, 1.5f),
+            minAttackRange = ParseFloat(unitJson, "minAttackRange", 0, 0f),
+            lineOfSight = ParseFloat(unitJson, "lineOfSight", 0, 14),  // Default 14
+            armorType = ParseString(unitJson, "armorType", "infantry_heavy"),
+            damageType = ParseString(unitJson, "damageType", "melee"),
+            defense = ParseDefenseBlock(unitJson),
+            cost = ParseCostBlock(unitJson)
+        };
+
+        // Apply default cost if none specified in JSON
+        if (unit.cost == null || (unit.cost.Supplies == 0 && unit.cost.Iron == 0 && unit.cost.Crystal == 0))
+        {
+            unit.cost = new CostBlock { Supplies = 100, Iron = 50 };
+        }
+
+        _unitsById[normalizedId] = unit;
+        Debug.Log($"[TechTreeDB] Sect unit: {normalizedId} (from {sectId}) HP={unit.hp} Dmg={unit.damage}");
+    }
+
+    /// <summary>
+    /// Parse the "tech" block embedded inside a sect JSON entry.
+    /// Normalizes the ID to "Tech_" + raw id (e.g., "DietaryMandate" → "Tech_DietaryMandate").
+    /// Registers the tech in _technologiesById so chapel research can look it up.
+    /// </summary>
+    void ParseSectTech(string sectJson, string sectId)
+    {
+        int techIndex = sectJson.IndexOf("\"tech\":");
+        if (techIndex == -1) return;
+
+        int blockStart = sectJson.IndexOf("{", techIndex);
+        if (blockStart == -1) return;
+
+        int blockEnd = FindMatchingBrace(sectJson, blockStart);
+        if (blockEnd == -1) return;
+
+        string techJson = sectJson.Substring(blockStart, blockEnd - blockStart + 1);
+        string rawId = ParseString(techJson, "id", "");
+        if (string.IsNullOrEmpty(rawId)) return;
+
+        // Prefix with "Tech_"
+        string normalizedId = "Tech_" + rawId;
+
+        var tech = new TechnologyDef
+        {
+            id = normalizedId,
+            name = rawId.Replace("_", " "),  // Already PascalCase in JSON, just clean underscores
+            effect = ParseString(techJson, "effect", ""),
+            desc = ParseString(techJson, "effect", ""),  // Use effect as desc
+            researchTime = ParseFloat(techJson, "researchTime", 0, 45),  // Default 45s
+            cost = ParseCostBlock(techJson)
+        };
+
+        // Apply default cost if none specified
+        if (tech.cost == null || (tech.cost.Supplies == 0 && tech.cost.Iron == 0 && tech.cost.Crystal == 0))
+        {
+            tech.cost = new CostBlock { Supplies = 150, Iron = 75, Crystal = 50 };
+        }
+
+        _technologiesById[normalizedId] = tech;
+        Debug.Log($"[TechTreeDB] Sect tech: {normalizedId} (from {sectId}) Time={tech.researchTime}s");
     }
 
     // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Enhanced TechTreeDB.ParseAllSects() to extract sect unit and tech definitions from TechTree.json
- Added ParseSectUnit() and ParseSectTech() methods with ID normalization (JSON IDs to SectConfig IDs)
- Updated all 12 sect entries in TechTree.json with missing trainingTime, cost, lineOfSight, and researchTime
- Chapel training and research can now resolve real unit/tech stats instead of using fallback placeholders

## Test plan
- [ ] Build project with no compile errors
- [ ] In-game: temple appears in builder build menu at Era 1
- [ ] Adopt a sect at temple -> spell panel shows sect spell
- [ ] Build chapel -> training shows sect unit with correct stats
- [ ] Chapel research shows sect tech with correct cost/time