### PR TITLE
fix(movement,multiplayer): rework movement system, fix LAN port

### DIFF
--- a/Assets/Scripts/Core/Components/CoreComponents.cs
+++ b/Assets/Scripts/Core/Components/CoreComponents.cs
@@ -131,6 +131,27 @@ public struct GuardPoint : IComponentData
 }
 
 /// <summary>
+/// Per-unit smoothed movement direction for flow-field smoothing.
+/// Prevents cell-boundary oscillation by lerping toward the raw flow field direction.
+/// </summary>
+public struct SmoothedDirection : IComponentData
+{
+    public float3 Value;
+}
+
+/// <summary>
+/// Tracks consecutive frames where movement was blocked by passability or slope.
+/// Used by MovementSystem to detect stuck units and try alternate directions.
+/// </summary>
+public struct StuckState : IComponentData
+{
+    /// <summary>Consecutive frames where movement was blocked.</summary>
+    public byte Counter;
+    /// <summary>Which perpendicular attempt was last tried (0=none, 1=left, 2=right).</summary>
+    public byte LastAttempt;
+}
+
+/// <summary>
 /// Rally point for newly trained units.
 /// </summary>
 public struct RallyPoint : IComponentData

--- a/Assets/Scripts/Core/Components/FlowFieldComponents.cs
+++ b/Assets/Scripts/Core/Components/FlowFieldComponents.cs
@@ -261,32 +261,23 @@ public struct FlowFieldLookup
         if (!DestToSlot.TryGetValue(snappedDest, out int slot))
             return directDir;
 
-        // Bilinear interpolation: sample the 4 nearest cell centers and
-        // blend based on sub-cell position for smooth, continuous directions.
-        float fx = (position.x - Origin.x) / CellSize - 0.5f;
-        float fz = (position.z - Origin.z) / CellSize - 0.5f;
-        int x0 = (int)math.floor(fx);
-        int z0 = (int)math.floor(fz);
-        float tx = fx - x0;
-        float tz = fz - z0;
+        // Simple per-cell lookup (smoothing is handled per-unit in MovementSystem)
+        int cx = (int)math.floor((position.x - Origin.x) / CellSize);
+        int cz = (int)math.floor((position.z - Origin.z) / CellSize);
+        cx = math.clamp(cx, 0, GridWidth - 1);
+        cz = math.clamp(cz, 0, GridHeight - 1);
 
-        float2 d00 = SampleCell(slot, x0, z0);
-        float2 d10 = SampleCell(slot, x0 + 1, z0);
-        float2 d01 = SampleCell(slot, x0, z0 + 1);
-        float2 d11 = SampleCell(slot, x0 + 1, z0 + 1);
+        int idx = slot * CellsPerField + cz * GridWidth + cx;
+        if (idx < 0 || idx >= DirectionData.Length)
+            return directDir;
 
-        // Lerp horizontally then vertically
-        float2 flowDir2 = math.lerp(
-            math.lerp(d00, d10, tx),
-            math.lerp(d01, d11, tx),
-            tz);
+        float2 flowDir2 = DirectionData[idx];
 
-        // If interpolated direction is near-zero (all neighbors unreachable), use direct
+        // If cell direction is zero (unreachable/destination), use direct
         if (math.lengthsq(flowDir2) < 1e-6f)
             return directDir;
 
-        float3 flowDir = new float3(flowDir2.x, 0f, flowDir2.y);
-        flowDir = math.normalizesafe(flowDir);
+        float3 flowDir = math.normalizesafe(new float3(flowDir2.x, 0f, flowDir2.y));
 
         // Blend: near destination use direct-line for precise arrival,
         // far from destination use flow field for obstacle avoidance.

--- a/Assets/Scripts/Multiplayer/Lobby/LobbyManager.cs
+++ b/Assets/Scripts/Multiplayer/Lobby/LobbyManager.cs
@@ -16,9 +16,9 @@ namespace TheWaningBorder.Multiplayer
     /// Manages multiplayer lobby state and networking.
     /// 
     /// Architecture:
