### PR TITLE
fix(combat): prevent LastDamagedByFaction crash and standardize projectile spawns

### DIFF
--- a/Assets/Scripts/Core/Settings/CrystalConstants.cs.meta
+++ b/Assets/Scripts/Core/Settings/CrystalConstants.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 57db128b1c5f4aa4ea6f9c0dcb8e80d2

--- a/Assets/Scripts/Presentation/ProceduralUnitGenerator.cs.meta
+++ b/Assets/Scripts/Presentation/ProceduralUnitGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd3a3671c46fe1b47a641d14bf5356c5

--- a/Assets/Scripts/Presentation/UnitAnimationSync.cs.meta
+++ b/Assets/Scripts/Presentation/UnitAnimationSync.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5a5746c5f73e0714fa9fdbc9b392ff47

--- a/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
@@ -19,6 +19,7 @@ namespace TheWaningBorder.Systems.Combat
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<BuildingRangedAttack>();
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
         }
 
         public void OnUpdate(ref SystemState state)
@@ -26,7 +27,8 @@ namespace TheWaningBorder.Systems.Combat
             float dt = SystemAPI.Time.DeltaTime;
             float time = (float)SystemAPI.Time.ElapsedTime;
             var em = state.EntityManager;
-            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
+            var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
 
             // Snapshot all potential targets (anything with Health + FactionTag + Transform)
             var targetQuery = SystemAPI.QueryBuilder()
@@ -116,6 +118,11 @@ namespace TheWaningBorder.Systems.Combat
                         attackerCrystalMod *= 1f + buff.AttBonus;
                     }
 
+                    // Spawn height: use entity's Radius + 0.5f (taller buildings shoot higher)
+                    float spawnYOffset = em.HasComponent<Radius>(entity)
+                        ? em.GetComponentData<Radius>(entity).Value + 0.5f
+                        : 1.5f;
+
                     for (int t = 0; t < targets.Length; t++)
                     {
                         // Apply crystal debuff on target
@@ -129,7 +136,7 @@ namespace TheWaningBorder.Systems.Combat
                         int modifiedDamage = math.max(1, (int)(attack.ValueRO.Damage * crystalMod));
                         CreateProjectile(ref ecb, myPos, targets[t].Position,
                             targets[t].Distance, entity, myFaction,
-                            modifiedDamage, time, targets[t].Entity, isCrystal, dmgType);
+                            modifiedDamage, time, targets[t].Entity, isCrystal, dmgType, spawnYOffset);
                     }
                     attack.ValueRW.Timer = attack.ValueRO.Cooldown;
                 }
@@ -141,15 +148,12 @@ namespace TheWaningBorder.Systems.Combat
             tgtTransforms.Dispose();
             tgtFactions.Dispose();
             tgtHealth.Dispose();
-
-            ecb.Playback(em);
-            ecb.Dispose();
         }
 
         private static void CreateProjectile(ref EntityCommandBuffer ecb,
             float3 start, float3 targetPos, float distance,
             Entity shooter, Faction faction, int damage, float time, Entity target,
-            bool isLaser = false, DamageType dmgType = DamageType.Ranged)
+            bool isLaser = false, DamageType dmgType = DamageType.Ranged, float spawnYOffset = 1.5f)
         {
             float speed = isLaser ? LaserSpeed : ArrowSpeed;
             var direction = math.normalize(targetPos - start);
@@ -174,7 +178,7 @@ namespace TheWaningBorder.Systems.Combat
 
             ecb.AddComponent(projectile, new LocalTransform
             {
-                Position = start + new float3(0, 3f, 0), // Spawn above building
+                Position = start + new float3(0, spawnYOffset, 0),
                 Rotation = quaternion.LookRotation(velocity, new float3(0, 1, 0)),
                 Scale = 1f
             });

--- a/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
@@ -177,12 +177,17 @@ namespace TheWaningBorder.Systems.Combat
                         if (em.HasComponent<DamageTypeData>(entity))
                             dmgType = em.GetComponentData<DamageTypeData>(entity).Value;
 
+                        // Spawn height: use entity's Radius + 0.5f (taller units shoot higher)
+                        float spawnYOffset = em.HasComponent<Radius>(entity)
+                            ? em.GetComponentData<Radius>(entity).Value + 0.5f
+                            : 1.5f;
+
                         // Create arrow projectile
                         bool isAOE = em.HasComponent<AOEShooterData>(entity);
                         float aoeRadius = isAOE ? em.GetComponentData<AOEShooterData>(entity).Radius : 0f;
                         CreateArrow(ref ecb, myPos, targetPos, dist, entity,
                             faction.ValueRO.Value, finalDamage, (float)time, tgt.Value, dmgType,
-                            isAOE, aoeRadius);
+                            isAOE, aoeRadius, spawnYOffset);
 
                         // Reset state — use unit's configured cooldown
                         float cooldownValue = 1.5f;
