### PR TITLE
fix(combat): battalion pop cap, building crystal buffs, cadaver mining (#185)

### DIFF
--- a/Assets/Scripts/AI/Managers/AIEconomyManager.cs
+++ b/Assets/Scripts/AI/Managers/AIEconomyManager.cs
@@ -706,6 +706,7 @@ namespace TheWaningBorder.AI
                 .WithEntityAccess())
             {
                 if (cadaverState.ValueRO.Depleted == 1) continue;
+                if (cadaverState.ValueRO.RemainingCrystal <= 0) continue;
                 cadaverList.Add(entity);
                 cadaverPositions.Add(transform.ValueRO.Position);
             }

--- a/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
@@ -108,11 +108,28 @@ namespace TheWaningBorder.Systems.Combat
                     if (em.HasComponent<DamageTypeData>(entity))
                         dmgType = em.GetComponentData<DamageTypeData>(entity).Value;
 
+                    // Crystal buff/debuff modifiers (same pattern as MeleeCombatSystem)
+                    float attackerCrystalMod = 1.0f;
+                    if (em.HasComponent<CrystalBuff>(entity))
+                    {
+                        var buff = em.GetComponentData<CrystalBuff>(entity);
+                        attackerCrystalMod *= 1f + buff.AttBonus;
+                    }
+
                     for (int t = 0; t < targets.Length; t++)
                     {
+                        // Apply crystal debuff on target
+                        float crystalMod = attackerCrystalMod;
+                        if (em.HasComponent<CrystalDebuff>(targets[t].Entity))
+                        {
+                            var debuff = em.GetComponentData<CrystalDebuff>(targets[t].Entity);
+                            crystalMod *= 1f + debuff.AttPenalty;
+                        }
+
+                        int modifiedDamage = math.max(1, (int)(attack.ValueRO.Damage * crystalMod));
                         CreateProjectile(ref ecb, myPos, targets[t].Position,
                             targets[t].Distance, entity, myFaction,
-                            attack.ValueRO.Damage, time, targets[t].Entity, isCrystal, dmgType);
+                            modifiedDamage, time, targets[t].Entity, isCrystal, dmgType);
                     }
                     attack.ValueRW.Timer = attack.ValueRO.Cooldown;
                 }

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -99,6 +99,14 @@ namespace TheWaningBorder.Systems.Training
                         var faction = em.GetComponentData<FactionTag>(entity).Value;
                         int requiredPop = PopulationHelper.GetUnitPopulationCost(unitId);
 
+                        // Battalions spawn multiple members — scale pop cost accordingly
+                        var spawnClass = UnitFactory.GetUnitClass(unitId);
+                        if (spawnClass == UnitClass.Melee || spawnClass == UnitClass.Ranged)
+                        {
+                            int battalionSize = 5 * 3; // BattalionFactory.DefaultColumns * DefaultRows
+                            requiredPop = requiredPop * battalionSize;
+                        }
+
                         // Include units already spawned this frame in the capacity check
                         int facKey = (int)faction;
                         spawnedPopThisFrame.TryGetValue(facKey, out int extraSpawned);


### PR DESCRIPTION
## Summary

Fixes three bugs from #185:

- **TrainingSystem**: Battalion spawns (Melee/Ranged) now correctly account for 15-member pop cost instead of 1, preventing multiple barracks from exceeding the population cap in the same frame.
- **BuildingCombatSystem**: Building ranged attacks now apply CrystalBuff (attacker) and CrystalDebuff (target) damage modifiers, matching the pattern used in MeleeCombatSystem.
- **AIEconomyManager**: Cadaver assignment now skips cadavers where `RemainingCrystal <= 0`, even if the `Depleted` flag hasn't been set yet.

## Test plan

- [ ] Verify two barracks training battalions simultaneously cannot exceed pop cap
- [ ] Verify crystal-buffed buildings deal increased damage
- [ ] Verify buildings attacking crystal-debuffed targets deal increased damage
- [ ] Verify AI miners no longer get stuck walking to empty cadavers

Closes #185