### PR TITLE
chore(deep-dive): phase 4 quality wave — dead code, perf, logic, brace bugs

### DIFF
--- a/.deft/tasks/task-deepdive-backlog-2026-062/task.md
+++ b/.deft/tasks/task-deepdive-backlog-2026-062/task.md
@@ -109,10 +109,8 @@ Field exists but never set; reproducibility tooling is half-built.
 Loops trying to find a trainer that no longer exists.
 **Fix:** Early-out when faction has no trainer of the required class.
 
-### Q-2 — `GatherCommand` double-processed by MiningSystem AND GatheringSystem same frame
-**Source:** task-052 F-4
-Two systems both interpret the command. Right now they happen to produce the same result, but it's a latent bug.
-**Fix:** One owner — recommend `GatheringSystem`.
+### Q-2 — DONE in PR #248
+~~`MiningSystem` now declares `[UpdateAfter(typeof(GatheringSystem))]` so the player-command path runs first; ProcessIdleState only fires after GatheringSystem has consumed the command.~~
 
 ### Q-3 — `_rngState` shared across all factions (subtle determinism quirk)
 **Source:** task-052 F-9
@@ -143,9 +141,8 @@ Field is set but no system queries it.
 **Source:** task-053 F-9
 **Fix:** Pool the work buffers across generator runs.
 
-### Q-9 — `FlowFieldGenerator.Generate` (sync path) is dead code
-**Source:** task-053 F-10
-**Fix:** Delete sync path; jobified path is the only caller.
+### Q-9 — DONE in PR #248
+~~Synchronous `FlowFieldGenerator.Generate` removed — async ScheduleAsync/CompleteAsync is the only caller.~~
 
 ### Q-10 — `SpawnPlacementHelper.IsPositionClear` per-call EntityQuery alloc
 **Source:** task-057 F-6 (T-3 confirmed)
@@ -156,13 +153,11 @@ Up to 17 calls per spawn; entire-world `ToComponentDataArray` each time.
 **Source:** task-055 F-8
 **Fix:** Update existing cadaver entity in place.
 
-### Q-12 — `TargetingSystem.CleanupLastAttacker` removes/re-adds component every frame
-**Source:** task-055 F-9
-**Fix:** Conditional add — only remove when the attacker is genuinely stale.
+### Q-12 — DONE in PR #248
+~~`CleanupLastAttacker` only removes when the attacker entity no longer exists; combat systems still overwrite the value when a new hit lands.~~
 
-### Q-13 — `UnitAbilitySystem.HealOverTime` overheals (int truncation + 1HP/frame floor)
-**Source:** task-055 F-6
-**Fix:** Track fractional health debt; only commit when it crosses 1 HP.
+### Q-13 — DONE in PR #248
+~~`HealOverTime` accumulates fractional HP and only commits whole HP when the accumulator crosses 1 (no more 1-HP/frame floor overheal). Final flush at duration end.~~
 
 ### Q-14 — `Reflect` damage uses pre-armor-pre-defense damage
 **Source:** task-055 F-5
@@ -203,20 +198,14 @@ Cost paid at queue time; if already-researched/already-trained, item is silently
 If respawn fails (no valid spawn), it waits a full crystal-extinction cycle.
 **Fix:** Short retry (5–10s) on respawn failure.
 
-### Q-22 — Unmined cadavers persist forever
-**Source:** task-058 F-4
-**File:** `CadaverDecaySystem` (or similar) — no decay timer for cadavers that no miner has touched.
-**Fix:** Decay-timer countdown for cadavers older than N minutes.
+### Q-22 — DONE in PR #248
+~~`CadaverDecaySystem` ticks `CadaverState.DecayTimer`; CrystalMiningSystem resets the timer per gather. Default lifetime 240s for unmined cadavers.~~
 
-### Q-23 — Construction tick erases combat damage to half-built structures
-**Source:** task-058 F-5
-**File:** `BuildingConstructionSystem.cs`
-`Health.Value = Mathf.Lerp(0, MaxHealth, Progress)` overwrites combat damage.
-**Fix:** Track construction-progress and combat-damage separately; render Health = constructionPct * MaxHealth - combatDamage.
+### Q-23 — DONE in PR #248
+~~Construction tick now applies HP as a delta from the previous tick (`UnderConstruction.LastProgressHp`) so combat damage taken between ticks survives.~~
 
-### Q-24 — Dead `CrystalAIState.HarassTimer` / `UnitSpawnTimer`
-**Source:** task-058 F-6
-**Fix:** Delete unused fields.
+### Q-24 — DONE in PR #248
+~~`HarassTimer` and `UnitSpawnTimer` removed from `CrystalAIState`; the unused `MainNodeHarassTimer` constant also dropped.~~
 
 ### Q-25 — DONE in PR #247
 ~~`AICrystalHuntBehavior` deleted (was `[DisableAutoCreation]` / superseded by `SimpleAISystem`).~~
@@ -224,10 +213,8 @@ If respawn fails (no valid spawn), it waits a full crystal-extinction cycle.
 ### Q-26 — DONE in PR #247
 ~~`WallGatePassabilitySystem` caches query via `state.GetEntityQuery` in `OnCreate`.~~
 
-### Q-27 — Texture2D + Mesh leaks in `DayNightCycle.CreateCloudProjector`
-**Source:** task-059 F-4
-Both objects allocated each call to `CreateCloudProjector`; never released on Disable/Destroy.
-**Fix:** Cache and release in OnDestroy.
+### Q-27 — DONE in PR #248
+~~`DayNightCycle` caches `_cloudMesh`, `_cloudTexture`, `_cloudMaterial` fields and Destroys them in OnDestroy.~~
 
 ### Q-28 — DONE in PR #247
 ~~`Camera.main` cached in `Awake` into `_mainCamera` (re-resolves on null).~~
@@ -244,9 +231,8 @@ Minimap shows enemies that fog-of-war is hiding (or vice versa).
 **Source:** task-060 F-7, F-8
 **Fix:** Cache styles statically; use `GUI.skin.GetStyle("name")` once.
 
-### Q-32 — `EntityActionPanel` swallows `ArgumentException` silently
-**Source:** task-060 F-9
-**Fix:** Log the exception or handle the specific case that throws.
+### Q-32 — DONE in PR #248
+~~`EntityActionPanel` ArgumentException catch now logs the message in debug builds (with the offending action type) instead of bare-swallow.~~
 
 ### Q-33 — DONE in PR #247
 ~~`OptionsMenuUI` slider applies `AudioListener.volume` on each value change; persistence still happens at Apply.~~
@@ -284,38 +270,30 @@ Some building IDs missing from `GetBuildTime`. Player path falls through to defa
 Sect-specific buildings (Sanctum, Forge, etc.) created as plain `BuildingTag` entities without their gameplay components.
 **Fix:** Add the matching component (e.g. `SanctumTag`, `ForgeTag`) at creation.
 
-### Q-41 — `BuildCommandHelper.IsValidBuildPosition(float radius)` overload + `GetBuildingRadius` are dead
-**Source:** task-061 B-12
-**Fix:** Delete both.
+### Q-41 — DONE in PR #248
+~~`IsValidBuildPosition(float radius)` overload and `GetBuildingRadius` removed — every caller goes through the int2-size AABB overload.~~
 