@@ -274,7 +279,8 @@ namespace TheWaningBorder.Systems.Combat
         /// </summary>
         private void CreateArrow(ref EntityCommandBuffer ecb, float3 start, float3 targetPos,
             float distance, Entity shooter, Faction faction, int damage, float time, Entity targetEntity,
-            DamageType dmgType = DamageType.Ranged, bool isAOE = false, float aoeRadius = 0f)
+            DamageType dmgType = DamageType.Ranged, bool isAOE = false, float aoeRadius = 0f,
+            float spawnYOffset = 1.5f)
         {
             // Calculate initial velocity towards target
             var direction = math.normalize(targetPos - start);
@@ -297,7 +303,7 @@ namespace TheWaningBorder.Systems.Combat
 
             ecb.AddComponent(arrow, new LocalTransform
             {
-                Position = start + new float3(0, 1.5f, 0), // Spawn at archer height
+                Position = start + new float3(0, spawnYOffset, 0),
                 Rotation = quaternion.LookRotation(velocity, new float3(0, 1, 0)),
                 Scale = 1f
             });

--- a/Assets/Scripts/Systems/Crystal/CrystalExtinctionSystem.cs.meta
+++ b/Assets/Scripts/Systems/Crystal/CrystalExtinctionSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fb0a97794f4d94848b61e7b8ab633ea0

--- a/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/GodsplinterCombatSystem.cs
@@ -140,19 +140,24 @@ namespace TheWaningBorder.Systems.Crystal
                     int siegeFinal = CombatModifiers.CalculateFinalDamage(
                         siegeDmg, dmgType, armorType, defenseValue, 1.0f, crystalMod);
 
-                    // Apply direct damage to target
+                    // Apply direct damage to target — use immediate write so multiple attackers
+                    // in the same frame correctly stack damage (not last-write-wins via ECB)
                     var health = em.GetComponentData<Health>(tgt.Value);
                     health.Value -= siegeFinal;
                     if (health.Value < 0) health.Value = 0;
-                    ecb.SetComponent(tgt.Value, health);
+                    em.SetComponentData(tgt.Value, health);
 
                     // Track last damager faction for kill credit (used by PillageSystem, CaravanDeathSystem)
                     if (em.HasComponent<FactionTag>(entity))
                     {
-                        ecb.AddComponent(tgt.Value, new LastDamagedByFaction
+                        var lastDamaged = new LastDamagedByFaction
                         {
                             Value = em.GetComponentData<FactionTag>(entity).Value
-                        });
+                        };
+                        if (em.HasComponent<LastDamagedByFaction>(tgt.Value))
+                            em.SetComponentData(tgt.Value, lastDamaged);
+                        else
+                            ecb.AddComponent(tgt.Value, lastDamaged);
                     }
 
                     // Reset siege cooldown
@@ -222,11 +227,16 @@ namespace TheWaningBorder.Systems.Crystal
                         }
                     }
 
+                    // Spawn height: use entity's Radius + 0.5f (taller units shoot higher)
+                    float spawnYOffset = em.HasComponent<Radius>(entity)
+                        ? em.GetComponentData<Radius>(entity).Value + 0.5f
+                        : 1.5f;
+
                     // Fire laser at each target
                     for (int t = 0; t < targets.Length; t++)
                     {
                         CreateLaser(ref ecb, myPos, targets[t].Position,
-                            targets[t].Distance, entity, myFaction, laserDmg, time, targets[t].Entity, dmgType);
+                            targets[t].Distance, entity, myFaction, laserDmg, time, targets[t].Entity, dmgType, spawnYOffset);
                     }
 
                     if (targets.Length > 0)