-    /// - Host listens on BROADCAST_PORT (47777) for discovery and join requests
+    /// - Host listens on BROADCAST_PORT (27015) for discovery and join requests
     /// - Client uses two sockets:
-    ///   1. Broadcast listener on 47777 (ReuseAddress) for game discovery
+    ///   1. Broadcast listener on 27015 (ReuseAddress) for game discovery
     ///   2. Private socket on random port for direct messages
     /// 
     /// Protocol:
@@ -35,7 +35,7 @@ namespace TheWaningBorder.Multiplayer
         // CONSTANTS
         // ═══════════════════════════════════════════════════════════════════════
         
-        public const int BROADCAST_PORT = 47777;
+        public const int BROADCAST_PORT = 27015;
         public const float BROADCAST_INTERVAL = 1.0f;
         public const float LOBBY_SYNC_INTERVAL = 0.5f;
         public const float DISCOVERY_TIMEOUT = 5.0f;
@@ -136,6 +136,17 @@ namespace TheWaningBorder.Multiplayer
                 Debug.Log($"[LobbyManager] Started hosting '{gameName}' on port {BROADCAST_PORT}");
                 return true;
             }
+            catch (SocketException se)
+            {
+                string hint = se.SocketErrorCode == SocketError.AddressAlreadyInUse
+                    ? $"Port {BROADCAST_PORT} already in use. Close other game instances."
+                    : se.SocketErrorCode == SocketError.AccessDenied
+                        ? $"Port {BROADCAST_PORT} blocked. Check Windows Firewall settings."
+                        : se.Message;
+                OnError?.Invoke($"Network error: {hint}");
+                Debug.LogError($"[LobbyManager] Host socket error: {hint}");
+                return false;
+            }
             catch (Exception e)
             {
                 OnError?.Invoke($"Failed to start host: {e.Message}");
@@ -168,6 +179,17 @@ namespace TheWaningBorder.Multiplayer
 
                 Debug.Log($"[LobbyManager] Started client on port {_clientPort}");
                 return true;
+            }
+            catch (SocketException se)
+            {
+                string hint = se.SocketErrorCode == SocketError.AddressAlreadyInUse
+                    ? $"Port {BROADCAST_PORT} already in use. Close other game instances."
+                    : se.SocketErrorCode == SocketError.AccessDenied
+                        ? $"Port {BROADCAST_PORT} blocked. Check Windows Firewall settings."
+                        : se.Message;
+                OnError?.Invoke($"Network error: {hint}");
+                Debug.LogError($"[LobbyManager] Client socket error: {hint}");
+                return false;
             }
             catch (Exception e)
             {

--- a/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
+++ b/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
@@ -67,29 +67,18 @@ namespace TheWaningBorder.Systems.Movement
             int w = field.Value.Width;
             int h = field.Value.Height;
 
-            // Bilinear interpolation: sample the 4 nearest cell centers for smooth directions
-            float fx = (position.x - grid.Origin.x) / grid.CellSize - 0.5f;
-            float fz = (position.z - grid.Origin.z) / grid.CellSize - 0.5f;
-            int x0 = (int)math.floor(fx);
-            int z0 = (int)math.floor(fz);
-            float tx = fx - x0;
-            float tz = fz - z0;
+            // Simple per-cell lookup (smoothing is per-unit in MovementSystem)
+            int cx = (int)math.floor((position.x - grid.Origin.x) / grid.CellSize);
+            int cz = (int)math.floor((position.z - grid.Origin.z) / grid.CellSize);
+            cx = math.clamp(cx, 0, w - 1);
+            cz = math.clamp(cz, 0, h - 1);
 
-            float2 d00 = SampleManaged(field.Value.DirectionField, x0, z0, w, h);
-            float2 d10 = SampleManaged(field.Value.DirectionField, x0 + 1, z0, w, h);
-            float2 d01 = SampleManaged(field.Value.DirectionField, x0, z0 + 1, w, h);
-            float2 d11 = SampleManaged(field.Value.DirectionField, x0 + 1, z0 + 1, w, h);
-
-            float2 flowDir2 = math.lerp(
-                math.lerp(d00, d10, tx),
-                math.lerp(d01, d11, tx),
-                tz);
+            float2 flowDir2 = field.Value.DirectionField[cz * w + cx];
 
             if (math.lengthsq(flowDir2) < 1e-6f)
                 return directDir;
 
-            float3 flowDir = new float3(flowDir2.x, 0f, flowDir2.y);
-            flowDir = math.normalizesafe(flowDir);
+            float3 flowDir = math.normalizesafe(new float3(flowDir2.x, 0f, flowDir2.y));
 
             // Blend: near destination use direct-line for precise arrival,
             // far from destination use flow field for obstacle avoidance.

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -106,6 +106,12 @@ namespace TheWaningBorder.Systems.Movement
                     ecb.AddComponent<UserMoveOrder>(entity);
                 }
 
