### PR TITLE
fix(movement): bilinear interpolation for smooth flow field paths

### DIFF
--- a/Assets/Scripts/Core/Components/FlowFieldComponents.cs
+++ b/Assets/Scripts/Core/Components/FlowFieldComponents.cs
@@ -261,21 +261,27 @@ public struct FlowFieldLookup
         if (!DestToSlot.TryGetValue(snappedDest, out int slot))
             return directDir;
 
-        // Convert unit position to cell index
-        int cx = (int)math.floor((position.x - Origin.x) / CellSize);
-        int cy = (int)math.floor((position.z - Origin.z) / CellSize);
-        if (cx < 0 || cx >= GridWidth || cy < 0 || cy >= GridHeight)
-            return directDir;
+        // Bilinear interpolation: sample the 4 nearest cell centers and
+        // blend based on sub-cell position for smooth, continuous directions.
+        float fx = (position.x - Origin.x) / CellSize - 0.5f;
+        float fz = (position.z - Origin.z) / CellSize - 0.5f;
+        int x0 = (int)math.floor(fx);
+        int z0 = (int)math.floor(fz);
+        float tx = fx - x0;
+        float tz = fz - z0;
 
-        int cellIndex = cy * GridWidth + cx;
-        int dataIndex = slot * CellsPerField + cellIndex;
+        float2 d00 = SampleCell(slot, x0, z0);
+        float2 d10 = SampleCell(slot, x0 + 1, z0);
+        float2 d01 = SampleCell(slot, x0, z0 + 1);
+        float2 d11 = SampleCell(slot, x0 + 1, z0 + 1);
 
-        if (dataIndex < 0 || dataIndex >= DirectionData.Length)
-            return directDir;
+        // Lerp horizontally then vertically
+        float2 flowDir2 = math.lerp(
+            math.lerp(d00, d10, tx),
+            math.lerp(d01, d11, tx),
+            tz);
 
-        float2 flowDir2 = DirectionData[dataIndex];
-
-        // If cell has no valid direction (unreachable or destination), use direct
+        // If interpolated direction is near-zero (all neighbors unreachable), use direct
         if (math.lengthsq(flowDir2) < 1e-6f)
             return directDir;
 
@@ -292,5 +298,19 @@ public struct FlowFieldLookup
         }
 
         return flowDir;
+    }
+
+    /// <summary>
+    /// Sample direction data for a single cell, clamping to grid bounds.
+    /// Returns float2.zero for out-of-bounds or invalid cells.
+    /// </summary>
+    private float2 SampleCell(int slot, int cx, int cy)
+    {
+        cx = math.clamp(cx, 0, GridWidth - 1);
+        cy = math.clamp(cy, 0, GridHeight - 1);
+        int idx = slot * CellsPerField + cy * GridWidth + cx;
+        if (idx < 0 || idx >= DirectionData.Length)
+            return float2.zero;
+        return DirectionData[idx];
     }
 }

--- a/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
+++ b/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
@@ -64,16 +64,27 @@ namespace TheWaningBorder.Systems.Movement
             var grid = PassabilityGrid.Instance;
             if (grid == null) return directDir;
 
-            // Convert unit position to cell index
-            int2 cell = grid.WorldToCell(position);
-            if (cell.x < 0 || cell.x >= field.Value.Width ||
-                cell.y < 0 || cell.y >= field.Value.Height)
-                return directDir;
+            int w = field.Value.Width;
+            int h = field.Value.Height;
 
-            int cellIndex = cell.y * field.Value.Width + cell.x;
-            float2 flowDir2 = field.Value.DirectionField[cellIndex];
+            // Bilinear interpolation: sample the 4 nearest cell centers for smooth directions
+            float fx = (position.x - grid.Origin.x) / grid.CellSize - 0.5f;
+            float fz = (position.z - grid.Origin.z) / grid.CellSize - 0.5f;
+            int x0 = (int)math.floor(fx);
+            int z0 = (int)math.floor(fz);
+            float tx = fx - x0;
+            float tz = fz - z0;
 
-            // If cell has no valid direction (unreachable or destination), use direct
+            float2 d00 = SampleManaged(field.Value.DirectionField, x0, z0, w, h);
+            float2 d10 = SampleManaged(field.Value.DirectionField, x0 + 1, z0, w, h);
+            float2 d01 = SampleManaged(field.Value.DirectionField, x0, z0 + 1, w, h);
+            float2 d11 = SampleManaged(field.Value.DirectionField, x0 + 1, z0 + 1, w, h);
+
+            float2 flowDir2 = math.lerp(
+                math.lerp(d00, d10, tx),
+                math.lerp(d01, d11, tx),
+                tz);
+
             if (math.lengthsq(flowDir2) < 1e-6f)
                 return directDir;
 
@@ -90,6 +101,19 @@ namespace TheWaningBorder.Systems.Movement
             }
 
             return flowDir;
+        }
+
+        /// <summary>
+        /// Sample direction field at a cell, clamping to grid bounds.
+        /// Returns float2.zero for out-of-bounds cells.
+        /// </summary>
+        private static float2 SampleManaged(
+            Unity.Collections.NativeArray<float2> directionField,
+            int cx, int cy, int width, int height)
+        {
+            cx = math.clamp(cx, 0, width - 1);
+            cy = math.clamp(cy, 0, height - 1);
+            return directionField[cy * width + cx];
         }
     }
 }


### PR DESCRIPTION
DirectionFieldJob only produces 8 discrete directions per cell (N/NE/E/SE/S/SW/W/NW), causing rigid grid-aligned movement. Added bilinear interpolation of 4 nearest cell centers based on sub-cell position for smooth continuous direction vectors. Applied to both FlowFieldLookup (Burst) and FlowFieldMovementHelper (managed fallback).