### PR TITLE
fix(multiplayer): execute local commands in lockstep and deterministic Crystal AI (#169)

### DIFF
--- a/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
+++ b/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
@@ -163,13 +163,27 @@ namespace TheWaningBorder.Multiplayer
             {
                 if (CanAdvanceTick())
                 {
+                    // Store local commands in _remoteCommands so ProcessTick executes them
+                    // alongside any remote commands for deterministic execution order
+                    int futureTick = _currentTick + INPUT_DELAY_TICKS;
+                    if (_localCommandBuffer.Count > 0)
+                    {
+                        if (!_remoteCommands.ContainsKey(futureTick))
+                            _remoteCommands[futureTick] = new Dictionary<int, List<LockstepCommand>>();
+                        _remoteCommands[futureTick][_localPlayerIndex] = new List<LockstepCommand>(_localCommandBuffer);
+                    }
+
+                    // Confirm our own tick so we don't block ourselves
+                    _confirmedTicks[_localPlayerIndex] = Math.Max(
+                        _confirmedTicks.GetValueOrDefault(_localPlayerIndex, -1), futureTick);
+
+                    // Broadcast local commands to remote players
+                    BroadcastTick(futureTick, _localCommandBuffer);
+                    _localCommandBuffer.Clear();
+
                     ProcessTick(_currentTick);
                     _currentTick++;
                     _tickAccumulator -= TICK_DURATION;
-                    
-                    // Send our commands for future tick
-                    BroadcastTick(_currentTick + INPUT_DELAY_TICKS, _localCommandBuffer);
-                    _localCommandBuffer.Clear();
                 }
                 else
                 {

--- a/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
@@ -31,6 +31,7 @@ namespace TheWaningBorder.Systems.Crystal
     public partial class CrystalAISystem : SystemBase
     {
         private float _decisionTimer;
+        private int _decisionTick;  // Deterministic tick counter for multiplayer sync
         private const float DecisionInterval = 5.0f; // AI thinks every 5 seconds
 
         // Building costs (crystal) — tuned so curse expands slowly early
@@ -69,9 +70,11 @@ namespace TheWaningBorder.Systems.Crystal
 
             int crystalBank = resources.Crystal;
 
-            // Get a random seed for this tick
+            // Deterministic random seed — use tick counter, not elapsed time,
+            // so host and client produce identical AI decisions
+            _decisionTick++;
             var random = new Unity.Mathematics.Random(
-                (uint)(World.Time.ElapsedTime * 1000 + 1));
+                (uint)(_decisionTick * 7919 + GameSettings.SpawnSeed + 1));
 
             // Collect query data into temp arrays to iterate safely
             var query = em.CreateEntityQuery(


### PR DESCRIPTION
## Summary

Fixes #169

### Bug 1: Local commands never executed
`ProcessTick()` only read from `_remoteCommands`. Local commands were queued, broadcast to remotes, then cleared — but never stored for local execution. The sender never saw their own commands run.

**Fix:** Before broadcasting, store local commands in `_remoteCommands[futureTick][localPlayerIndex]`. Now `ProcessTick()` executes all commands (local + remote) in deterministic order.

### Bug 2: Crystal AI desync
`CrystalAISystem` seeded Random with `World.Time.ElapsedTime` which differs between host/client. Each client made different AI decisions.

**Fix:** Use deterministic `_decisionTick` counter + `GameSettings.SpawnSeed` instead of elapsed time.

## Test plan
- [ ] Host moves unit -> client sees it move
- [ ] Client moves unit -> host sees it move
- [ ] Crystal AI behaves identically on both clients
- [ ] No DESYNC errors in console