+                // Reset smoothing state for fresh movement
+                if (em.HasComponent<SmoothedDirection>(entity))
+                    ecb.SetComponent(entity, new SmoothedDirection { Value = float3.zero });
+                if (em.HasComponent<StuckState>(entity))
+                    ecb.SetComponent(entity, new StuckState { Counter = 0, LastAttempt = 0 });
+
                 // DON'T remove AttackCommand here - let UnifiedCombatSystem see the MoveCommand
                 // and skip attack processing for this entity
 
@@ -172,6 +178,12 @@ namespace TheWaningBorder.Systems.Movement
                     ecb.RemoveComponent<UserMoveOrder>(entity);
                 }
 
+                // Reset smoothing state for fresh movement
+                if (em.HasComponent<SmoothedDirection>(entity))
+                    ecb.SetComponent(entity, new SmoothedDirection { Value = float3.zero });
+                if (em.HasComponent<StuckState>(entity))
+                    ecb.SetComponent(entity, new StuckState { Counter = 0, LastAttempt = 0 });
+
                 // Remove AttackMoveCommand itself - it's been processed
                 ecb.RemoveComponent<AttackMoveCommand>(entity);
             }
@@ -198,6 +210,12 @@ namespace TheWaningBorder.Systems.Movement
                     dd.ValueRW.Has = 0;
                     continue;
                 }
+
+                // Lazy-add new components (safe via ECB — structural change deferred)
+                if (!em.HasComponent<SmoothedDirection>(entity))
+                    ecb.AddComponent(entity, new SmoothedDirection { Value = float3.zero });
+                if (!em.HasComponent<StuckState>(entity))
+                    ecb.AddComponent(entity, new StuckState { Counter = 0, LastAttempt = 0 });
 
                 // Get move speed: FormationSpeedOverride > MoveSpeed > default
                 float speed = DefaultMoveSpeed;
@@ -227,12 +245,10 @@ namespace TheWaningBorder.Systems.Movement
                     dd.ValueRW.Has = 0;
 
                     // Remove UserMoveOrder tag when destination reached
-                    // This allows auto-targeting to resume
                     if (em.HasComponent<UserMoveOrder>(entity))
                         ecb.RemoveComponent<UserMoveOrder>(entity);
 
                     // Remove AttackMoveTag when destination reached
-                    // Attack-move is complete, unit becomes idle
                     if (em.HasComponent<AttackMoveTag>(entity))
                         ecb.RemoveComponent<AttackMoveTag>(entity);
 
@@ -250,74 +266,134 @@ namespace TheWaningBorder.Systems.Movement
                 float dist = math.sqrt(distSqr);
                 float3 dir = to / math.max(1e-5f, dist);
 