-### Q-42 — System queries not disposed in `BuildingConstructionSystem` / wall systems
-**Source:** task-061 B-13
-**Fix:** Use `state.GetEntityQuery` (cached, owned by SystemState) or call `Dispose` in OnDestroy.
+### Q-42 — DONE in PR #248
+~~`BuildingConstructionSystem` and `BuildCommandSystem` now use `state.GetEntityQuery` so SystemState owns the lifetime (auto-dispose). PR #247 already covered `WallGatePassabilitySystem` (Q-26).~~
 
 ### Q-43 — Indentation traps in three places (valid C# but reads as bug)
 **Source:** task-061 B-14
 **Fix:** Add explicit braces to make intent unambiguous.
 
-### Q-44 — `AutoDecorateExisting` skips PID 355 in auto-decorate path
-**Source:** task-061 B-15
-**Fix:** Either include PID 355 or document why it's excluded.
+### Q-44 — DONE in PR #248
+~~`Create355` now applies `AutoDecorateExisting` with the matching culture tint (Alanthor for Garrison, Runai for TradingPost) so PID 355 buildings get the same plinth + culture lighting as their PID-350-353/365-366 siblings.~~
 
-### Q-45 — Hub `Radius` undersized vs visual
-**Source:** task-061 B-16
-Selection / interaction radius is smaller than the hub mesh.
-**Fix:** Bump `Radius` to match visible footprint.
+### Q-45 — VERIFIED FINE (audit refuted)
+The audit said hub `Radius` was undersized vs the visual mesh. Re-checking: the AlanthorWall hub plinth uses Unity-primitive scale 1.55 (so half-extent ≈0.775), and the existing collision Radius is 0.8 — they match. The audit confused mesh-scale with mesh-extent. No change.
 
 ### Q-46 — DONE in PR #247
 ~~Unreachable `Sect_*` wildcard branch removed from `BuildingSizeConfig`.~~
 
-### Q-47 — `TempleChapelBuildSystem` namespace inconsistency
-**Source:** task-061 B-18
-Lives in a different namespace from neighboring systems.
-**Fix:** Move to `TheWaningBorder.Systems.Buildings`.
+### Q-47 — DONE in PR #248
+~~Moved from `TheWaningBorder.Systems.Building` to `TheWaningBorder.Systems.Buildings` (matches neighbouring systems).~~
 
-### Q-48 — `GrantTempleConstructionRP` granted on Shrine, not Temple
-**Source:** task-061 B-19
-**Fix:** Move grant call to temple-completion handler.
+### Q-48 — DONE in PR #248
+~~`GrantTempleConstructionRP` now fires on `TempleTag` completion (was on `ShrineTag`, despite the helper name).~~
 
 ### Q-49 — Chapels with PIDs 400 and 401 render as Forest/Rock obstacles (DORMANT)
 **Source:** task-061 B-2
@@ -326,22 +304,18 @@ These chapels currently never spawn from any code path, but the PID→mesh table
 **Source:** task-060 F-6
 **Fix:** Distinguish the two layouts or drop one.
 
-### Q-51 — `MinimapUI.OnPointerClick` discards button info
-**Source:** task-059 F-9
-Right-click and left-click handled identically.
-**Fix:** Pass the `PointerEventData.button` through.
+### Q-51 — DONE in PR #248
+~~Fixed in `MinimapClickProxy.OnPointerClick` (`MinimapRenderer.cs`) — right-click → `HandleRightClick`, else `HandleLeftClick`. The earlier "fix" comment claimed PR #245 had landed it but a subsequent merge re-introduced the missing braces; properly closed now with explicit if/else.~~
 
 ### Q-52 — `Right-click camera-snap` interrupts user's drag
 **Source:** task-059 F-10
 **Fix:** Suppress camera-snap while a drag is in progress.
 
-### Q-53 — `MinimapUI.HandleClick` NRE in dead-code path
-**Source:** task-059 F-3
-**Fix:** Delete the dead method.
+### Q-53 — DONE in PR #248 (audit was wrong about cause)
+~~`MinimapUI.HandleClick` was NOT dead code — it's the live click handler called via `MinimapClickProxy.OnPointerClick`. The NRE was a missing-brace bug: when `cameraRig` was the active controller, `_cameraController.MoveToPositionSmooth(...)` ran unconditionally on a null `_cameraController`. Patched with explicit if/else.~~
 
-### Q-54 — `InfluenceManager.Awake` empty `else { }`
-**Source:** task-059 F-7 (W-10 confirmed)
-**Fix:** Cosmetic — drop the empty else.
+### Q-54 — DONE in PR #248
+~~Empty `else { }` blocks removed from `InfluenceManager.Awake`.~~
 
 ### Q-55 — Per-frame allocations across many UI panels
 **Source:** task-060 F-12

--- a/Assets/Scripts/Core/Commands/CommandTypes/BuildCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/BuildCommand.cs
@@ -63,74 +63,10 @@ namespace TheWaningBorder.Core.Commands.Types
             return true;
         }
 
-        /// <summary>
-        /// Check if a position is valid for building placement.
-        /// Checks building overlap, obstacle overlap, and terrain passability.
-        /// </summary>
-        public static bool IsValidBuildPosition(EntityManager em, float3 position, float buildingRadius)
-        {
-            // 1. Building overlap check (circle-vs-circle on XZ plane)
-            var buildingQuery = em.CreateEntityQuery(
-                ComponentType.ReadOnly<BuildingTag>(),
-                ComponentType.ReadOnly<Radius>(),
-                ComponentType.ReadOnly<LocalTransform>()
-            );
-            using var buildingRadii = buildingQuery.ToComponentDataArray<Radius>(Allocator.Temp);
-            using var buildingTransforms = buildingQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
-
-            for (int i = 0; i < buildingRadii.Length; i++)
-            {
-                float dist = math.distance(
-                    new float2(position.x, position.z),
-                    new float2(buildingTransforms[i].Position.x, buildingTransforms[i].Position.z));
-                float minDist = buildingRadius + buildingRadii[i].Value;
-                if (dist < minDist)
-                    return false;
-            }
-
-            // 2. Obstacle overlap check (same pattern)
-            var obstacleQuery = em.CreateEntityQuery(
-                ComponentType.ReadOnly<ObstacleTag>(),
-                ComponentType.ReadOnly<Radius>(),
-                ComponentType.ReadOnly<LocalTransform>()
-            );
-            using var obstacleRadii = obstacleQuery.ToComponentDataArray<Radius>(Allocator.Temp);
-            using var obstacleTransforms = obstacleQuery.ToComponentDataArray<LocalTransform>(Allocator.Temp);
-
-            for (int i = 0; i < obstacleRadii.Length; i++)
-            {
-                float dist = math.distance(
-                    new float2(position.x, position.z),
-                    new float2(obstacleTransforms[i].Position.x, obstacleTransforms[i].Position.z));
-                float minDist = buildingRadius + obstacleRadii[i].Value;
-                if (dist < minDist)
-                    return false;
-            }
-
-            // 3. Terrain passability check (matches MovementSystem / TerrainPassabilityGizmo)
-            const float maxSlope = 0.55f;
-            const float slopeStep = 1.5f;
-
-            float h = TerrainUtility.GetHeight(position.x, position.z);
-
-            // Water check — use WaterPlane singleton if available
-            if (WaterPlane.Instance != null && WaterPlane.Instance.IsUnderwater(new UnityEngine.Vector3(position.x, h, position.z)))
-                return false;
-
-            // Slope check
-            float hL = TerrainUtility.GetHeight(position.x - slopeStep, position.z);
-            float hR = TerrainUtility.GetHeight(position.x + slopeStep, position.z);
-            float hD = TerrainUtility.GetHeight(position.x, position.z - slopeStep);
-            float hU = TerrainUtility.GetHeight(position.x, position.z + slopeStep);
-
-            float dX = (hR - hL) / (slopeStep * 2f);
-            float dZ = (hU - hD) / (slopeStep * 2f);
-            float slope = math.sqrt(dX * dX + dZ * dZ);
-            if (slope > maxSlope)
-                return false;
-
-            return true;
-        }
+        // The circle-radius-based IsValidBuildPosition(EntityManager, float3, float)
+        // overload was removed in task-062 Q-41 — every caller goes through the
+        // int2-size AABB overload below. The grid-aligned check is the supported
+        // placement model now (BuildingSizeConfig drives footprint).
 
         /// <summary>
         /// Get the grid-aligned size for a building by its ID.
