### PR TITLE
fix(crystal): crystal integration fixes (#186)

### DIFF
--- a/Assets/Scripts/AI/Behaviors/AICrystalHuntBehavior.cs
+++ b/Assets/Scripts/AI/Behaviors/AICrystalHuntBehavior.cs
@@ -84,12 +84,29 @@ namespace TheWaningBorder.AI
             if (!foundBase) return;
 
             // Collect crystal faction entities within hunt range of base
+            // First: crystal units (primary targets)
             var creatures = new NativeList<Entity>(Allocator.Temp);
             var creaturePositions = new NativeList<float3>(Allocator.Temp);
 
             foreach (var (factionTag, transform, entity) in
                 SystemAPI.Query<RefRO<FactionTag>, RefRO<LocalTransform>>()
                 .WithAll<CrystalTag, UnitTag>()
+                .WithEntityAccess())
+            {
+                if (factionTag.ValueRO.Value != Faction.White) continue;
+
+                float dist = math.distance(basePos, transform.ValueRO.Position);
+                if (dist <= HUNT_RANGE)
+                {
+                    creatures.Add(entity);
+                    creaturePositions.Add(transform.ValueRO.Position);
+                }
+            }
+
+            // Second: crystal buildings as fallback targets (anything crystal with Health)
+            foreach (var (factionTag, transform, health, entity) in
+                SystemAPI.Query<RefRO<FactionTag>, RefRO<LocalTransform>, RefRO<Health>>()
+                .WithAll<CrystalTag, BuildingTag>()
                 .WithEntityAccess())
             {
                 if (factionTag.ValueRO.Value != Faction.White) continue;

--- a/Assets/Scripts/AI/Managers/AIBuildingManager.cs
+++ b/Assets/Scripts/AI/Managers/AIBuildingManager.cs
@@ -265,6 +265,10 @@ namespace TheWaningBorder.AI
             float buildTime = GetBuildTime(buildingId);
             ecb.AddComponent(building, new UnderConstruction { Progress = 0f, Total = buildTime });
 
+            // Set initial scale to 0.3f so buildings don't appear full-size before first construction tick
+            ecb.SetComponent(building, LocalTransform.FromPositionRotationScale(
+                req.DesiredPosition, quaternion.identity, 0.3f));
+
             // Set HP to 1 during construction (restored to max on completion)
             int maxHP = GetDefaultMaxHP(buildingId);
             ecb.SetComponent(building, new Health { Value = 1, Max = maxHP });

--- a/Assets/Scripts/Core/Components/CrystalComponents.cs
+++ b/Assets/Scripts/Core/Components/CrystalComponents.cs
@@ -39,16 +39,23 @@ public struct CrystalSubNodeTag : IComponentData
 /// </summary>
 public struct CrystalNode : IComponentData
 {
-    public float SpreadPerTick;     // Cells per tick (logical units)
-    public float SpreadRadius;      // World radius
-    public float TickInterval;      // Seconds between ticks
-    public float TickTimer;         // Accumulated time
-    public float CurrentRingRadius; // Current outer edge of the spread wavefront
+    public float SpreadRadius;      // World radius (territory radius)
     public byte Enabled;
 }
 
 /// <summary>
-/// Per-node level derived from CurrentRingRadius.
+/// Runtime state for crystal spread progression.
+/// Tracks the expanding ring wavefront per-node (used by CrystalSpreadSystem).
+/// Separated from CrystalNode to keep config fields distinct from runtime state.
+/// </summary>
+public struct CrystalSpreadState : IComponentData
+{
+    public float TickTimer;         // Accumulated time since last spread tick
+    public float CurrentRingRadius; // Current outer edge of the spread wavefront
+}
+
+/// <summary>
+/// Per-node level derived from CrystalSpreadState.CurrentRingRadius.
 /// Level 1 (radius 0-5):  Fast spread, only Crystallings — easy to farm.
 /// Level 2 (radius 5-10): Moderate spread, Veilstingers unlocked.
 /// Level 3 (radius 10+):  Slow spread, Godsplinters unlocked — dangerous.

--- a/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
@@ -29,6 +29,7 @@ namespace TheWaningBorder.Entities
                 typeof(CrystalTag),
                 typeof(CrystalMainNodeTag),
                 typeof(CrystalNode),
+                typeof(CrystalSpreadState),
                 typeof(CrystalNodeLevel),
                 typeof(CrystalAIState),
                 typeof(CrystalResourceValue),
@@ -44,13 +45,10 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new BuildingTag { IsBase = 0 });
             em.SetComponentData(entity, new CrystalNode
             {
-                SpreadPerTick = MainNodeSpreadPerTick,
                 SpreadRadius = MainNodeSpreadRadius,
-                TickInterval = MainNodeTickInterval,
-                TickTimer = 0f,
-                CurrentRingRadius = 0f,
                 Enabled = 1
             });
+            em.SetComponentData(entity, new CrystalSpreadState { TickTimer = 0f, CurrentRingRadius = 0f });
             em.SetComponentData(entity, new CrystalNodeLevel { Value = 1 });
             em.SetComponentData(entity, new CrystalAIState
             {
@@ -106,13 +104,10 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent<CrystalMainNodeTag>(entity);
             ecb.AddComponent(entity, new CrystalNode
             {
-                SpreadPerTick = MainNodeSpreadPerTick,
                 SpreadRadius = MainNodeSpreadRadius,
-                TickInterval = MainNodeTickInterval,
-                TickTimer = 0f,
-                CurrentRingRadius = 0f,
                 Enabled = 1
             });
+            ecb.AddComponent(entity, new CrystalSpreadState { TickTimer = 0f, CurrentRingRadius = 0f });
             ecb.AddComponent(entity, new CrystalNodeLevel { Value = 1 });
             ecb.AddComponent(entity, new CrystalAIState
             {

--- a/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
@@ -28,6 +28,7 @@ namespace TheWaningBorder.Entities
                 typeof(CrystalTag),
                 typeof(CrystalSubNodeTag),
                 typeof(CrystalNode),
+                typeof(CrystalSpreadState),
                 typeof(CrystalResourceValue),
                 typeof(OwnerNode)
             );
@@ -41,13 +42,10 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Resource });
             em.SetComponentData(entity, new CrystalNode
             {
-                SpreadPerTick = ResourceNodeSpreadPerTick,
                 SpreadRadius = ResourceNodeSpreadRadius,
-                TickInterval = ResourceNodeTickInterval,
-                TickTimer = 0f,
-                CurrentRingRadius = 0f,
                 Enabled = 1
             });
+            em.SetComponentData(entity, new CrystalSpreadState { TickTimer = 0f, CurrentRingRadius = 0f });
             em.SetComponentData(entity, new CrystalResourceValue { BuildCost = ResourceNodeBuildCost });
             em.SetComponentData(entity, new OwnerNode { Value = Entity.Null });
 
@@ -81,13 +79,10 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new CrystalSubNodeTag { Type = CrystalSubNodeType.Resource });
             ecb.AddComponent(entity, new CrystalNode
             {
-                SpreadPerTick = ResourceNodeSpreadPerTick,
                 SpreadRadius = ResourceNodeSpreadRadius,
-                TickInterval = ResourceNodeTickInterval,
-                TickTimer = 0f,
-                CurrentRingRadius = 0f,
                 Enabled = 1
             });
+            ecb.AddComponent(entity, new CrystalSpreadState { TickTimer = 0f, CurrentRingRadius = 0f });
             ecb.AddComponent(entity, new CrystalResourceValue { BuildCost = ResourceNodeBuildCost });
             ecb.AddComponent(entity, new OwnerNode { Value = Entity.Null });
 

--- a/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
@@ -4,6 +4,7 @@ using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
+using static TheWaningBorder.Core.Config.CrystalConstants;
 
 namespace TheWaningBorder.Systems.Creatures
 {
@@ -69,33 +70,34 @@ namespace TheWaningBorder.Systems.Creatures
             }
 
             // === Main Node Spread ===
-            foreach (var (crystalNode, nodeLevel, transform, entity) in SystemAPI
-                .Query<RefRW<CrystalNode>, RefRW<CrystalNodeLevel>, RefRO<LocalTransform>>()
+            foreach (var (crystalNode, spreadState, nodeLevel, transform, entity) in SystemAPI
+                .Query<RefRO<CrystalNode>, RefRW<CrystalSpreadState>, RefRW<CrystalNodeLevel>, RefRO<LocalTransform>>()
                 .WithAll<CrystalMainNodeTag>()
                 .WithEntityAccess())
             {
-                ref var node = ref crystalNode.ValueRW;
-                if (node.Enabled == 0) continue;
+                if (crystalNode.ValueRO.Enabled == 0) continue;
+
+                ref var spread = ref spreadState.ValueRW;
 
                 // Update node level from current spread radius
-                nodeLevel.ValueRW.Value = CrystalNodeLevel.FromRadius(node.CurrentRingRadius);
+                nodeLevel.ValueRW.Value = CrystalNodeLevel.FromRadius(spread.CurrentRingRadius);
 
-                // Tick timer
-                node.TickTimer += dt;
-                if (node.TickTimer < node.TickInterval) continue;
-                node.TickTimer = 0f;
+                // Tick timer (interval from CrystalConstants)
+                spread.TickTimer += dt;
+                if (spread.TickTimer < MainNodeTickInterval) continue;
+                spread.TickTimer = 0f;
 
                 // Ring already at max radius -- nothing to spread
-                if (node.CurrentRingRadius >= node.SpreadRadius) continue;
+                if (spread.CurrentRingRadius >= crystalNode.ValueRO.SpreadRadius) continue;
 
                 // Level-based ring step: fast early, slow late
                 int level = nodeLevel.ValueRW.Value;
                 float ringStep = level == 1 ? 3.0f : level == 2 ? 2.0f : 1.0f;
 
                 // Advance the ring frontier
-                float prevRadius = node.CurrentRingRadius;
-                float newRadius = math.min(prevRadius + ringStep, node.SpreadRadius);
-                node.CurrentRingRadius = newRadius;
+                float prevRadius = spread.CurrentRingRadius;
+                float newRadius = math.min(prevRadius + ringStep, crystalNode.ValueRO.SpreadRadius);
+                spread.CurrentRingRadius = newRadius;
 
                 // Per-node budget check
                 int perNodeBudget = MaxTilesPerNode - (existingGroundTotal / math.max(1, nodeCount));
@@ -108,8 +110,8 @@ namespace TheWaningBorder.Systems.Creatures
             }
 
             // === Resource Sub-Node Spread ===
-            foreach (var (crystalNode, transform, subTag, entity) in SystemAPI
-                .Query<RefRW<CrystalNode>, RefRO<LocalTransform>, RefRO<CrystalSubNodeTag>>()
+            foreach (var (crystalNode, spreadState, transform, subTag, entity) in SystemAPI
+                .Query<RefRO<CrystalNode>, RefRW<CrystalSpreadState>, RefRO<LocalTransform>, RefRO<CrystalSubNodeTag>>()
                 .WithAll<CrystalSubNodeTag>()
                 .WithNone<CrystalMainNodeTag>()
                 .WithEntityAccess())
@@ -117,22 +119,23 @@ namespace TheWaningBorder.Systems.Creatures
                 // Only Resource sub-nodes spread cursed ground
                 if (subTag.ValueRO.Type != CrystalSubNodeType.Resource) continue;
 
-                ref var node = ref crystalNode.ValueRW;
-                if (node.Enabled == 0) continue;
+                if (crystalNode.ValueRO.Enabled == 0) continue;
 
-                // Tick timer
-                node.TickTimer += dt;
-                if (node.TickTimer < node.TickInterval) continue;
-                node.TickTimer = 0f;
+                ref var spread = ref spreadState.ValueRW;
+
+                // Tick timer (interval from CrystalConstants)
+                spread.TickTimer += dt;
+                if (spread.TickTimer < ResourceNodeTickInterval) continue;
+                spread.TickTimer = 0f;
 
                 // Ring already at max radius -- nothing to spread
-                if (node.CurrentRingRadius >= node.SpreadRadius) continue;
+                if (spread.CurrentRingRadius >= crystalNode.ValueRO.SpreadRadius) continue;
 
                 float ringStep = BaseRingStep;
 
-                float prevRadius = node.CurrentRingRadius;
-                float newRadius = math.min(prevRadius + ringStep, node.SpreadRadius);
-                node.CurrentRingRadius = newRadius;
+                float prevRadius = spread.CurrentRingRadius;
+                float newRadius = math.min(prevRadius + ringStep, crystalNode.ValueRO.SpreadRadius);
+                spread.CurrentRingRadius = newRadius;
 
                 int perNodeBudget = MaxTilesPerNode - (existingGroundTotal / math.max(1, nodeCount));
                 if (perNodeBudget <= 0) continue;

--- a/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
@@ -68,6 +68,7 @@ namespace TheWaningBorder.Systems.Crystal
             _mainNodeQuery = EntityManager.CreateEntityQuery(
                 ComponentType.ReadWrite<CrystalAIState>(),
                 ComponentType.ReadOnly<CrystalNode>(),
+                ComponentType.ReadOnly<CrystalSpreadState>(),
                 ComponentType.ReadOnly<CrystalNodeLevel>(),
                 ComponentType.ReadOnly<LocalTransform>(),
                 ComponentType.ReadOnly<CrystalMainNodeTag>()
@@ -127,6 +128,7 @@ namespace TheWaningBorder.Systems.Crystal
             using var entities = _mainNodeQuery.ToEntityArray(Allocator.Temp);
             using var aiStates = _mainNodeQuery.ToComponentDataArray<CrystalAIState>(Allocator.Temp);
             using var crystalNodes = _mainNodeQuery.ToComponentDataArray<CrystalNode>(Allocator.Temp);
+            using var spreadStates = _mainNodeQuery.ToComponentDataArray<CrystalSpreadState>(Allocator.Temp);
             using var nodeLevels = _mainNodeQuery.ToComponentDataArray<CrystalNodeLevel>(Allocator.Temp);
             using var transforms = _mainNodeQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
 
@@ -134,7 +136,7 @@ namespace TheWaningBorder.Systems.Crystal
             {
                 var ai = aiStates[n];
                 var nodePos = transforms[n].Position;
-                float spreadRadius = crystalNodes[n].CurrentRingRadius;
+                float spreadRadius = spreadStates[n].CurrentRingRadius;
                 int nodeLevel = nodeLevels[n].Value;
 
                 // Refresh bank balance (may have changed from previous node's spending)

--- a/Assets/Scripts/Systems/Visibility/FogOfWarSystem.cs
+++ b/Assets/Scripts/Systems/Visibility/FogOfWarSystem.cs
@@ -40,10 +40,12 @@ namespace TheWaningBorder.Systems.Visibility
             mgr.BeginFrame();
 
             // Query all entities with LineOfSight and position
+            // Exclude CrystalTag: crystal entities are enemy to all players and should NOT reveal fog
             var query = em.CreateEntityQuery(
                 ComponentType.ReadOnly<LineOfSight>(),
                 ComponentType.ReadOnly<LocalTransform>(),
-                ComponentType.ReadOnly<FactionTag>());
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.Exclude<CrystalTag>());
 
             var entities = query.ToEntityArray(Allocator.Temp);
             var lineOfSights = query.ToComponentDataArray<LineOfSight>(Allocator.Temp);

--- a/Assets/Scripts/UI/Panels/EntityExtractors.cs
+++ b/Assets/Scripts/UI/Panels/EntityExtractors.cs
@@ -136,10 +136,11 @@ namespace TheWaningBorder.UI
                     string threat = level switch { 1 => "Low Threat", 2 => "Moderate Threat", _ => "High Threat" };
                     info.Description = $"Level {level} — {threat}";
                 }
-                if (em.HasComponent<CrystalNode>(entity))
+                if (em.HasComponent<CrystalNode>(entity) && em.HasComponent<CrystalSpreadState>(entity))
                 {
                     var cn = em.GetComponentData<CrystalNode>(entity);
-                    int pct = cn.SpreadRadius > 0 ? (int)(cn.CurrentRingRadius / cn.SpreadRadius * 100f) : 0;
+                    var ss = em.GetComponentData<CrystalSpreadState>(entity);
+                    int pct = cn.SpreadRadius > 0 ? (int)(ss.CurrentRingRadius / cn.SpreadRadius * 100f) : 0;
                     info.Description += $"\nSpread: {pct}%";
                 }
             }


### PR DESCRIPTION
## Summary
- **FogOfWarSystem**: Exclude crystal entities from fog-of-war visibility stamping so crystal faction no longer reveals fog for players
- **AIBuildingManager**: Set initial building scale to 0.3f during AI construction so buildings don't appear full-size before first construction tick
- **AICrystalHuntBehavior**: Add crystal buildings (with Health) as fallback hunt targets alongside crystal units
- **CrystalNode cleanup**: Remove stale `SpreadPerTick`, `TickInterval`, `TickTimer`, `CurrentRingRadius` fields; extract runtime spread state into new `CrystalSpreadState` component; update all factories, CrystalSpreadSystem, CrystalAISystem, and EntityExtractors

Closes #186

## Files Changed
- `Systems/Visibility/FogOfWarSystem.cs`
- `AI/Managers/AIBuildingManager.cs`
- `AI/Behaviors/AICrystalHuntBehavior.cs`
- `Core/Components/CrystalComponents.cs`
- `Entities/Buildings/CrystalMainNode.cs`
- `Entities/Buildings/CrystalResourceNode.cs`
- `Systems/Creatures/CrystalSpreadSystem.cs`
- `Systems/Crystal/CrystalAISystem.cs`
- `UI/Panels/EntityExtractors.cs`

## Test plan
- [ ] Verify crystal entities do not reveal fog of war for any player
- [ ] Verify AI-placed buildings start at small scale (0.3f) and grow during construction
- [ ] Verify AI crystal hunt sends military units to attack crystal buildings when no units are nearby
- [ ] Verify CrystalSpreadSystem still spreads cursed ground correctly with new CrystalSpreadState component
- [ ] Verify CrystalAISystem builds sub-nodes based on spread radius from CrystalSpreadState
- [ ] Verify EntityInfoPanel shows correct spread percentage for crystal nodes

?? Generated with [Claude Code](https://claude.com/claude-code)