-                // Pre-warm flow field cache for this destination (managed call,
-                // but just a dictionary lookup / queue enqueue — not in the hot path).
-                // This ensures async generation is triggered for uncached destinations.
+                // Pre-warm flow field cache for this destination
                 if (ffm != null)
                     ffm.RequestFlowField(goal);
 
-                // Flow-field direction lookup via NativeArray-based FlowFieldLookup
-                // (no managed singleton access — uses pre-built lookup struct).
-                // Falls back to direct-line if lookup is not valid or field not cached.
+                // Flow-field direction lookup (NativeArray-based, falls back to direct-line)
                 dir = ffLookup.GetDirection(pos, goal, dir, dist);
+
+                // === Per-unit direction smoothing ===
+                // Lerp toward raw flow field direction to prevent cell-boundary oscillation.
+                float3 smoothedDir = dir;
+                if (em.HasComponent<SmoothedDirection>(entity))
+                {
+                    float3 prev = em.GetComponentData<SmoothedDirection>(entity).Value;
+                    if (math.lengthsq(prev) > 1e-8f)
+                    {
+                        const float SmoothRate = 12f;
+                        smoothedDir = math.normalizesafe(math.lerp(prev, dir, math.saturate(SmoothRate * dt)));
+                    }
+                    ecb.SetComponent(entity, new SmoothedDirection { Value = smoothedDir });
+                }
 
                 var t = xf.ValueRO;
 
-                // Smooth rotation toward movement direction
-                float facingDot = 1f;
-                if (math.lengthsq(dir) > 1e-8f)
+                // === Cosmetic rotation (does NOT affect speed) ===
+                if (math.lengthsq(smoothedDir) > 1e-8f)
                 {
-                    float3 fwd = math.normalize(new float3(dir.x, 0f, dir.z));
+                    float3 fwd = math.normalize(new float3(smoothedDir.x, 0f, smoothedDir.z));
                     quaternion targetRot = quaternion.RotateY(math.atan2(fwd.x, fwd.z));
-
-                    // Slerp toward target rotation at TurnSpeed
                     float maxTurn = TurnSpeed * dt;
                     SmoothSlerp(in t.Rotation, in targetRot, maxTurn, out var smoothed);
                     t.Rotation = smoothed;
-
-                    // Measure how well unit faces its goal (1 = facing, 0 = perpendicular, -1 = backwards)
-                    float3 currentFwd = math.mul(t.Rotation, new float3(0, 0, 1));
-                    facingDot = math.dot(new float3(currentFwd.x, 0, currentFwd.z), fwd);
                 }
 
-                // Scale movement by facing: full speed when facing goal, reduced when turning
-                // Clamp so units still creep forward even while turning (min 20% speed)
-                float facingFactor = math.clamp(facingDot, 0.2f, 1f);
-                float step = math.min(speed * dt * facingFactor, dist);
-                float3 nextPos = pos + dir * step;
+                // === Full speed movement — no facingFactor ===
+                float step = math.min(speed * dt, dist);
+                float3 nextPos = pos + smoothedDir * step;
 
-                // === PASSABILITY CHECK: avoid stepping onto blocked grid cells ===
+                // === PASSABILITY CHECK ===
+                bool blocked = false;
                 var passGrid = PassabilityGrid.Instance;
                 if (passGrid != null)
                 {
                     int2 nextCell = passGrid.WorldToCell(nextPos);
                     if (!passGrid.IsPassable(nextCell))
-                    {
-                        // Blocked — don't move this frame but KEEP destination.
-                        // Flow field will provide obstacle-aware direction next frame.
-                        continue;
-                    }
+                        blocked = true;
                 }
 