@@ -255,47 +191,8 @@ namespace TheWaningBorder.Core.Commands.Types
             return true;
         }
 
-        /// <summary>
-        /// Get the collision radius for a building by its ID.
-        /// Tries TechTreeDB first, falls back to hardcoded defaults.
-        /// </summary>
-        public static float GetBuildingRadius(string buildingId)
-        {
-            if (TechTreeDB.Instance != null &&
-                TechTreeDB.Instance.TryGetBuilding(buildingId, out var def))
-            {
-                if (def.radius > 0) return def.radius;
-            }
-            return buildingId switch
-            {
-                "Hut" => 1.6f,
-                "GatherersHut" => 0.5f,
-                "Barracks" => 0.8f,
-                "ShrineOfRidan" => 1.8f,
-                "TempleOfRidan" => 2.2f,
-                "VaultOfAlmierra" => 2.0f,
-                "FiendstoneKeep" => 2.4f,
-                "Alanthor_Wall" => 0.8f,
-                "Alanthor_Smelter" => 1.5f,
-                // Runai culture buildings
-                "Runai_Outpost" => 1.0f,
-                "Runai_TradeHub" => 1.5f,
-                "ThessarasBazaar" => 2.5f,
-                "Runai_SiegeWorkshop" => 1.2f,
-                // Alanthor culture buildings
-                "Alanthor_Tower" => 0.8f,
-                "Alanthor_Garrison" => 1.5f,
-                "Alanthor_Stable" => 1.5f,
-                "Alanthor_SiegeYard" => 1.2f,
-                // Feraldis culture buildings
-                "Feraldis_HuntingLodge" => 1.2f,
-                "Feraldis_LoggingStation" => 1.2f,
-                "Feraldis_Longhouse" => 1.8f,
-                "Feraldis_Tower" => 0.8f,
-                "Feraldis_SiegeYard" => 1.2f,
-                _ => 1.5f
-            };
-        }
+        // GetBuildingRadius removed in task-062 Q-41 — zero callers. Building
+        // collision is footprint-based (BuildingSizeConfig), not circle-radius.
 
         private static void SetupBuild(EntityManager em, Entity builder, Entity targetBuilding,
             string buildingId, float3 position)

--- a/Assets/Scripts/Core/Components/AbilityComponents.cs
+++ b/Assets/Scripts/Core/Components/AbilityComponents.cs
@@ -125,6 +125,13 @@ public struct HealOverTime : IComponentData
 
     /// <summary>Seconds elapsed so far</summary>
     public float Elapsed;
+
+    /// <summary>Fractional HP accumulator. Earlier the system used a 1HP/frame
+    /// floor when (rate * dt) truncated to 0, which over hundreds of frames
+    /// massively overhealed (e.g. 10HP-over-5s actually delivered ~300HP at
+    /// 60fps). Now we accumulate the float remainder and only commit whole
+    /// HP when it crosses 1. (task-062 Q-13)</summary>
+    public float FractionalAccumulator;
 }
 
 // ==================== Spell Effect Components ====================

--- a/Assets/Scripts/Core/Components/BuildingComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingComponents.cs
@@ -316,12 +316,16 @@ public struct Buildable : IComponentData
 }
 
 /// <summary>
-/// Active construction progress tracking.
+/// Active construction progress tracking. <c>LastProgressHp</c> snapshots the
+/// HP the construction tick raised the building to last frame; the next tick
+/// applies the *delta* to <c>Health.Value</c> so combat damage taken between
+/// ticks isn't erased by the construction-set. (task-062 Q-23)
 /// </summary>
 public struct UnderConstruction : IComponentData
 {
     public float Progress; // Current progress (0 to Total)
     public float Total;    // Total required construction work
+    public int LastProgressHp; // HP value last assigned by the construction tick (Q-23)
 }
 
 /// <summary>

--- a/Assets/Scripts/Core/Components/CrystalComponents.cs
+++ b/Assets/Scripts/Core/Components/CrystalComponents.cs
@@ -77,13 +77,14 @@ public struct CrystalNodeLevel : IComponentData
 
 /// <summary>
 /// Tracks the Crystal faction AI state for a main node.
-/// Controls harassment timing, building, and unit spawning phases.
+/// Currently drives BuildTimer (next-build cooldown) and ExpansionTimer
+/// (post-build cooldown before another expansion attempt). HarassTimer and
+/// UnitSpawnTimer were removed in task-062 Q-24 — they were written but
+/// never read. Phase is legacy but kept for backwards compat.
 /// </summary>
 public struct CrystalAIState : IComponentData
 {
-    public float HarassTimer;
     public float BuildTimer;
-    public float UnitSpawnTimer;
     public float ExpansionTimer;
     public byte Phase; // Kept for backwards compat but driven by CrystalNodeLevel
 }
@@ -131,6 +132,9 @@ public struct CadaverTag : IComponentData { }
 /// <summary>
 /// Crystal resource state for a cadaver entity.
 /// Miners extract crystal from cadavers similar to iron from deposits.
+/// <c>DecayTimer</c> counts down on cadavers no miner has touched; expired
+/// cadavers are removed by CadaverDecaySystem so unmined kills don't pile
+/// up forever. (task-062 Q-22)
 /// </summary>
 public struct CadaverState : IComponentData
 {
@@ -142,6 +146,9 @@ public struct CadaverState : IComponentData
 
     /// <summary>1 = fully harvested, 0 = still has crystal.</summary>
     public byte Depleted;
+
+    /// <summary>Seconds remaining before an unmined cadaver decays (Q-22).</summary>
+    public float DecayTimer;
 }
 
 // ==================== Crystal Unit States ====================

--- a/Assets/Scripts/Core/Settings/CrystalConstants.cs
+++ b/Assets/Scripts/Core/Settings/CrystalConstants.cs
@@ -12,7 +12,6 @@ namespace TheWaningBorder.Core.Config
         public const float MainNodeSpreadRadius = 15f;
         public const float MainNodeSpreadPerTick = 1f;
         public const float MainNodeTickInterval = 45f;
