### PR TITLE
fix(commands): Q-5 — CommandQueueSystem two-phase iteration

### DIFF
--- a/.deft/tasks/task-deepdive-backlog-2026-062/task.md
+++ b/.deft/tasks/task-deepdive-backlog-2026-062/task.md
@@ -122,11 +122,8 @@ RNG state in some AI subsystems is shared, so AI A's roll affects AI B's next ro
 Allocates ~6 NativeArrays + a managed `bool[]` per call.
 **Fix:** Pool the buffers or cache the query.
 
-### Q-5 — `CommandQueueSystem` structural changes during iteration
-**Source:** task-053 F-5
-**File:** `Assets/Scripts/Systems/Commands/CommandQueueSystem.cs`
-Iterator-invalidation pattern (mining/gathering systems already had this fixed). Shift-queue feature breaks once a queued command activates.
-**Fix:** Collect into a `NativeList`, mutate after iteration.
+### Q-5 — DONE in PR #250
+~~`CommandQueueSystem` now runs in two phases: phase 1 snapshots `(Entity, DispatchKind, TargetPosition)` decisions into a `NativeList<PendingDispatch>`; phase 2 applies structural changes (helper calls + `CommandQueueActive` removal) after the foreach has finished. Buffer pops still happen in phase 1 (buffer mutation, not archetype change). Defensive `em.Exists` + `HasComponent` guards in phase 2.~~
 
 ### Q-6 — `MovementSystem` `BlendRadius=2f` lets units clip walls within 2m of goal
 **Source:** task-053 F-7

--- a/Assets/Scripts/Systems/Movement/CommandQueueSystem.cs
+++ b/Assets/Scripts/Systems/Movement/CommandQueueSystem.cs
@@ -1,4 +1,5 @@
 // File: Assets/Scripts/Systems/Movement/CommandQueueSystem.cs
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using TheWaningBorder.Core.Commands.Types;
@@ -12,14 +13,44 @@ namespace TheWaningBorder.Systems.Movement
     /// Removes CommandQueueActive when the buffer is empty.
     /// Skips entities tagged CommandQueueFrozen (Shift held — see RTSInputManager).
     /// Runs before MovementSystem so queued commands set DesiredDestination before movement.
