### PR TITLE
fix(multiplayer): lockstep sync, lobby networking, and AI control

### DIFF
--- a/Assets/Scripts/UI/Menus/MultiplayerLobbyUI.cs
+++ b/Assets/Scripts/UI/Menus/MultiplayerLobbyUI.cs
@@ -717,6 +717,18 @@ namespace TheWaningBorder.UI.Menus
             GameSettings.NetworkRole = NetworkRole.Server;
             GameSettings.LocalPlayerFaction = Faction.Blue;
 
+            // Sync lobby network slot types into LobbyConfig so AI bootstrap
+            // knows which factions are human-controlled
+            GameSettings.FactionToPlayerMapping.Clear();
+            for (int i = 0; i < LobbyConfig.ActiveSlotCount; i++)
+            {
+                LobbyConfig.Slots[i].Type = _networkSlots[i].Type;
+                if (_networkSlots[i].Type == SlotType.Human)
+                {
+                    GameSettings.FactionToPlayerMapping[LobbyConfig.Slots[i].Faction] = (ulong)i;
+                }
+            }
+
             // Notify clients
             string msg = $"{MSG_START}{_port}";
             byte[] data = Encoding.UTF8.GetBytes(msg);
@@ -739,6 +751,18 @@ namespace TheWaningBorder.UI.Menus
             GameSettings.IsMultiplayer = true;
             GameSettings.NetworkRole = NetworkRole.Client;
             GameSettings.LocalPlayerFaction = LobbyConfig.Slots[_mySlotIndex].Faction;
+
+            // Sync lobby network slot types into LobbyConfig so AI bootstrap
+            // knows which factions are human-controlled
+            GameSettings.FactionToPlayerMapping.Clear();
+            for (int i = 0; i < LobbyConfig.ActiveSlotCount; i++)
+            {
+                LobbyConfig.Slots[i].Type = _networkSlots[i].Type;
+                if (_networkSlots[i].Type == SlotType.Human)
+                {
+                    GameSettings.FactionToPlayerMapping[LobbyConfig.Slots[i].Faction] = (ulong)i;
+                }
+            }
 
             Cleanup();
             SceneManager.LoadScene(GameSceneName);


### PR DESCRIPTION
## Summary
- Fix AI controlling human players: FactionToPlayerMapping was never populated
- Fix lobby AccessDenied socket error: use raw Socket with ReuseAddress
- Change broadcast port 27015 to 47515
- Assign NetworkedEntity IDs to all entities for lockstep sync
- Reset NetworkIdGenerator at game start for deterministic IDs

## Test plan
- [ ] Host controls own units (no AI takeover)
- [ ] Joiner controls own units (no AI takeover)
- [ ] Commands sync between host and client
- [ ] No DESYNC errors in console