### PR TITLE
fix(multiplayer): initialize lockstep synchronously before AI

### DIFF
--- a/Assets/Scripts/Bootstrap/GameBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/GameBootstrap.cs
@@ -19,6 +19,7 @@ using TheWaningBorder.UI.Panels;
 using TheWaningBorder.UI.HUD;
 using TheWaningBorder.Systems.Research;
 using TheWaningBorder.Systems.Movement;
+using TheWaningBorder.Multiplayer;
 
 namespace TheWaningBorder.Bootstrap
 {
@@ -73,6 +74,13 @@ namespace TheWaningBorder.Bootstrap
                 ScenarioSetup.Bootstrap();
                 Debug.Log($"[GameBootstrap] Scenario mode initialized: {GameSettings.ActiveScenario}");
                 return;
+            }
+
+            // 0.5. Initialize lockstep BEFORE anything else in multiplayer
+            // This ensures LockstepServiceLocator.Instance is available when commands are issued
+            if (GameSettings.IsMultiplayer && LockstepBootstrap.Instance != null)
+            {
+                LockstepBootstrap.Instance.InitializeLockstepNow();
             }
 
             // 1. Initialize core data systems (TechTreeDB)

--- a/Assets/Scripts/Core/Multiplayer/ILockstepService.cs
+++ b/Assets/Scripts/Core/Multiplayer/ILockstepService.cs
@@ -23,6 +23,11 @@ namespace TheWaningBorder.Core.Multiplayer
         bool IsHost { get; }
         
         /// <summary>
+        /// Current simulation tick number. Used for deterministic seeding.
+        /// </summary>
+        int CurrentTick { get; }
+
+        /// <summary>
         /// Queue a command for lockstep synchronization.
         /// </summary>
         void QueueCommand(LockstepCommand cmd);

--- a/Assets/Scripts/Multiplayer/Lockstep/LockstepBootstrap.cs
+++ b/Assets/Scripts/Multiplayer/Lockstep/LockstepBootstrap.cs
@@ -92,25 +92,29 @@ namespace TheWaningBorder.Multiplayer
         {
             // Only initialize in the Game scene
             if (scene.name != "Game") return;
-            
-            // Don't re-initialize
+
+            // Don't re-initialize (may have been called synchronously by GameBootstrap already)
             if (_initialized) return;
-            
+
             // Only for multiplayer games
             if (!GameSettings.IsMultiplayer) return;
 
-            StartCoroutine(InitializeLockstep());
+            // Fallback: if GameBootstrap didn't call InitializeLockstepNow(), do it via coroutine
+            StartCoroutine(InitializeLockstepDeferred());
         }
 
-        private IEnumerator InitializeLockstep()
+        /// <summary>
+        /// Initialize lockstep SYNCHRONOUSLY. Called by GameBootstrap BEFORE AI initialization
+        /// to guarantee LockstepServiceLocator.Instance is available when commands are first issued.
+        /// </summary>
+        public void InitializeLockstepNow()
         {
-            // Wait for scene to fully load and entities to be created
-            yield return null;
-            yield return null;
+            if (_initialized) return;
+            if (!GameSettings.IsMultiplayer) return;
 
-            Debug.Log($"[LockstepBootstrap] Initializing - IsHost: {IsHost}, LocalPlayer: {LocalPlayerIndex}, Faction: {LocalFaction}");
+            Debug.Log($"[LockstepBootstrap] Initializing synchronously - IsHost: {IsHost}, LocalPlayer: {LocalPlayerIndex}, Faction: {LocalFaction}");
 
-            // Create LockstepManager if needed
+            // Create LockstepManager
             var lockstep = LockstepManager.Instance;
             if (lockstep == null)
             {
@@ -128,14 +132,22 @@ namespace TheWaningBorder.Multiplayer
                 lockstep.InitializeAsClient(LocalPort, HostIP, HostPort, LocalPlayerIndex, LocalFaction);
             }
 
-            // Wait for network ID assignment
-            yield return null;
-
-            // Start simulation
+            // Start simulation immediately
             lockstep.StartSimulation();
 
             _initialized = true;
-            Debug.Log("[LockstepBootstrap] Lockstep simulation started!");
+            Debug.Log("[LockstepBootstrap] Lockstep simulation started (synchronous)!");
+        }
+
+        private IEnumerator InitializeLockstepDeferred()
+        {
+            // Fallback path — only used if GameBootstrap didn't call InitializeLockstepNow()
+            yield return null;
+            yield return null;
+
+            if (_initialized) yield break; // Already initialized synchronously
+
+            InitializeLockstepNow();
         }
 
         // ═══════════════════════════════════════════════════════════════════════

--- a/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
+++ b/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
@@ -108,6 +108,11 @@ namespace TheWaningBorder.Multiplayer
         public bool IsHost => _isHost;
 
         /// <summary>
+        /// Current simulation tick number. Used for deterministic seeding.
+        /// </summary>
+        public int CurrentTick => _currentTick;
+
+        /// <summary>
         /// Queue a command for lockstep synchronization.
         /// </summary>
         public void QueueCommand(LockstepCommand cmd)

--- a/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
@@ -8,6 +8,7 @@ using Unity.Mathematics;
 using Unity.Transforms;
 using TheWaningBorder.Entities;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Core.Multiplayer;
 using TheWaningBorder.World.Terrain;
 using Cost = TheWaningBorder.Core.Cost;
 
@@ -70,9 +71,12 @@ namespace TheWaningBorder.Systems.Crystal
 
             int crystalBank = resources.Crystal;
 
-            // Deterministic random seed — use tick counter, not elapsed time,
-            // so host and client produce identical AI decisions
-            _decisionTick++;
+            // Deterministic random seed — in multiplayer, use lockstep tick (guaranteed
+            // synchronized between host and client). In singleplayer, use local counter.
+            if (GameSettings.IsMultiplayer && LockstepServiceLocator.IsActive)
+                _decisionTick = LockstepServiceLocator.Instance.CurrentTick;
+            else
+                _decisionTick++;
             var random = new Unity.Mathematics.Random(
                 (uint)(_decisionTick * 7919 + GameSettings.SpawnSeed + 1));
 


### PR DESCRIPTION
## Summary
- Fix critical timing bug: LockstepManager was created 3 frames after GameBootstrap ran
- LockstepServiceLocator.Instance was null when commands were first issued
- All commands executed locally instead of being queued for lockstep sync
- Add synchronous InitializeLockstepNow() called before AI init
- Use lockstep tick for CrystalAISystem random seed (deterministic across clients)

## Test plan
- Start multiplayer game (host + client)
- Move unit on host -> client sees it move
- Move unit on client -> host sees it move
- Crystal curse behaves identically on both screens