### PR TITLE
fix(movement): pass snapped destination from manager to lookup

### DIFF
--- a/Assets/Scripts/Core/Components/FlowFieldComponents.cs
+++ b/Assets/Scripts/Core/Components/FlowFieldComponents.cs
@@ -232,30 +232,19 @@ public struct FlowFieldLookup
     private const float BlendRadius = 6f;
 
     /// <summary>
-    /// Given a unit position and its goal, return the movement direction
-    /// using flow fields when available, with smooth blending near the goal.
+    /// Given a unit position, return the movement direction from a cached flow field.
+    /// The snappedDest parameter must come from FlowFieldManager.RequestFlowField()
+    /// (via FlowField.DestinationIndex) to ensure the same snap-to-passable and
+    /// coarse-grid snapping logic is used for both caching and lookup.
     /// Returns the direct-line direction as fallback.
-    /// Mirrors FlowFieldMovementHelper.GetDirection but uses NativeArrays only.
     /// </summary>
-    public float3 GetDirection(float3 position, float3 goal, float3 directDir, float distToGoal)
+    /// <param name="position">Unit's current world position.</param>
+    /// <param name="snappedDest">Snapped destination cell index from FlowField.DestinationIndex, or -1 if no field.</param>
+    /// <param name="directDir">Pre-computed normalized direct-line direction.</param>
+    /// <param name="distToGoal">Pre-computed distance to goal (horizontal).</param>
+    public float3 GetDirection(float3 position, int snappedDest, float3 directDir, float distToGoal)
     {
-        if (!IsValid) return directDir;
-
-        // Convert goal to destination cell index (same snapping as manager)
-        int gx = (int)math.floor((goal.x - Origin.x) / CellSize);
-        int gy = (int)math.floor((goal.z - Origin.z) / CellSize);
-        if (gx < 0 || gx >= GridWidth || gy < 0 || gy >= GridHeight)
-            return directDir;
-
-        int destIndex = gy * GridWidth + gx;
-
-        // Snap to same coarser grid as FlowFieldManager for cache lookup
-        const int SnapCells = 4;
-        int sx = (gx / SnapCells) * SnapCells + SnapCells / 2;
-        int sy = (gy / SnapCells) * SnapCells + SnapCells / 2;
-        sx = math.min(sx, GridWidth - 1);
-        sy = math.min(sy, GridHeight - 1);
-        int snappedDest = sy * GridWidth + sx;
+        if (!IsValid || snappedDest < 0) return directDir;
 
         // Look up slot for this destination
         if (!DestToSlot.TryGetValue(snappedDest, out int slot))

--- a/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
+++ b/Assets/Scripts/Systems/Movement/FlowFieldMovementHelper.cs
@@ -46,20 +46,17 @@ namespace TheWaningBorder.Systems.Movement
             var ffm = FlowFieldManager.Instance;
             if (ffm == null) return directDir;
 
+            // Request flow field (also queues generation if not cached)
+            var field = ffm.RequestFlowField(goal);
+            if (field == null) return directDir;
+
             // Try NativeArray-based lookup first (Burst-compatible path)
             var lookup = ffm.CurrentLookup;
             if (lookup.IsValid)
             {
-                // Ensure flow field is queued for generation
-                ffm.RequestFlowField(goal);
-
-                // Delegate to FlowFieldLookup (same logic, NativeArray-only)
-                return lookup.GetDirection(position, goal, directDir, distToGoal);
+                // Use the manager's snapped destination to avoid lookup mismatch
+                return lookup.GetDirection(position, field.Value.DestinationIndex, directDir, distToGoal);
             }
-
-            // Fallback: direct managed FlowField access (pre-initialization)
-            var field = ffm.RequestFlowField(goal);
-            if (field == null) return directDir;
 
             var grid = PassabilityGrid.Instance;
             if (grid == null) return directDir;

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -266,12 +266,19 @@ namespace TheWaningBorder.Systems.Movement
                 float dist = math.sqrt(distSqr);
                 float3 dir = to / math.max(1e-5f, dist);
 
-                // Pre-warm flow field cache for this destination
+                // Request/lookup flow field for this destination.
+                // The snapped destination index from RequestFlowField ensures the
+                // lookup uses the same cache key as the manager (including snap-to-passable).
+                int snappedDest = -1;
                 if (ffm != null)
-                    ffm.RequestFlowField(goal);
+                {
+                    var field = ffm.RequestFlowField(goal);
+                    if (field.HasValue)
+                        snappedDest = field.Value.DestinationIndex;
+                }
 
                 // Flow-field direction lookup (NativeArray-based, falls back to direct-line)
-                dir = ffLookup.GetDirection(pos, goal, dir, dist);
+                dir = ffLookup.GetDirection(pos, snappedDest, dir, dist);
 
                 // === Per-unit direction smoothing ===
                 // Lerp toward raw flow field direction to prevent cell-boundary oscillation.


### PR DESCRIPTION
## Summary

Fixes flow field direction lookup mismatch that caused units to always use direct-line movement instead of flow field pathfinding.

## Root Cause

`FlowFieldLookup.GetDirection()` was recomputing the snapped destination from the goal position without the snap-to-passable step that `FlowFieldManager.RequestFlowField()` performs. When a destination was near a building (impassable cell), the manager would snap to a passable cell first, then snap to the coarser grid. The lookup only did the coarser grid snap — producing a different cache key → cache miss → direct-line fallback.

## Fix

Pass the snapped destination index from `RequestFlowField()` return value (`FlowField.DestinationIndex`) directly into the lookup, so both sides always use the same cache key.

## Files Changed
- `FlowFieldComponents.cs` — `GetDirection()` now takes `int snappedDest` instead of `float3 goal`
- `MovementSystem.cs` — Gets snapped dest from `RequestFlowField()` return value
- `FlowFieldMovementHelper.cs` — Same pattern for managed fallback path