### PR TITLE
fix(movement): bootstrap flow field pathfinding singletons

### DIFF
--- a/Assets/Scripts/Bootstrap/GameBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/GameBootstrap.cs
@@ -18,6 +18,7 @@ using TheWaningBorder.UI.Common;
 using TheWaningBorder.UI.Panels;
 using TheWaningBorder.UI.HUD;
 using TheWaningBorder.Systems.Research;
+using TheWaningBorder.Systems.Movement;
 
 namespace TheWaningBorder.Bootstrap
 {
@@ -188,6 +189,24 @@ namespace TheWaningBorder.Bootstrap
                 var terrainGO = new GameObject("ProceduralTerrain");
                 terrainGO.AddComponent<TheWaningBorder.World.Terrain.ProceduralTerrain>();
                 Debug.Log("[GameBootstrap] Created ProceduralTerrain");
+            }
+
+            // Create passability grid for flow-field pathfinding (needs terrain)
+            var existingGrid = Object.FindFirstObjectByType<PassabilityGrid>();
+            if (existingGrid == null)
+            {
+                var gridGO = new GameObject("PassabilityGrid");
+                gridGO.AddComponent<PassabilityGrid>();
+                Debug.Log("[GameBootstrap] Created PassabilityGrid");
+            }
+
+            // Create flow field manager for obstacle-aware pathfinding (needs grid)
+            var existingFFM = Object.FindFirstObjectByType<FlowFieldManager>();
+            if (existingFFM == null)
+            {
+                var ffmGO = new GameObject("FlowFieldManager");
+                ffmGO.AddComponent<FlowFieldManager>();
+                Debug.Log("[GameBootstrap] Created FlowFieldManager");
             }
 
             // Initialize fog of war if enabled (disabled for Observer - they see everything)

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -286,6 +286,19 @@ namespace TheWaningBorder.Systems.Movement
                 float step = math.min(speed * dt * facingFactor, dist);
                 float3 nextPos = pos + dir * step;
 
+                // === PASSABILITY CHECK: avoid stepping onto blocked grid cells ===
+                var passGrid = PassabilityGrid.Instance;
+                if (passGrid != null)
+                {
+                    int2 nextCell = passGrid.WorldToCell(nextPos);
+                    if (!passGrid.IsPassable(nextCell))
+                    {
+                        // Blocked — don't move this frame but KEEP destination.
+                        // Flow field will provide obstacle-aware direction next frame.
+                        continue;
+                    }
+                }
+
                 // === SLOPE CHECK: block movement onto impassable steep terrain ===
                 float hCenter = TerrainUtility.GetHeight(nextPos.x, nextPos.z);
                 float hL = TerrainUtility.GetHeight(nextPos.x - SlopeCheckStep, nextPos.z);
@@ -298,15 +311,8 @@ namespace TheWaningBorder.Systems.Movement
 
                 if (slopeAtNext > MaxWalkableSlope)
                 {
-                    // Terrain too steep — stop moving
-                    dd.ValueRW.Has = 0;
-                    if (em.HasComponent<UserMoveOrder>(entity))
-                        ecb.RemoveComponent<UserMoveOrder>(entity);
-                    if (em.HasComponent<AttackMoveTag>(entity))
-                        ecb.RemoveComponent<AttackMoveTag>(entity);
-                    // PatrolTag: not removed; PatrolSystem will re-route to next waypoint
-                    if (em.HasComponent<FormationSpeedOverride>(entity))
-                        ecb.RemoveComponent<FormationSpeedOverride>(entity);
+                    // Terrain too steep — skip movement this frame but KEEP destination.
+                    // Flow field will provide obstacle-aware direction next frame.
                     continue;
                 }
 

--- a/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
+++ b/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
@@ -71,7 +71,6 @@ namespace TheWaningBorder.Systems.Work
             foreach (var (transform, radius, entity) in SystemAPI
                          .Query<RefRO<LocalTransform>, RefRO<Radius>>()
                          .WithAll<BuildingTag>()
-                         .WithNone<UnderConstruction>()
                          .WithEntityAccess())
             {
                 currentBuildings.Add(entity, new BuildingRecord


### PR DESCRIPTION
Root cause: GameBootstrap never created PassabilityGrid or FlowFieldManager, so flow field pathfinding was completely disabled. Units always moved in straight lines ignoring all obstacles.