-                // === SLOPE CHECK: block movement onto impassable steep terrain ===
-                float hCenter = TerrainUtility.GetHeight(nextPos.x, nextPos.z);
-                float hL = TerrainUtility.GetHeight(nextPos.x - SlopeCheckStep, nextPos.z);
-                float hR = TerrainUtility.GetHeight(nextPos.x + SlopeCheckStep, nextPos.z);
-                float hD = TerrainUtility.GetHeight(nextPos.x, nextPos.z - SlopeCheckStep);
-                float hU = TerrainUtility.GetHeight(nextPos.x, nextPos.z + SlopeCheckStep);
-                float dX = (hR - hL) / (SlopeCheckStep * 2f);
-                float dZ = (hU - hD) / (SlopeCheckStep * 2f);
-                float slopeAtNext = math.sqrt(dX * dX + dZ * dZ);
-
-                if (slopeAtNext > MaxWalkableSlope)
+                // === SLOPE CHECK ===
+                if (!blocked)
                 {
-                    // Terrain too steep — skip movement this frame but KEEP destination.
-                    // Flow field will provide obstacle-aware direction next frame.
+                    float hL = TerrainUtility.GetHeight(nextPos.x - SlopeCheckStep, nextPos.z);
+                    float hR = TerrainUtility.GetHeight(nextPos.x + SlopeCheckStep, nextPos.z);
+                    float hD = TerrainUtility.GetHeight(nextPos.x, nextPos.z - SlopeCheckStep);
+                    float hU = TerrainUtility.GetHeight(nextPos.x, nextPos.z + SlopeCheckStep);
+                    float dX = (hR - hL) / (SlopeCheckStep * 2f);
+                    float dZ = (hU - hD) / (SlopeCheckStep * 2f);
+                    float slopeAtNext = math.sqrt(dX * dX + dZ * dZ);
+                    if (slopeAtNext > MaxWalkableSlope)
+                        blocked = true;
+                }
+
+                // === STUCK DETECTION with 3-tier escalation ===
+                if (blocked)
+                {
+                    if (em.HasComponent<StuckState>(entity))
+                    {
+                        var stuck = em.GetComponentData<StuckState>(entity);
+                        stuck.Counter = (byte)math.min(stuck.Counter + 1, 255);
+
+                        if (stuck.Counter > 30)
+                        {
+                            // Tier 3 (30+ frames ≈ 0.5s): cancel destination entirely
+                            dd.ValueRW.Has = 0;
+                            if (em.HasComponent<UserMoveOrder>(entity))
+                                ecb.RemoveComponent<UserMoveOrder>(entity);
+                            if (em.HasComponent<AttackMoveTag>(entity))
+                                ecb.RemoveComponent<AttackMoveTag>(entity);
+                            if (em.HasComponent<FormationSpeedOverride>(entity))
+                                ecb.RemoveComponent<FormationSpeedOverride>(entity);
+                            ecb.SetComponent(entity, new StuckState { Counter = 0, LastAttempt = 0 });
+                        }
+                        else if (stuck.Counter > 5)
+                        {
+                            // Tier 2 (6-30 frames): try perpendicular directions
+                            byte attempt = (byte)(stuck.LastAttempt == 1 ? 2 : 1);
+                            float3 perp = attempt == 1
+                                ? new float3(-smoothedDir.z, 0f, smoothedDir.x)
+                                : new float3(smoothedDir.z, 0f, -smoothedDir.x);
+                            perp = math.normalizesafe(perp);
+
+                            float3 perpPos = pos + perp * step;
+                            bool perpBlocked = false;
+                            if (passGrid != null)
+                            {
+                                int2 perpCell = passGrid.WorldToCell(perpPos);
+                                if (!passGrid.IsPassable(perpCell))
+                                    perpBlocked = true;
+                            }
+
+                            if (!perpBlocked)
+                            {
+                                perpPos.y = TerrainUtility.GetHeight(perpPos.x, perpPos.z);
+                                t.Position = perpPos;
+                            }
+
+                            stuck.LastAttempt = attempt;
+                            ecb.SetComponent(entity, stuck);
+                        }
+                        else
+                        {
+                            // Tier 1 (1-5 frames): retry same direction, flow field may update
+                            ecb.SetComponent(entity, stuck);
+                        }
+                    }
+
+                    // Always write back rotation even when blocked (cosmetic update)
+                    xf.ValueRW = t;
                     continue;
                 }
 
