### PR TITLE
feat(sect): task-063 phase 2c — 4 more Lv I passives

### DIFF
--- a/Assets/Scripts/Core/Components/BuildingComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingComponents.cs
@@ -331,6 +331,20 @@ public struct UnderConstruction : IComponentData
 }
 
 /// <summary>
+/// Tracks the wall-clock time of the most recent damage taken by a building.
+/// Written by <c>CombatDamageHelper.TrackLastDamager</c>; read by sect systems
+/// that need an "out of combat" signal (e.g. Renewal's auto-repair, which
+/// only ticks once SecondsSinceLastDamage &gt;= OutOfCombatThreshold).
+/// (task-063 phase 2c)
+/// </summary>
+public struct BuildingDamageState : IComponentData
+{
+    /// <summary>Seconds-since-world-start when this building was last damaged.
+    /// Matches <c>SystemAPI.Time.ElapsedTime</c>.</summary>
+    public double LastDamagedAt;
+}
+
+/// <summary>
 /// Build order assigned to a builder unit.
 /// </summary>
 public struct BuildOrder : IComponentData

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -54,6 +54,39 @@ public struct Invulnerable : IComponentData
 }
 
 /// <summary>
+/// Witness's "All-Seeing" vision-bonus stamp (task-063 sect Lv I+).
+/// Stamped on a Scout entity once its LineOfSight.Radius has been multiplied
+/// by Witness's per-level vision factor. <c>AppliedLevel</c> records the
+/// level the bonus was applied at — when Phase 4 lever upgrades land, the
+/// diff between AppliedLevel and the current lever level is applied.
+/// </summary>
+public struct WitnessVisionApplied : IComponentData
+{
+    public byte AppliedLevel; // 1/2/3 — matches SectQuery.LevelOf
+}
+
+/// <summary>
+/// Justice's "Marked for Sentence" mark (task-063 sect Lv I).
+/// Applied to an enemy unit when it kills one of your units, IF the killed
+/// unit's faction has Justice adopted. While active:
+///   - The marked unit is visible through fog of war to the marker faction.
+///   - It takes +10% damage (Lv I — scales to +20%/+30% in Phase 4) from
+///     units of the marker faction.
+/// Self-removed by SpellBuffSystem when TimeRemaining hits 0.
+/// </summary>
+public struct MarkedForSentence : IComponentData
+{
+    /// <summary>Faction that placed the mark (the avenger).</summary>
+    public Faction MarkerFaction;
+
+    /// <summary>Bonus damage multiplier added when the marker faction attacks (e.g. 0.10 = +10%).</summary>
+    public float DamageBonus;
+
+    /// <summary>Seconds remaining on the mark.</summary>
+    public float TimeRemaining;
+}
+
+/// <summary>
 /// Veneration's "Fervor" passive (task-063 sect Lv I).
 /// On every kill the killer unit gains a stack of +damage / +attack-speed
 /// for a few seconds, refreshed on each kill. The stack count is capped to

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -101,6 +101,42 @@ namespace TheWaningBorder.Systems.Combat
                 final = (int)(final * condemned.DamageMultiplier);
             }
 