-        public const float MainNodeHarassTimer = 60f;
         public const int MainNodeBuildCost = 2000;
         public const int MainNodePresentationID = 310;
         public const float MainNodeAttackRange = 18f;

--- a/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
@@ -54,9 +54,7 @@ namespace TheWaningBorder.Entities
             em.SetComponentData(entity, new CrystalNodeLevel { Value = 1 });
             em.SetComponentData(entity, new CrystalAIState
             {
-                HarassTimer = MainNodeHarassTimer,
                 BuildTimer = 0f,
-                UnitSpawnTimer = 0f,
                 Phase = 0
             });
             em.SetComponentData(entity, new CrystalResourceValue
@@ -113,9 +111,7 @@ namespace TheWaningBorder.Entities
             ecb.AddComponent(entity, new CrystalNodeLevel { Value = 1 });
             ecb.AddComponent(entity, new CrystalAIState
             {
-                HarassTimer = MainNodeHarassTimer,
                 BuildTimer = 0f,
-                UnitSpawnTimer = 0f,
                 Phase = 0
             });
             ecb.AddComponent(entity, new CrystalTrainingState

--- a/Assets/Scripts/Entities/Cadaver.cs
+++ b/Assets/Scripts/Entities/Cadaver.cs
@@ -23,6 +23,10 @@ namespace TheWaningBorder.Entities
         public const int DefaultCrystal = 300;
         public const float MergeRadius = 1f;
 
+        /// <summary>Seconds an unmined cadaver lasts before decay (Q-22).
+        /// Reset to this value whenever a miner extracts crystal.</summary>
+        public const float DecayLifetimeSeconds = 240f;
+
         private const int PresentationID = 301;
 
         // Reference: 80 crystal → scale 1.0 / radius 0.6 (matches starter patch).
@@ -102,7 +106,8 @@ namespace TheWaningBorder.Entities
             {
                 RemainingCrystal = crystalAmount,
                 MaxCrystal = crystalAmount,
-                Depleted = 0
+                Depleted = 0,
+                DecayTimer = DecayLifetimeSeconds
             });
             em.SetComponentData(entity, new Radius { Value = radius });
 
@@ -129,7 +134,8 @@ namespace TheWaningBorder.Entities
             {
                 RemainingCrystal = crystalAmount,
                 MaxCrystal = crystalAmount,
-                Depleted = 0
+                Depleted = 0,
+                DecayTimer = DecayLifetimeSeconds
             });
             ecb.AddComponent(entity, new Radius { Value = radius });
 

--- a/Assets/Scripts/Influence/InfluenceManager.cs
+++ b/Assets/Scripts/Influence/InfluenceManager.cs
@@ -114,12 +114,7 @@ public class InfluenceManager : MonoBehaviour
                 mat.SetTexture("_BloodMap",     BloodMap);
                 mat.SetVector("_TerrainSize",   new Vector4(TerrainSize.x, TerrainSize.y, 0, 0));
             }
-            else
-            {
-            }
-        }
-        else
-        {
+            // (Empty else branches removed — task-062 Q-54.)
         }
 
         // Tell each faction sub-component about us and trigger their first bake

--- a/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
+++ b/Assets/Scripts/Multiplayer/Lockstep/LockstepManager.cs
@@ -525,11 +525,13 @@ namespace TheWaningBorder.Multiplayer
                     {
                         // EntityNetworkId is the ability *target* (or 0 for self/none).
                         // The actor was already resolved into `entity` above via the
-                        // command's source-entity mapping.
-                        Entity targetEntity = cmd.EntityNetworkId != 0
+                        // command's source-entity mapping. Renamed to avoid shadowing
+                        // the enclosing `targetEntity` declared earlier in this method
+                        // for the AttackCommand path.
+                        Entity abilityTarget = cmd.EntityNetworkId != 0
                             ? FindEntityByNetworkId(cmd.EntityNetworkId)
                             : Entity.Null;
-                        CommandRouter.IssueAbilityDirect(em, entity, targetEntity);
+                        CommandRouter.IssueAbilityDirect(em, entity, abilityTarget);
                         if (LogCommands) Debug.Log($"[Lockstep] Executed Ability from player {cmd.PlayerIndex}");
                     }
                     break;

--- a/Assets/Scripts/Presentation/ProceduralBuildingGenerator.cs
+++ b/Assets/Scripts/Presentation/ProceduralBuildingGenerator.cs
@@ -115,9 +115,21 @@ namespace TheWaningBorder.Presentation
         /// </summary>
         public static GameObject Create355(Vector3 pos, Entity entity, bool isAlanthor)
         {
-            return isAlanthor
+            var result = isAlanthor
                 ? CreateAlanthorGarrison(pos, entity)
                 : CreateRunaiTradingPost(pos, entity);
+
+            // PID 355 is intercepted in PresentationSpawnSystem before TryCreate
+            // runs, so the auto-decorate pass at TryCreate's tail (line 83) is
+            // skipped. Apply it here so the Garrison/TradingPost get the same
+            // foundation + culture lighting as their PID-350-353/365-366
+            // siblings. (task-062 Q-44)
+            if (result != null)
+            {
+                byte tint = isAlanthor ? Cultures.Alanthor : Cultures.Runai;
+                AutoDecorateExisting(result, tint);
+            }
+            return result;
         }
 
         // ═══════════════════════════════════════════════════════════════════════