-                t.Position = nextPos;
+                // Not blocked — reset stuck counter
+                if (em.HasComponent<StuckState>(entity))
+                    ecb.SetComponent(entity, new StuckState { Counter = 0, LastAttempt = 0 });
 
+                // === Terrain height snap ===
+                nextPos.y = TerrainUtility.GetHeight(nextPos.x, nextPos.z);
+
+                t.Position = nextPos;
                 xf.ValueRW = t;
             }
         }

--- a/Assets/Scripts/UI/Menus/MultiplayerLobbyUI.cs
+++ b/Assets/Scripts/UI/Menus/MultiplayerLobbyUI.cs
@@ -29,7 +29,7 @@ namespace TheWaningBorder.UI.Menus
         public event Action OnBackPressed;
 
         private const string GameSceneName = "Game";
-        private const int BROADCAST_PORT = 47777;
+        private const int BROADCAST_PORT = 27015;
         private const float BROADCAST_INTERVAL = 1.0f;
         private const float LOBBY_SYNC_INTERVAL = 0.5f;
         private const float DISCOVERY_TIMEOUT = 5.0f;
@@ -455,6 +455,16 @@ namespace TheWaningBorder.UI.Menus
                 _hostSocket.EnableBroadcast = true;
                 Debug.Log($"[MultiplayerLobby] Host listening on port {BROADCAST_PORT}");
             }
+            catch (SocketException se)
+            {
+                string hint = se.SocketErrorCode == SocketError.AddressAlreadyInUse
+                    ? $"Port {BROADCAST_PORT} already in use. Close other game instances."
+                    : se.SocketErrorCode == SocketError.AccessDenied
+                        ? $"Port {BROADCAST_PORT} blocked. Check Windows Firewall settings."
+                        : se.Message;
+                _error = $"Network error: {hint}";
+                Debug.LogError($"[MultiplayerLobby] Host socket error: {hint}");
+            }
             catch (Exception e)
             {
                 _error = $"Failed to start host: {e.Message}";
@@ -478,6 +488,16 @@ namespace TheWaningBorder.UI.Menus
                 _clientPrivatePort = (ushort)((IPEndPoint)_clientPrivateSocket.Client.LocalEndPoint).Port;
 
                 Debug.Log($"[MultiplayerLobby] Client listening on broadcast:{BROADCAST_PORT}, private:{_clientPrivatePort}");
+            }
+            catch (SocketException se)
+            {
+                string hint = se.SocketErrorCode == SocketError.AddressAlreadyInUse
+                    ? $"Port {BROADCAST_PORT} already in use. Close other game instances."
+                    : se.SocketErrorCode == SocketError.AccessDenied
+                        ? $"Port {BROADCAST_PORT} blocked. Check Windows Firewall settings."
+                        : se.Message;
+                _error = $"Network error: {hint}";
+                Debug.LogError($"[MultiplayerLobby] Client socket error: {hint}");
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary
- **Movement system rework**: Remove facingFactor speed scaling (caused diagonal veering/spiraling), replace bilinear flow field interpolation with per-cell lookup + per-unit SmoothedDirection lerp, add StuckState with 3-tier escalation (retry ? perpendicular ? cancel destination)
- **LAN port fix**: Change BROADCAST_PORT from 47777 to 27015 (widely whitelisted gaming port), add SocketException handling with firewall guidance messages

## Test plan
- [ ] Move units diagonally with no obstacles ? straight-line path, no veering/spiral
- [ ] Move units toward building ? flow around it, not stuck
- [ ] Move units into dead-end ? try perpendicular, then cancel after ~0.5s
- [ ] Start multiplayer lobby ? no forbidden port warning
- [ ] Host+Client on LAN ? discovery works on port 27015

?? Generated with [Claude Code](https://claude.com/claude-code)