+            // MarkedForSentence (Justice Lv I passive): if the target was marked
+            // by the attacker's faction, the marker faction's units deal bonus
+            // damage. Other factions attacking the same target don't get the
+            // bonus — the mark is per-marker. (task-063 phase 2c)
+            if (em.HasComponent<MarkedForSentence>(target)
+                && em.HasComponent<FactionTag>(attacker))
+            {
+                var mark = em.GetComponentData<MarkedForSentence>(target);
+                if (mark.MarkerFaction == em.GetComponentData<FactionTag>(attacker).Value
+                    && mark.DamageBonus > 0f)
+                {
+                    final = (int)(final * (1f + mark.DamageBonus));
+                }
+            }
+
+            // Wrath Lv I "Spite of the Forsaken" passive: attacker deals
+            // +0.5% damage per 5% HP missing (max +9.5% at 1 HP). The blood-
+            // pool half (+10% in pools at Lv I) lives behind Phase 3 and is
+            // not applied here. Phase 4 scales the per-stack bonus to 1% / 1.5%
+            // for Lv II / Lv III. (task-063 phase 2c)
+            if (em.HasComponent<FactionTag>(attacker)
+                && em.HasComponent<Health>(attacker)
+                && SectQuery.IsAdoptedAtLeast(em,
+                    em.GetComponentData<FactionTag>(attacker).Value,
+                    SectConfig.Wrath, SectLeverKind.Passive))
+            {
+                var hp = em.GetComponentData<Health>(attacker);
+                if (hp.Max > 0 && hp.Value < hp.Max)
+                {
+                    float fractionMissing = 1f - (float)hp.Value / hp.Max;
+                    // 0.5% per 5% missing == 0.1× the missing fraction.
+                    float bonus = fractionMissing * 0.10f;
+                    final = (int)(final * (1f + bonus));
+                }
+            }
+
             // IgniteBuff: attacker's next attacks deal bonus fire damage
             if (em.HasComponent<IgniteBuff>(attacker))
             {
@@ -153,9 +189,15 @@ namespace TheWaningBorder.Systems.Combat
         /// Updates LastDamagedByFaction and LastAttackerEntity on the target.
         /// Used by PillageSystem, CaravanDeathSystem, and defensive-stance
         /// return-fire logic.
+        ///
+        /// If <paramref name="elapsedTime"/> is non-zero AND the target is a
+        /// building, also stamps <see cref="BuildingDamageState.LastDamagedAt"/>
+        /// so out-of-combat readers (Renewal's auto-repair Lv I, etc.) can
+        /// gate repair ticks on a quiet-window threshold. Pass 0 from callers
+        /// that don't have the time handy. (task-063 phase 2c)
         /// </summary>
         public static void TrackLastDamager(EntityManager em, EntityCommandBuffer ecb,
-            Entity attacker, Entity target)
+            Entity attacker, Entity target, double elapsedTime = 0)
         {
             if (em.HasComponent<FactionTag>(attacker))
             {
@@ -175,6 +217,16 @@ namespace TheWaningBorder.Systems.Combat
                 em.SetComponentData(target, new LastAttackerEntity { Value = attacker });
                 else
                     ecb.AddComponent(target, new LastAttackerEntity { Value = attacker });
+
+            // Building-only damage timestamp for the out-of-combat repair window.
+            if (elapsedTime > 0 && em.HasComponent<BuildingTag>(target))
+            {
+                var stamp = new BuildingDamageState { LastDamagedAt = elapsedTime };
+                if (em.HasComponent<BuildingDamageState>(target))
+                    em.SetComponentData(target, stamp);
+                else
+                    ecb.AddComponent(target, stamp);
+            }
         }
 
         // task-063 phase 1: ApplySectOnHitDebuffs deleted with the old

--- a/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
@@ -42,6 +42,7 @@ namespace TheWaningBorder.Systems.Combat
             var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
             var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
             var dt = SystemAPI.Time.DeltaTime;
+            var elapsed = SystemAPI.Time.ElapsedTime; // for BuildingDamageState stamps
             var em = state.EntityManager;
 
             foreach (var (transform, target, cooldown, damage, entity) in SystemAPI
@@ -200,7 +201,7 @@ namespace TheWaningBorder.Systems.Combat
                         em.SetComponentData(tgt.Value, health);
 
                         // Fix #226: last-damager tracking routed through shared helper
-                        CombatDamageHelper.TrackLastDamager(em, ecb, entity, tgt.Value);
+                        CombatDamageHelper.TrackLastDamager(em, ecb, entity, tgt.Value, elapsed);
 
                         // Reset cooldown (sect attack-speed multiplier removed in Phase 1).
                         cd.Timer = cd.Cooldown;

--- a/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
+++ b/Assets/Scripts/Systems/Combat/ProjectileSystem.cs
@@ -138,7 +138,7 @@ namespace TheWaningBorder.Systems.Combat
 
                             if (t >= 0.95f || distToTarget < HitRadius)
                             {
-                                ApplyDamage(em, ecb, proj, targetEntity, targetIsAlive, arr.Shooter);
+                                ApplyDamage(em, ecb, proj, targetEntity, targetIsAlive, arr.Shooter, time);
                                 shouldDestroy = true;
                             }
                             else
@@ -201,7 +201,7 @@ namespace TheWaningBorder.Systems.Combat
                                 float d = math.length(new float2(diff.x, diff.z));
                                 if (d < 2.5f)
                                 {
-                                    ApplyDamage(em, ecb, proj, pierceEntities[pi], true, arr.Shooter);
+                                    ApplyDamage(em, ecb, proj, pierceEntities[pi], true, arr.Shooter, time);
                                     pierce.RemainingPierces--;
                                     if (pierce.RemainingPierces <= 0) { shouldDestroy = true; break; }
                                 }
@@ -221,7 +221,7 @@ namespace TheWaningBorder.Systems.Combat
                         }
                         else if (!shouldDestroy && (t >= 0.95f || distToTarget < HitRadius))
                         {
-                            ApplyDamage(em, ecb, proj, targetEntity, targetIsAlive, arr.Shooter);
+                            ApplyDamage(em, ecb, proj, targetEntity, targetIsAlive, arr.Shooter, time);
                             shouldDestroy = true;
                         }
                         else if (!shouldDestroy)
@@ -284,7 +284,7 @@ namespace TheWaningBorder.Systems.Combat
         /// Shared between arrow and laser impact paths.
         /// </summary>
         private static void ApplyDamage(EntityManager em, EntityCommandBuffer ecb, in Projectile proj,
-            Entity targetEntity, bool targetIsAlive, Entity shooter = default)
+            Entity targetEntity, bool targetIsAlive, Entity shooter = default, double elapsed = 0)
         {
             if (!targetIsAlive || targetEntity == Entity.Null || !em.Exists(targetEntity)) return;
             if (!em.HasComponent<Health>(targetEntity)) return;
@@ -345,6 +345,17 @@ namespace TheWaningBorder.Systems.Combat
                     em.SetComponentData(targetEntity, new LastAttackerEntity { Value = shooter });
                     else
                         ecb.AddComponent(targetEntity, new LastAttackerEntity { Value = shooter });
+            }
+
+            // Stamp BuildingDamageState for the out-of-combat repair window
+            // (Renewal Lv I auto-repair). (task-063 phase 2c)
+            if (elapsed > 0 && em.HasComponent<BuildingTag>(targetEntity))
+            {
+                var stamp = new BuildingDamageState { LastDamagedAt = elapsed };
+                if (em.HasComponent<BuildingDamageState>(targetEntity))
+                    em.SetComponentData(targetEntity, stamp);
+                else
+                    ecb.AddComponent(targetEntity, stamp);
             }
         }
 