@@ -280,7 +290,7 @@ namespace TheWaningBorder.Systems.Crystal
         /// </summary>
         private static void CreateLaser(ref EntityCommandBuffer ecb, float3 start, float3 targetPos,
             float distance, Entity shooter, Faction faction, int damage, float time, Entity targetEntity,
-            DamageType dmgType = DamageType.Siege)
+            DamageType dmgType = DamageType.Siege, float spawnYOffset = 1.5f)
         {
             var direction = math.normalize(targetPos - start);
             var velocity = direction * LaserSpeed;
@@ -290,7 +300,7 @@ namespace TheWaningBorder.Systems.Crystal
 
             ecb.AddComponent(laser, new LocalTransform
             {
-                Position = start + new float3(0, 2.5f, 0), // Spawn above Godsplinter (tall unit)
+                Position = start + new float3(0, spawnYOffset, 0),
                 Rotation = quaternion.LookRotation(velocity, new float3(0, 1, 0)),
                 Scale = 1f
             });

--- a/Assets/Scripts/Systems/Crystal/VeilstingerCombatSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/VeilstingerCombatSystem.cs
@@ -32,8 +32,8 @@ namespace TheWaningBorder.Systems.Crystal
         // Gun offset constants relative to the unit's center
         // These approximate the leftgun/rightgun child positions on the Veilstinger prefab
         private const float GunSideOffset = 0.5f;   // Left/right distance from center
-        private const float GunHeightOffset = 1.2f;  // Height above ground
         private const float GunForwardOffset = 0.3f; // Slightly in front of center
+        private const float DefaultSpawnYOffset = 1.5f; // Fallback if no Radius component
 
         // Cached query — created once in OnCreate, reused every frame
         private EntityQuery _targetQuery;
@@ -168,6 +168,11 @@ namespace TheWaningBorder.Systems.Crystal
                         if (em.HasComponent<DamageTypeData>(entity))
                             dmgType = em.GetComponentData<DamageTypeData>(entity).Value;
 
+                        // Spawn height: use entity's Radius + 0.5f (taller units shoot higher)
+                        float gunHeight = em.HasComponent<Radius>(entity)
+                            ? em.GetComponentData<Radius>(entity).Value + 0.5f
+                            : DefaultSpawnYOffset;
+
                         // Compute gun world positions based on facing direction
                         var facingDir = math.normalizesafe(
                             new float3(targetPos.x - myPos.x, 0, targetPos.z - myPos.z),
@@ -177,12 +182,12 @@ namespace TheWaningBorder.Systems.Crystal
                         float3 leftGunPos = myPos
                             + facingDir * GunForwardOffset
                             - rightDir * GunSideOffset
-                            + new float3(0, GunHeightOffset, 0);
+                            + new float3(0, gunHeight, 0);
 
                         float3 rightGunPos = myPos
                             + facingDir * GunForwardOffset
                             + rightDir * GunSideOffset
-                            + new float3(0, GunHeightOffset, 0);
+                            + new float3(0, gunHeight, 0);
 
                         // Fire primary laser from left gun at Target1
                         CreateLaserFromGun(ref ecb, leftGunPos, targetPos,

--- a/Assets/Scripts/UI/HUD/ActiveAbilityBar.cs.meta
+++ b/Assets/Scripts/UI/HUD/ActiveAbilityBar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 16b30c3818e8b24418a2425fad9254e3

--- a/Assets/Scripts/UI/HUD/CrystalDebugPanel.cs.meta
+++ b/Assets/Scripts/UI/HUD/CrystalDebugPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9eff7d1d79e0e8438042160896a8696

--- a/Assets/Scripts/UI/HUD/SectPassiveHUD.cs.meta
+++ b/Assets/Scripts/UI/HUD/SectPassiveHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9c53d3ee90182145bf7b6ac837ccf67


### PR DESCRIPTION
## Summary
- **GodsplinterCombatSystem**: Fix crash from `ecb.AddComponent<LastDamagedByFaction>` on entities that already have it. Now checks `HasComponent` first; uses `SetComponentData` if present, `AddComponent` if not. Also switched siege damage to direct `em.SetComponentData` (matching MeleeCombatSystem pattern) so multiple attackers in the same frame stack correctly.
- **BuildingCombatSystem**: Replaced raw `new EntityCommandBuffer(Allocator.Temp)` + immediate `Playback()` with deferred `EndSimulationEntityCommandBufferSystem` ECB, matching the pattern used by all other combat systems.
- **Arrow spawn height standardization**: All 4 ranged combat systems (RangedCombatSystem, BuildingCombatSystem, GodsplinterCombatSystem, VeilstingerCombatSystem) now use `Radius + 0.5f` as projectile spawn Y offset, so taller entities shoot from higher. Falls back to 1.5f if no Radius component.

Closes #187

## Test plan
- [ ] Verify Godsplinters can siege the same target repeatedly without crash
- [ ] Verify buildings fire projectiles at correct height (should scale with building size)
- [ ] Verify archers and crystal units fire from appropriate heights
- [ ] Verify kill credit tracking still works after Godsplinter siege kills

?? Generated with [Claude Code](https://claude.com/claude-code)