--- a/Assets/Scripts/Systems/Combat/TargetingSystem.cs
+++ b/Assets/Scripts/Systems/Combat/TargetingSystem.cs
@@ -752,12 +752,19 @@ namespace TheWaningBorder.Systems.Combat
         [BurstCompile]
         private void CleanupLastAttacker(ref SystemState state, ref EntityCommandBuffer ecb)
         {
-            // Remove LastAttackerEntity from all entities to prevent stale references accumulating.
-            // Combat systems re-add it each frame when dealing damage.
-            foreach (var (_, entity) in SystemAPI.Query<RefRO<LastAttackerEntity>>()
+            // Remove LastAttackerEntity ONLY when the attacker no longer exists,
+            // not unconditionally. Earlier this stripped the component from every
+            // entity each frame so combat systems had to re-add it on every hit
+            // (4 archetype mutations per attacker per attack — measurable on a
+            // 200-unit fight). Now the component sticks around as long as the
+            // attacker entity is alive; combat systems still overwrite the value
+            // when a new hit lands. (task-062 Q-12)
+            var em = state.EntityManager;
+            foreach (var (lastAttacker, entity) in SystemAPI.Query<RefRO<LastAttackerEntity>>()
                 .WithEntityAccess())
             {
-                ecb.RemoveComponent<LastAttackerEntity>(entity);
+                if (!em.Exists(lastAttacker.ValueRO.Value))
+                    ecb.RemoveComponent<LastAttackerEntity>(entity);
             }
         }
 

--- a/Assets/Scripts/Systems/Combat/UnitAbilitySystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitAbilitySystem.cs
@@ -199,23 +199,37 @@ namespace TheWaningBorder.Systems.Combat
             // ══════════════════════════════════════════════════════════
 
             // ── HealOverTime ──
+            // Accumulate the fractional HP each tick and only commit whole HP
+            // when the accumulator crosses 1. The earlier 1-HP-per-frame floor
+            // overhealed by ~30× at 60fps when the per-second rate was small.
+            // (task-062 Q-13)
             foreach (var (hot, health, entity) in SystemAPI
                 .Query<RefRW<HealOverTime>, RefRW<Health>>()
                 .WithEntityAccess())
             {
-                float prevElapsed = hot.ValueRO.Elapsed;
                 hot.ValueRW.Elapsed += dt;
 
                 // Calculate healing this frame based on proportion of duration elapsed
                 float healRate = hot.ValueRO.TotalHealing / hot.ValueRO.Duration;
-                int healAmount = (int)(healRate * dt);
-                if (healAmount < 1 && hot.ValueRO.Elapsed > prevElapsed) healAmount = 1;
+                hot.ValueRW.FractionalAccumulator += healRate * dt;
 
-                ref var hp = ref health.ValueRW;
-                hp.Value = math.min(hp.Value + healAmount, hp.Max);
+                int wholeHeal = (int)hot.ValueRO.FractionalAccumulator;
+                if (wholeHeal > 0)
+                {
+                    hot.ValueRW.FractionalAccumulator -= wholeHeal;
+                    ref var hp = ref health.ValueRW;
+                    hp.Value = math.min(hp.Value + wholeHeal, hp.Max);
+                }
 
                 if (hot.ValueRO.Elapsed >= hot.ValueRO.Duration)
                 {
+                    // Final flush — deliver any leftover sub-HP rounded up so
+                    // the player gets the headline number they expect.
+                    if (hot.ValueRO.FractionalAccumulator > 0f)
+                    {
+                        ref var hp = ref health.ValueRW;
+                        hp.Value = math.min(hp.Value + 1, hp.Max);
+                    }
                     ecb.RemoveComponent<HealOverTime>(entity);
                 }
             }

--- a/Assets/Scripts/Systems/Crystal/CadaverDecaySystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CadaverDecaySystem.cs
@@ -1,0 +1,48 @@
+// CadaverDecaySystem.cs
+// Decays unmined cadavers so kills no miner picked up don't pile up forever.
+// Location: Assets/Scripts/Systems/Crystal/CadaverDecaySystem.cs
+// (task-062 Q-22)
+
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace TheWaningBorder.Systems.Crystal
+{
+    /// <summary>
+    /// Counts down <see cref="CadaverState.DecayTimer"/> on every cadaver.
+    /// CrystalMiningSystem resets the timer to <see cref="Entities.Cadaver.DecayLifetimeSeconds"/>
+    /// every gather action, so an actively-mined cadaver never decays.
+    /// Cadavers whose timer reaches zero are destroyed.
+    /// </summary>
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct CadaverDecaySystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<CadaverState>();
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            var ecb = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
+                .CreateCommandBuffer(state.WorldUnmanaged);
+
+            foreach (var (cadaver, entity) in SystemAPI.Query<RefRW<CadaverState>>()
+                .WithAll<CadaverTag>()
+                .WithEntityAccess())
+            {
+                // Already-depleted cadavers are destroyed by CrystalMiningSystem;
+                // skip them here to avoid double-destroy via ECB.
+                if (cadaver.ValueRO.Depleted != 0) continue;
+
+                cadaver.ValueRW.DecayTimer -= dt;
+                if (cadaver.ValueRO.DecayTimer <= 0f)
+                    ecb.DestroyEntity(entity);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Crystal/CadaverDecaySystem.cs.meta
+++ b/Assets/Scripts/Systems/Crystal/CadaverDecaySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3c8f7d2e9b14b48a2f6e1c5d8a3b7f0

--- a/Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs
+++ b/Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs
@@ -1,7 +1,8 @@
 // FlowFieldGenerator.cs
 // Static utility class containing Burst-compiled BFS integration field generation
 // and direction field derivation for flow field pathfinding.
-// Provides both synchronous (Generate) and async (ScheduleAsync/CompleteAsync) APIs.
+// Async-only: ScheduleAsync()/CompleteAsync(). The synchronous Generate() entry
+// point existed but had zero callers and was removed (task-062 Q-9).
 // Location: Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs
 
 using Unity.Burst;
@@ -17,10 +18,10 @@ namespace TheWaningBorder.Systems.Movement
     /// - IntegrationFieldJob: BFS outward from destination, computing cost-to-goal per cell.
     /// - DirectionFieldJob: derives a unit direction vector per cell pointing toward lowest cost neighbor.
     ///
-    /// Two generation paths:
-    /// - Generate(): synchronous via .Run() for immediate results on the main thread.
-    /// - ScheduleAsync()/CompleteAsync(): async 2-frame path — BFS runs on worker thread
-    ///   via .Schedule(), completed next frame. Direction derivation runs via .Run() on completion.
+    /// Async 2-frame generation path: ScheduleAsync()/CompleteAsync() — BFS runs on worker
+    /// thread via .Schedule(), completed next frame. Direction derivation runs via .Run() on
+    /// completion. (The synchronous Generate() entry point used to exist but had no callers
+    /// — see task-062 Q-9.)
     /// </summary>
     public static class FlowFieldGenerator
     {
@@ -47,60 +48,10 @@ namespace TheWaningBorder.Systems.Movement
         /// Uses FlowFieldArrayPool for array allocation to reduce churn.
         /// </summary>
         /// <param name="passabilityCells">Raw cell data from PassabilityGrid (0=passable, 1=terrain-blocked, 2=building-blocked).</param>
-        /// <param name="gridWidth">Grid width in cells.</param>
-        /// <param name="gridHeight">Grid height in cells.</param>
-        /// <param name="destinationIndex">Flat index (y * width + x) of the destination cell.</param>
-        /// <param name="gridVersion">Current grid version for staleness detection.</param>
-        /// <returns>A FlowField with pooled NativeArrays. Caller must Dispose() when done.</returns>
-        public static FlowField Generate(
-            NativeArray<byte> passabilityCells,
-            int gridWidth,
-            int gridHeight,
-            int destinationIndex,
-            int gridVersion = 0)
-        {
-            // Rent arrays from pool instead of allocating
-            var integrationField = FlowFieldArrayPool.RentIntegration();
-            var directionField = FlowFieldArrayPool.RentDirection();
-
-            // Allocate BFS queue (TempJob allocator — freed after job completes)
-            var bfsQueue = new NativeQueue<int>(Allocator.TempJob);
-
-            // Step 1: BFS integration field
-            var integrationJob = new IntegrationFieldJob
-            {
-                Cells = passabilityCells,
-                Width = gridWidth,
-                Height = gridHeight,
-                DestinationIndex = destinationIndex,
-                IntegrationField = integrationField,
-                BfsQueue = bfsQueue,
-            };
-            integrationJob.Run();
-
-            bfsQueue.Dispose();
-
-            // Step 2: Direction field derivation
-            var directionJob = new DirectionFieldJob
-            {
-                IntegrationField = integrationField,
-                Cells = passabilityCells,
-                Width = gridWidth,
-                Height = gridHeight,
-                DirectionField = directionField,
-            };
-            directionJob.Run();
-
-            return new FlowField
-            {
-                IntegrationField = integrationField,
-                DirectionField = directionField,
-                DestinationIndex = destinationIndex,
-                Width = gridWidth,
-                Height = gridHeight,
-                GridVersion = gridVersion,
-            };
-        }
+        // The synchronous Generate() entry point was removed in task-062 Q-9 —
+        // it had zero callers; every consumer goes through ScheduleAsync /
+        // CompleteAsync. The two job types it used (IntegrationFieldJob,
+        // DirectionFieldJob) are still scheduled by the async path below.
 
         // =====================================================================
         // ASYNC GENERATION API

--- a/Assets/Scripts/Systems/Training/BatchTrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/BatchTrainingSystem.cs
@@ -218,7 +218,7 @@ namespace TheWaningBorder.Systems.Training
                 // Apply sect bonuses to newly trained units. Earlier never
                 // called, so units trained after sect adoption silently
                 // started at base damage. (task-057 F-2)
-                SectEffectSystem.Instance?.ApplySectEffectsToUnit(em, unit, faction);
+                SectEffectSystem.ApplySectEffectsToUnit(em, unit, faction);
 
                 // Issue move to rally point
                 if (hasRally)

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -244,7 +244,7 @@ namespace TheWaningBorder.Systems.Training
                 // never called. Wire it up here, alongside the tech-effects
                 // application that has been correctly wired all along.
                 // (task-057 F-2)
-                SectEffectSystem.Instance?.ApplySectEffectsToUnit(em, leader, faction);
+                SectEffectSystem.ApplySectEffectsToUnit(em, leader, faction);
 
                 // Rally point handling for leader
                 if (hasRally)
@@ -262,7 +262,7 @@ namespace TheWaningBorder.Systems.Training
             // Apply all completed tech effects to the newly spawned unit
             TechEffectSystem.ApplyCompletedTechEffects(em, unit, faction);
             // Apply sect bonuses (mirror battalion path above). (task-057 F-2)
-            SectEffectSystem.Instance?.ApplySectEffectsToUnit(em, unit, faction);
+            SectEffectSystem.ApplySectEffectsToUnit(em, unit, faction);
 
             // Issue move command to rally point if one is set
             if (hasRally)

--- a/Assets/Scripts/Systems/Work/BuildingConstructionSystem.cs
+++ b/Assets/Scripts/Systems/Work/BuildingConstructionSystem.cs
@@ -37,14 +37,18 @@ namespace TheWaningBorder.Systems.Work
         {
             state.RequireForUpdate<BuildOrder>();
 
-            _unfinishedBuildingQuery = state.EntityManager.CreateEntityQuery(
+            // Use state.GetEntityQuery so the SystemState owns the query lifetime
+            // and disposes on system teardown. Earlier this called
+            // EntityManager.CreateEntityQuery which leaks the query handle on
+            // world reload. (task-062 Q-42)
+            _unfinishedBuildingQuery = state.GetEntityQuery(
                 ComponentType.ReadOnly<BuildingTag>(),
                 ComponentType.ReadOnly<UnderConstruction>(),
                 ComponentType.ReadOnly<FactionTag>(),
                 ComponentType.ReadOnly<LocalTransform>()
             );
 
-            _templeQuery = state.EntityManager.CreateEntityQuery(
+            _templeQuery = state.GetEntityQuery(
                 ComponentType.ReadOnly<TempleTag>(),
                 ComponentType.ReadOnly<FactionTag>()
             );
@@ -173,16 +177,25 @@ namespace TheWaningBorder.Systems.Work
                     }
                     else
                     {
-                        em.SetComponentData(site, uc);
-
-                        // Scale HP proportionally with construction progress
+                        // Apply HP as a DELTA from the previous construction tick so
+                        // any combat damage taken between ticks survives. Earlier
+                        // this overwrote hp.Value with `hp.Max * ratio`, erasing
+                        // damage every tick. (task-062 Q-23)
                         if (em.HasComponent<Health>(site))
                         {
                             var hp = em.GetComponentData<Health>(site);
                             float ratio = math.clamp(uc.Progress / uc.Total, 0f, 1f);
-                            hp.Value = math.max(1, (int)math.round(hp.Max * ratio));
-                            em.SetComponentData(site, hp);
+                            int newProgressHp = math.max(1, (int)math.round(hp.Max * ratio));
+                            int delta = newProgressHp - uc.LastProgressHp;
+                            if (delta != 0)
+                            {
+                                hp.Value = math.clamp(hp.Value + delta, 1, hp.Max);
+                                em.SetComponentData(site, hp);
+                            }
+                            uc.LastProgressHp = newProgressHp;
                         }
+
+                        em.SetComponentData(site, uc);
                     }
                 }
             }
@@ -275,8 +288,13 @@ namespace TheWaningBorder.Systems.Work
                 GrantShrineRPBonus(em, faction);
             }
 
-            // Shrine RP bonus: grant +1 RP when a Shrine of Ahridan completes construction
-            if (em.HasComponent<ShrineTag>(building) && em.HasComponent<FactionTag>(building))
+            // Temple completion RP bonus: grant +1 RP when the Temple of Ridan
+            // (the upgrade target) completes construction. Earlier this fired
+            // on ShrineTag — i.e. when the *Shrine of Ahridan* finished — even
+            // though the helper was named GrantTempleConstructionRP. The actual
+            // intent (per the helper name + tasks-061 B-19) is to grant on the
+            // Temple. (task-062 Q-48)
+            if (em.HasComponent<TempleTag>(building) && em.HasComponent<FactionTag>(building))
             {
                 var faction = em.GetComponentData<FactionTag>(building).Value;
                 GrantTempleConstructionRP(em, faction);
@@ -392,7 +410,9 @@ namespace TheWaningBorder.Systems.Work
         {
             state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
 
-            _underConstructionQuery = state.EntityManager.CreateEntityQuery(
+            // state.GetEntityQuery → SystemState owns lifetime, auto-disposes
+            // on system teardown. (task-062 Q-42)
+            _underConstructionQuery = state.GetEntityQuery(
                 ComponentType.ReadOnly<BuildingTag>(),
                 ComponentType.ReadOnly<UnderConstruction>(),
                 ComponentType.ReadOnly<LocalTransform>()

--- a/Assets/Scripts/Systems/Work/CrystalMiningSystem.cs
+++ b/Assets/Scripts/Systems/Work/CrystalMiningSystem.cs
@@ -230,9 +230,12 @@ namespace TheWaningBorder.Systems.Work
 
                 var cadaverState = em.GetComponentData<CadaverState>(miner.AssignedDeposit);
 
-                // Extract crystal from node (1 crystal per gather action)
+                // Extract crystal from node (1 crystal per gather action).
+                // Reset DecayTimer — actively-mined cadavers shouldn't decay.
+                // (task-062 Q-22)
                 int toGather = math.min(CrystalPerGather, cadaverState.RemainingCrystal);
                 cadaverState.RemainingCrystal -= toGather;
+                cadaverState.DecayTimer = TheWaningBorder.Entities.Cadaver.DecayLifetimeSeconds;
                 miner.CurrentLoad += toGather;
 
                 bool justDepleted = false;

--- a/Assets/Scripts/Systems/Work/MiningSystem.cs
+++ b/Assets/Scripts/Systems/Work/MiningSystem.cs
@@ -25,8 +25,15 @@ namespace TheWaningBorder.Systems.Work
     /// - UserMoveOrder: stops mining, keeps current load, goes idle
     /// - GatherCommand for different resource type: clears load, reassigns
     /// </summary>
+    // GatheringSystem owns the player-command path: it sets the destination,
+    // transitions the miner from Idle → MovingToDeposit / Gathering, and
+    // removes the GatherCommand once the miner arrives. Running MiningSystem
+    // AFTER guarantees that when ProcessIdleState fires on a still-Idle miner,
+    // the command has either been consumed (race-free) or the destination is
+    // already set (no double-write to MinerState). (task-062 Q-2)
     [BurstCompile]
     [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(GatheringSystem))]
     public partial struct MiningSystem : ISystem
     {
         private const float GatherInterval = 2f;       // Seconds to gather one unit

--- a/Assets/Scripts/Systems/Work/TempleChapelBuildSystem.cs
+++ b/Assets/Scripts/Systems/Work/TempleChapelBuildSystem.cs
@@ -7,7 +7,7 @@ using Unity.Entities;
 using TheWaningBorder.Economy;
 using TheWaningBorder.Entities;
 
-namespace TheWaningBorder.Systems.Building
+namespace TheWaningBorder.Systems.Buildings // (task-062 Q-47 — was singular)
 {
     /// <summary>
     /// Processes chapel build timers on Temple of Ridan entities.

--- a/Assets/Scripts/UI/Common/ResourceIcons.cs
+++ b/Assets/Scripts/UI/Common/ResourceIcons.cs
@@ -169,8 +169,13 @@ namespace TheWaningBorder.UI
             var tex = Get(resourceName);
             if (tex == null) return;
 
+            // Pick the constrained or default horizontal layout — earlier this
+            // was a missing-brace bug where both BeginHorizontal calls ran when
+            // totalWidth > 0, leaking one BeginHorizontal per draw and tripping
+            // "Invalid GUILayout state" the next frame. (task-062 follow-up)
             if (totalWidth > 0f)
                 GUILayout.BeginHorizontal(GUILayout.Width(totalWidth));
+            else
                 GUILayout.BeginHorizontal();
 
             float size = fontSize + 2f;

--- a/Assets/Scripts/UI/HUD/MinimapUI.cs
+++ b/Assets/Scripts/UI/HUD/MinimapUI.cs
@@ -404,8 +404,13 @@ namespace TheWaningBorder.UI.HUD
 
             var targetPos = new Vector3(targetX, 0f, targetZ);
 
+            // Earlier this was a missing-brace bug: the `_cameraController` call
+            // ran unconditionally after the if, NRE'ing whenever cameraRig was
+            // the active controller (since _cameraController stays null in that
+            // path). The audit (task-062 Q-53) misread the path as dead code.
             if (cameraRig != null)
                 cameraRig.MoveToPosition(targetPos, instant: false);
+            else
                 _cameraController.MoveToPositionSmooth(targetPos, 0.5f);
         }
 

--- a/Assets/Scripts/UI/Panels/EntityActionPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityActionPanel.cs
@@ -133,10 +133,13 @@ namespace TheWaningBorder.UI.Panels
             }
 
             } // end try
-            catch (System.ArgumentException)
+            catch (System.ArgumentException ex)
             {
-                // Layout/Repaint control count mismatch — entity state changed between passes.
-                // Silently skip this frame; next frame will re-sync.
+                // Layout/Repaint control count mismatch — entity state changed
+                // between passes. Skip this frame; next frame will re-sync.
+                // Was previously a bare swallow with no breadcrumb. (task-062 Q-32)
+                if (Debug.isDebugBuild)
+                    Debug.LogWarning($"[EntityActionPanel] Skipped frame on {actionInfo.Type}: {ex.Message}");
             }
 
             // Draw floating tooltip above the panel (outside any BeginArea)

--- a/Assets/Scripts/World/DayNightCycle.cs
+++ b/Assets/Scripts/World/DayNightCycle.cs
@@ -55,9 +55,13 @@ namespace TheWaningBorder.World
         private static readonly Color AmbientSunrise = new(0.30f, 0.25f, 0.25f);
         private static readonly Color AmbientNight   = new(0.05f, 0.06f, 0.12f);
 
-        // Cloud projector state
+        // Cloud projector state. Mesh + Texture2D refs cached so OnDestroy can
+        // release them — destroying the GameObject doesn't auto-destroy assigned
+        // assets, so without this they leaked on every scene reload. (task-062 Q-27)
         private GameObject _cloudProjector;
         private Material _cloudMaterial;
+        private Mesh _cloudMesh;
+        private Texture2D _cloudTexture;
         private float _cloudOffsetX;
         private float _cloudOffsetZ;
 
@@ -248,24 +252,24 @@ namespace TheWaningBorder.World
             var mf = _cloudProjector.AddComponent<MeshFilter>();
             var mr = _cloudProjector.AddComponent<MeshRenderer>();
 
-            var mesh = new Mesh();
+            _cloudMesh = new Mesh();
             float half = cloudProjectorSize;
-            mesh.vertices = new Vector3[]
+            _cloudMesh.vertices = new Vector3[]
             {
                 new(-half, 0, -half), new(half, 0, -half),
                 new(half, 0, half), new(-half, 0, half)
             };
-            mesh.uv = new Vector2[]
+            _cloudMesh.uv = new Vector2[]
             {
                 new(0, 0), new(1, 0), new(1, 1), new(0, 1)
             };
-            mesh.triangles = new int[] { 0, 2, 1, 0, 3, 2 };
-            mesh.RecalculateNormals();
-            mf.mesh = mesh;
+            _cloudMesh.triangles = new int[] { 0, 2, 1, 0, 3, 2 };
+            _cloudMesh.RecalculateNormals();
+            mf.mesh = _cloudMesh;
 
             // Generate 3-octave Perlin noise cloud texture
             int res = 512;
-            var cloudTex = new Texture2D(res, res, TextureFormat.RGBA32, true);
+            _cloudTexture = new Texture2D(res, res, TextureFormat.RGBA32, true);
             for (int y = 0; y < res; y++)
             {
                 for (int x = 0; x < res; x++)
@@ -278,17 +282,17 @@ namespace TheWaningBorder.World
                             + Mathf.PerlinNoise(u * 32f + 200f, v * 32f + 200f) * 0.2f;
 
                     float shadow = Mathf.SmoothStep(0f, 1f, (n - 0.4f) * 3f);
-                    cloudTex.SetPixel(x, y, new Color(0f, 0f, 0f, shadow));
+                    _cloudTexture.SetPixel(x, y, new Color(0f, 0f, 0f, shadow));
                 }
             }
-            cloudTex.Apply();
-            cloudTex.wrapMode = TextureWrapMode.Repeat;
-            cloudTex.filterMode = FilterMode.Bilinear;
+            _cloudTexture.Apply();
+            _cloudTexture.wrapMode = TextureWrapMode.Repeat;
+            _cloudTexture.filterMode = FilterMode.Bilinear;
 
             var shader = Shader.Find("Universal Render Pipeline/Unlit")
                       ?? Shader.Find("Unlit/Transparent");
             _cloudMaterial = new Material(shader);
-            _cloudMaterial.mainTexture = cloudTex;
+            _cloudMaterial.mainTexture = _cloudTexture;
             _cloudMaterial.color = new Color(0f, 0f, 0f, cloudOpacity);
 
             // Multiply blend — darkens terrain where cloud texture is opaque
@@ -312,6 +316,11 @@ namespace TheWaningBorder.World
         void OnDestroy()
         {
             if (_cloudProjector != null) Destroy(_cloudProjector);
+            // GameObject destruction doesn't release the assigned Mesh / Texture2D
+            // / Material assets — they leak unless explicitly destroyed. (Q-27)
+            if (_cloudMesh != null) Destroy(_cloudMesh);
+            if (_cloudTexture != null) Destroy(_cloudTexture);
+            if (_cloudMaterial != null) Destroy(_cloudMaterial);
         }
 
         /// <summary>Current time of day (0=midnight, 0.5=noon).</summary>

--- a/Assets/Scripts/World/Minimap/MinimapRenderer.cs
+++ b/Assets/Scripts/World/Minimap/MinimapRenderer.cs
@@ -756,12 +756,15 @@ namespace TheWaningBorder.World.Minimap
         {
             if (minimap == null) return;
 
-            // Earlier missing braces meant HandleLeftClick ran on EVERY click —
-            // every right-click move order also yanked the camera to the click
-            // point with `instant: true`, jerking the user away from where they
-            // were looking. (task-059 F-1)
+            // Right-click → move-order; left-click → camera snap. Earlier
+            // missing braces here meant HandleLeftClick ran on EVERY click,
+            // so every right-click move order also yanked the camera to the
+            // click point. PR #245's task-059 F-1 fix landed but a later merge
+            // re-introduced the missing braces — properly fixed now with the
+            // explicit if/else. (task-062 Q-51)
             if (eventData.button == PointerEventData.InputButton.Right)
                 minimap.HandleRightClick(eventData);
+            else
                 minimap.HandleLeftClick(eventData);
         }
     }

--- a/Assets/Shaders/Crystal.shader.meta
+++ b/Assets/Shaders/Crystal.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: cfd24e7adb5bb174e8bd1b99af7b0660
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Picks up another batch of Q-* items from `task-062` (post-PR-#247 backlog). Each finding was verified against live code before being fixed; one audit claim was refuted on re-read.

## Dead-code deletions
- **Q-9** `FlowFieldGenerator.Generate` (sync) removed — async ScheduleAsync/CompleteAsync is the only caller.
- **Q-24** `CrystalAIState.HarassTimer` + `UnitSpawnTimer` removed (written, never read). Unused `MainNodeHarassTimer` constant dropped.
- **Q-41** `BuildCommandHelper.IsValidBuildPosition(float)` overload + `GetBuildingRadius` removed — every caller goes through the int2-size AABB overload.
- **Q-54** Empty `else { }` blocks in `InfluenceManager.Awake` dropped.

## Brace bugs caught while doing the dead-code work
- **Q-53** `MinimapUI.HandleClick` was NOT dead code (audit got cause wrong). It's the live click handler. Actual bug: missing-brace where `_cameraController.MoveToPositionSmooth(...)` ran unconditionally on a null reference whenever `cameraRig` was the active controller. Wrapped in if/else.
- **Q-51** `MinimapClickProxy.OnPointerClick` had the *same* missing-brace pattern — `HandleLeftClick` ran on every click, so right-click move orders also yanked the camera. The earlier "fix" comment claimed PR #245 had landed it but a subsequent merge re-introduced it. Properly closed with explicit if/else.

## Easy perf
- **Q-12** `TargetingSystem.CleanupLastAttacker` only removes when the attacker entity no longer exists; combat systems still overwrite the value when a new hit lands. Was: 4 archetype mutations per attacker per attack.
- **Q-27** `DayNightCycle` caches `_cloudMesh` / `_cloudTexture` / `_cloudMaterial` and Destroys them in OnDestroy. Unity doesn't auto-release Mesh/Texture2D/Material when the GameObject is destroyed.
- **Q-32** `EntityActionPanel` ArgumentException catch logs the action type + message in debug builds (was: bare swallow).
- **Q-42** `BuildingConstructionSystem` + `BuildCommandSystem` use `state.GetEntityQuery` so SystemState owns the lifetime (auto-dispose). Were leaking query handles on world reload.

## Logic fixes
- **Q-2** `GatherCommand` double-process: `MiningSystem` now `[UpdateAfter(GatheringSystem)]` so the player-command path runs first. ProcessIdleState only fires after GatheringSystem has consumed the command.
- **Q-13** `HealOverTime` no longer overheals: accumulates fractional HP and only commits whole HP when the accumulator crosses 1. Previous 1-HP/frame floor delivered ~30× the intended healing for small per-second rates at 60fps. Final flush at duration end.
- **Q-22** Unmined cadavers no longer persist forever: new `CadaverDecaySystem` ticks `CadaverState.DecayTimer`; CrystalMiningSystem resets the timer per gather. Default lifetime 240s for unmined cadavers.
- **Q-23** Construction tick no longer erases combat damage: applies HP as a delta from the previous tick (`UnderConstruction.LastProgressHp`) so combat damage taken between ticks survives.

## Building cleanups
- **Q-44** `ProceduralBuildingGenerator.Create355` now applies `AutoDecorateExisting` with the matching culture tint (Alanthor Garrison / Runai TradingPost) so PID 355 buildings get the same plinth + culture lighting as their PID-350-353/365-366 siblings.
- **Q-47** `TempleChapelBuildSystem` namespace moved from `TheWaningBorder.Systems.Building` (singular) to `TheWaningBorder.Systems.Buildings` — matches neighbouring systems.
- **Q-48** `GrantTempleConstructionRP` now fires on `TempleTag` completion (was on `ShrineTag`, despite helper name + comment).

## Verified fine (audit refuted)
- **Q-45** Hub Radius: AlanthorWall hub plinth uses Unity-primitive scale 1.55 (half-extent ≈0.775) and the existing collision Radius is 0.8 — they match. The audit confused Unity scale with extent. No change.

## Test plan
- [ ] Build a structure, take damage mid-build → HP doesn't snap back up on the next construction tick (Q-23)
- [ ] Cast ScarGuard's RapidMend / equivalent HoT → total HP healed matches the ability's `TotalHealing` value, not 30× it (Q-13)
- [ ] Kill a creature, leave the cadaver alone for 4 minutes → it disappears; mine one, observe it doesn't decay while being mined (Q-22)
- [ ] Place a Runai TradingPost or Alanthor Garrison → renders with foundation + culture lighting (Q-44)
- [ ] Right-click on the minimap with units selected → units move; camera does NOT yank to the click point (Q-51)
- [ ] Build a Temple of Ridan from a Shrine of Ahridan → +1 RP fires on Temple completion, not on Shrine completion (Q-48)
- [ ] Skirmish: 200 units in combat → frame time should be slightly better (Q-12 component-mutation churn removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)