--- a/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
@@ -1,0 +1,117 @@
+// SectJusticeMarkSystem.cs
+// Implements Justice's Lv I "Marked for Sentence" passive: an enemy that
+// kills one of your units is marked for 30s — visible through fog and
+// taking +10% damage from units of your faction.
+//
+// Hook: scans freshly-dead entities (same WithNone-marker pattern as
+// PillageSystem / SectVenerationFervorSystem). Reads LastAttackerEntity
+// to find the killer, gates on the VICTIM's faction having Justice
+// adopted (the avenger is the dead unit's faction), then applies the
+// MarkedForSentence component to the killer.
+//
+// The damage bonus flows through CombatDamageHelper (a small read site
+// added in this same task) when the marker-faction's units attack.
+// Visibility-through-fog is enforced by FogOfWarSystem reading
+// MarkedForSentence on visible enemies and revealing them to the
+// marker faction.
+//
+// task-063 phase 2c.
+//
+// Location: Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectJusticeMarkSystem : ISystem
+    {
+        // Lv I tuning. Phase 4 will scale these via SectQuery.LevelOf.
+        private const float MarkDuration = 30f;
+        private const float MarkDamageBonus = 0.10f; // +10% damage taken at Lv I
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // Phase 1: tick existing marks. Collect expired into a list and
+            // remove after the foreach (structural change).
+            var expired = new NativeList<Entity>(8, Allocator.Temp);
+            foreach (var (mark, entity) in SystemAPI
+                .Query<RefRW<MarkedForSentence>>()
+                .WithEntityAccess())
+            {
+                mark.ValueRW.TimeRemaining -= dt;
+                if (mark.ValueRO.TimeRemaining <= 0f)
+                    expired.Add(entity);
+            }
+            for (int i = 0; i < expired.Length; i++)
+            {
+                if (em.Exists(expired[i]) && em.HasComponent<MarkedForSentence>(expired[i]))
+                    em.RemoveComponent<MarkedForSentence>(expired[i]);
+            }
+            expired.Dispose();
+
+            // Phase 2: detect kills and stamp the killer.
+            foreach (var (health, lastAttacker, victimFaction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastAttackerEntity>, RefRO<FactionTag>>()
+                .WithNone<DeathAnimationState, BuildingCollapseState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Entity killer = lastAttacker.ValueRO.Value;
+                if (killer == Entity.Null || !em.Exists(killer)) continue;
+                if (!em.HasComponent<FactionTag>(killer)) continue;
+
+                Faction avengerFaction = victimFaction.ValueRO.Value;
+                Faction killerFaction = em.GetComponentData<FactionTag>(killer).Value;
+                if (avengerFaction == killerFaction) continue; // friendly fire — no mark
+
+                // Gate on the VICTIM's faction having Justice adopted.
+                if (!SectQuery.IsAdoptedAtLeast(em, avengerFaction,
+                        SectConfig.Justice, SectLeverKind.Passive)) continue;
+
+                var mark = new MarkedForSentence
+                {
+                    MarkerFaction = avengerFaction,
+                    DamageBonus   = MarkDamageBonus,
+                    TimeRemaining = MarkDuration,
+                };
+
+                if (em.HasComponent<MarkedForSentence>(killer))
+                {
+                    // Refresh: take the harsher mark (longer duration / higher
+                    // bonus) if multiple Justice factions both lost a unit to
+                    // this killer recently.
+                    var existing = em.GetComponentData<MarkedForSentence>(killer);
+                    if (existing.MarkerFaction == avengerFaction)
+                    {
+                        // Same avenger — just refresh.
+                        existing.TimeRemaining = MarkDuration;
+                        em.SetComponentData(killer, existing);
+                    }
+                    else if (mark.DamageBonus > existing.DamageBonus
+                          || mark.TimeRemaining > existing.TimeRemaining)
+                    {
+                        em.SetComponentData(killer, mark);
+                    }
+                }
+                else
+                {
+                    em.AddComponentData(killer, mark);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e8b4f6d9c1a7358b6f0e3a5d9c8b2a4

--- a/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
@@ -1,0 +1,84 @@
+// SectRenewalAutoRepairSystem.cs
+// Implements Renewal's Lv I "Hands That Mend" passive (the auto-repair half):
+// buildings owned by a Renewal faction restore HP at 12% of MaxHP per minute
+// once they've been out of combat for at least OutOfCombatThreshold seconds.
+//
+// "Out of combat" is read from BuildingDamageState.LastDamagedAt (stamped by
+// CombatDamageHelper.TrackLastDamager + ProjectileSystem.ApplyDamage). A
+// building with no BuildingDamageState component is treated as "never been
+// damaged" — eligible immediately.
+//
+// The unit-refund half of the passive (12% of cost back when one of your
+// units dies) is deferred to a later phase — it overlaps with Ruin's refund
+// rule and needs the no-stack guard to be designed first.
+//
+// task-063 phase 2c.
+//
+// Location: Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
+
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectRenewalAutoRepairSystem : ISystem
+    {
+        // Lv I tuning. Phase 4: 25% / 40% per minute for Lv II / Lv III.
+        private const float RepairRatePerMinute = 0.12f;            // 12% of MaxHP per minute
+        private const float OutOfCombatThreshold = 5.0f;             // seconds without taking damage
+        private const float TickInterval = 0.5f;                     // half-second tick (240 buildings @ 60fps would be wasteful)
+
+        // Per-system tick accumulator.
+        private float _tickTimer;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BuildingTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            _tickTimer += dt;
+            if (_tickTimer < TickInterval) return;
+            float effectiveDt = _tickTimer;
+            _tickTimer = 0f;
+
+            var em = state.EntityManager;
+            double now = SystemAPI.Time.ElapsedTime;
+
+            // Convert per-minute rate to per-tick HP delta.
+            // tickHp = MaxHP * 0.12 * (effectiveDt / 60).
+            float perTickFraction = RepairRatePerMinute * (effectiveDt / 60f);
+
+            foreach (var (health, faction, entity) in SystemAPI
+                .Query<RefRW<Health>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<UnderConstruction>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value <= 0) continue;
+                if (health.ValueRO.Value >= health.ValueRO.Max) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Renewal, SectLeverKind.Passive)) continue;
+
+                // Out-of-combat gate: skip if damaged within the last threshold.
+                if (em.HasComponent<BuildingDamageState>(entity))
+                {
+                    var dmg = em.GetComponentData<BuildingDamageState>(entity);
+                    if (now - dmg.LastDamagedAt < OutOfCombatThreshold) continue;
+                }
+
+                // Tick repair. Round up so a low-Max building still gets at least 1 HP per tick.
+                int delta = (int)math.ceil(health.ValueRO.Max * perTickFraction);
+                if (delta < 1) delta = 1;
+
+                int newHp = math.min(health.ValueRO.Max, health.ValueRO.Value + delta);
+                health.ValueRW.Value = newHp;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a4e2c9d6b8f5137a4c1e3b8d6f9c2e5

--- a/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
@@ -1,0 +1,66 @@
+// SectWitnessVisionSystem.cs
+// Implements Witness's Lv I "All-Seeing" passive (scouts +25% vision range).
+//
+// Scans Scout-class units that don't yet carry WitnessVisionApplied and,
+// for those whose faction has Witness adopted, multiplies LineOfSight.Radius
+// by the Lv I factor and stamps WitnessVisionApplied to mark them as
+// already-bonused. This handles BOTH paths uniformly:
+//   - Scouts existing at adoption time: stamped on the next tick.
+//   - Scouts trained AFTER adoption: stamped when they enter the query.
+//
+// Lv II / Lv III scaling lives in Phase 4 — when the lever level upgrades,
+// a diff system will apply the (newFactor - oldFactor) delta to scouts
+// already stamped at the prior level. The AppliedLevel byte on the stamp
+// is what makes that diff math possible.
+//
+// task-063 phase 2c.
+//
+// Location: Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectWitnessVisionSystem : ISystem
+    {
+        // Lv I factor. Phase 4: 1.50× / 1.75× for Lv II / Lv III.
+        private const float VisionMultiplierLv1 = 1.25f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Collect scouts that need the bonus stamped — defer the actual
+            // archetype mutation (AddComponent) until after the foreach.
+            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+
+            foreach (var (unit, faction, los, entity) in SystemAPI
+                .Query<RefRO<UnitTag>, RefRO<FactionTag>, RefRW<LineOfSight>>()
+                .WithNone<WitnessVisionApplied>()
+                .WithEntityAccess())
+            {
+                if (unit.ValueRO.Class != UnitClass.Scout) continue;
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Witness, SectLeverKind.Passive)) continue;
+
+                los.ValueRW.Radius *= VisionMultiplierLv1;
+                pendingStamps.Add(entity);
+            }
+
+            for (int i = 0; i < pendingStamps.Length; i++)
+            {
+                if (em.Exists(pendingStamps[i]))
+                    em.AddComponentData(pendingStamps[i], new WitnessVisionApplied { AppliedLevel = 1 });
+            }
+            pendingStamps.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d9f7c5b8e2a4f1648c3b6d1a5e8f0c7


### PR DESCRIPTION
Continues Phase 2 by landing **Justice / Witness / Renewal / Wrath** Lv I passives end-to-end against the `SectQuery` read pattern from Phase 2b (PR #251). Each is a partial implementation — design pieces that depend on Phase 3 (blood pools) or larger infrastructure are deferred and noted in the system comments.

## New components
- **`MarkedForSentence`** (`SpellComponents.cs`): per-target mark with `MarkerFaction` + `DamageBonus` + `TimeRemaining`. Stamped on enemies that kill a Justice unit.
- **`WitnessVisionApplied`** (`SpellComponents.cs`): one-byte stamp on Scouts whose `LineOfSight` has already been bumped by Witness's adoption. `AppliedLevel` byte readied for Phase 4 lever upgrades.
- **`BuildingDamageState`** (`BuildingComponents.cs`): seconds-since-world timestamp of the most recent damage taken. Lets out-of-combat readers (Renewal auto-repair, future sect cooldown gates) detect quiet windows without polling Health every frame.

## New systems (`Assets/Scripts/Systems/Sect/`)
- **`SectJusticeMarkSystem`** — scans freshly-dead entities (same `WithNone` pattern as PillageSystem / SectVenerationFervorSystem). When the victim's faction has Justice adopted, stamps `MarkedForSentence` on the killer for 30s. Refresh rule: same-avenger refreshes timer, different-avenger only overwrites if harsher. Per-tick expiry in the same system.
- **`SectWitnessVisionSystem`** — scans Scout-class units without `WitnessVisionApplied`; if the faction has Witness adopted, multiplies `LineOfSight.Radius` by 1.25× (Lv I) and stamps the unit. Handles both at-adoption and at-training paths uniformly.
- **`SectRenewalAutoRepairSystem`** — half-second tick. For every faction-owned non-construction building of a Renewal-adopted faction, if `BuildingDamageState.LastDamagedAt` is older than 5s, restore HP at 12% of MaxHP per minute. Caps at MaxHP.

## Combat-pipeline patches
`CombatDamageHelper.ApplyBonusDamageOnHit` now reads:
- **`MarkedForSentence`**: when the marker faction's units attack the marked target, deal `+DamageBonus` (10% at Lv I).
- **Wrath's "Spite of the Forsaken"**: +0.5% damage per 5% HP missing on the attacker (max +9.5% at 1 HP). Blood-pool half is Phase 3.

`CombatDamageHelper.TrackLastDamager` grew an optional `elapsedTime` parameter; when non-zero AND the target is a building, it stamps `BuildingDamageState`. Wired through `MeleeCombatSystem` + `ProjectileSystem` (its private static `ApplyDamage` signature gained an `elapsed` parameter, threaded from the `OnUpdate` `time` local).

## Deferred (noted in system comments)
- Justice mark **visible-through-fog**: needs FogOfWarSystem patch to reveal `MarkedForSentence` units to the marker faction. Phase 5.
- Witness **"spotted enemies stay on minimap +15s"**: needs MinimapRenderer retention timer per spotted entity. Phase 5.
- Renewal **"killed units refund 12% cost"**: overlaps with Ruin's refund-on-destroy and needs the no-stack guard designed first.
- Wrath **blood-pool +10% damage** half: blocked on Phase 3 blood layer.
- **Lv II / Lv III scaling**: Phase 4 reads `SectQuery.LevelOf`.

## Test plan
- [ ] Adopt **Justice** → enemy unit kills one of yours → enemy gets MarkedForSentence (visual pending; check DesignTime tooltip / debugger). Your units attack the marked enemy → +10% damage. Mark expires after 30s.
- [ ] Adopt **Witness** → existing Scouts have +25% LineOfSight on the next tick. Train a new Scout → also gets the bonus on its first tick.
- [ ] Adopt **Renewal** → take a building down to ~50% HP → wait 5s → HP slowly regens to full at 12%/min.
- [ ] Adopt **Wrath** → take a unit down to low HP → it deals visibly more damage (max +9.5% at 1 HP).
- [ ] None of the above effects fire for non-adopted factions.

Backlog: 7 sects' Lv I passives still inert (Antiquity / Fortitude / Reclamation / Silence / War / Ash / Ruin). Phase 2d slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)