+    ///
+    /// Earlier this code mutated archetypes inside the SystemAPI.Query foreach
+    /// — `em.RemoveComponent&lt;CommandQueueActive&gt;` on empty buffers, and the
+    /// command helpers (MoveCommandHelper.Execute etc.) which add/remove a
+    /// dozen components apiece. That invalidated the iterator, so the second
+    /// shift-queue command on a unit silently dropped (the foreach aborted
+    /// after the first structural change). Phase 1 now snapshots per-entity
+    /// decisions into a NativeList; Phase 2 mutates after the foreach has
+    /// finished. (task-062 Q-5)
     /// </summary>
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     [UpdateBefore(typeof(MovementSystem))]
     public partial struct CommandQueueSystem : ISystem
     {
+        private enum DispatchKind : byte
+        {
+            None = 0,           // No-op (queue was empty + no buffer — should never collect)
+            ClearActive = 1,    // Buffer empty / missing → remove CommandQueueActive
+            Move = 2,
+            AttackMove = 3,
+            Patrol = 4,
+        }
+
+        private struct PendingDispatch
+        {
+            public Entity Entity;
+            public DispatchKind Kind;
+            public float3 TargetPosition;
+        }
+
         public void OnUpdate(ref SystemState state)
         {
             var em = state.EntityManager;
+
+            // Phase 1: snapshot decisions. Buffer reads + buffer.RemoveAt are
+            // safe inside the foreach (they don't change archetype); helpers
+            // and RemoveComponent are deferred to Phase 2.
+            var pending = new NativeList<PendingDispatch>(16, Allocator.Temp);
 
             foreach (var (dd, target, entity) in SystemAPI
                 .Query<RefRO<DesiredDestination>, RefRO<Target>>()
@@ -33,34 +64,63 @@ namespace TheWaningBorder.Systems.Movement
 
                 if (!em.HasBuffer<QueuedCommand>(entity))
                 {
-                    em.RemoveComponent<CommandQueueActive>(entity);
+                    pending.Add(new PendingDispatch { Entity = entity, Kind = DispatchKind.ClearActive });
                     continue;
                 }
 
                 var buffer = em.GetBuffer<QueuedCommand>(entity);
                 if (buffer.Length == 0)
                 {
-                    em.RemoveComponent<CommandQueueActive>(entity);
+                    pending.Add(new PendingDispatch { Entity = entity, Kind = DispatchKind.ClearActive });
                     continue;
                 }
 
-                // Pop the next command
+                // Pop the head — buffer mutation, not a structural change.
                 var cmd = buffer[0];
                 buffer.RemoveAt(0);
 
-                switch (cmd.Type)
+                var kind = cmd.Type switch
                 {
-                    case QueuedCommandType.Move:
-                        MoveCommandHelper.Execute(em, entity, cmd.TargetPosition);
+                    QueuedCommandType.Move       => DispatchKind.Move,
+                    QueuedCommandType.AttackMove => DispatchKind.AttackMove,
+                    QueuedCommandType.Patrol     => DispatchKind.Patrol,
+                    _ => DispatchKind.None,
+                };
+                if (kind == DispatchKind.None) continue;
+
+                pending.Add(new PendingDispatch
+                {
+                    Entity = entity,
+                    Kind = kind,
+                    TargetPosition = cmd.TargetPosition,
+                });
+            }
+
+            // Phase 2: apply structural changes after iteration is done.
+            for (int i = 0; i < pending.Length; i++)
+            {
+                var p = pending[i];
+                if (!em.Exists(p.Entity)) continue;
+
+                switch (p.Kind)
+                {
+                    case DispatchKind.ClearActive:
+                        if (em.HasComponent<CommandQueueActive>(p.Entity))
+                            em.RemoveComponent<CommandQueueActive>(p.Entity);
                         break;
-                    case QueuedCommandType.AttackMove:
-                        AttackMoveCommandHelper.Execute(em, entity, cmd.TargetPosition);
+                    case DispatchKind.Move:
+                        MoveCommandHelper.Execute(em, p.Entity, p.TargetPosition);
                         break;
-                    case QueuedCommandType.Patrol:
-                        PatrolCommandHelper.Execute(em, entity, cmd.TargetPosition);
+                    case DispatchKind.AttackMove:
+                        AttackMoveCommandHelper.Execute(em, p.Entity, p.TargetPosition);
+                        break;
+                    case DispatchKind.Patrol:
+                        PatrolCommandHelper.Execute(em, p.Entity, p.TargetPosition);
                         break;
                 }
             }
+
+            pending.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Q-5 — Iterator-invalidation in CommandQueueSystem

Same anti-pattern that previously bit the mining systems. `CommandQueueSystem.OnUpdate` mutated archetypes inside its `SystemAPI.Query<>().WithEntityAccess()` foreach: `em.RemoveComponent<CommandQueueActive>` on empty buffers, plus the command helpers (`MoveCommandHelper.Execute` / `AttackMoveCommandHelper` / `PatrolCommandHelper`) which each add/remove a dozen components.

The first structural change inside the foreach invalidated the iterator, so the shift-queue feature silently dropped any unit beyond the first one processed in a given tick. Multi-waypoint queues stalled on the second unit's first command.

## Refactor

Two-phase pattern (matches what mining/gathering systems already use):

- **Phase 1** — foreach collects `(Entity, DispatchKind, TargetPosition)` into a `NativeList<PendingDispatch>`. Buffer reads + `buffer.RemoveAt(0)` are safe inside the foreach (buffer mutation, not archetype change).
- **Phase 2** — outside the foreach, apply structural changes (helper calls + `CommandQueueActive` removal) with defensive `em.Exists` / `HasComponent` guards.

No behavioural change to dispatch logic — same per-entity decisions, just safe now.

Backlog (`task-062`) updated: Q-5 marked DONE in PR #250.

## Test plan
- [ ] Select 2 units, shift+right-click 3 waypoints each → both units traverse all 3 waypoints (was: second unit stalled after the first waypoint dispatched)
- [ ] Shift+right-click a queue while a unit has a current command in progress → queue waits, then drains in order on completion
- [ ] Hold shift, build a queue, release shift → queue drains starting from the first command
- [ ] Single-unit queue with 5 commands still works correctly
- [ ] Mixing Move / AttackMove / Patrol in the same queue → each command type fires through its helper as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)