### PR TITLE
feat(sect): task-063 phase 2d — 4 more Lv I passives

### DIFF
--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -54,6 +54,19 @@ public struct Invulnerable : IComponentData
 }
 
 /// <summary>
+/// Fortitude's "Veiled Stone" HP-bonus stamp (task-063 sect Lv I+).
+/// Stamped on a wall, wall hub, or tower entity once its <c>Health.Max</c>
+/// (and current <c>Value</c>, by the same fraction) has been multiplied
+/// by Fortitude's per-level HP factor. <c>AppliedLevel</c> records the
+/// level the bonus was applied at so Phase 4 lever upgrades can apply
+/// the diff (factorAtNewLevel / factorAtOldLevel) without re-scaling.
+/// </summary>
+public struct FortitudeHpApplied : IComponentData
+{
+    public byte AppliedLevel; // 1/2/3 — matches SectQuery.LevelOf
+}
+
+/// <summary>
 /// Witness's "All-Seeing" vision-bonus stamp (task-063 sect Lv I+).
 /// Stamped on a Scout entity once its LineOfSight.Radius has been multiplied
 /// by Witness's per-level vision factor. <c>AppliedLevel</c> records the

--- a/Assets/Scripts/Data/TechTree/BuildingCosts.cs
+++ b/Assets/Scripts/Data/TechTree/BuildingCosts.cs
@@ -4,6 +4,7 @@
 // Part of: Data/
 
 using System.Collections.Generic;
+using Unity.Entities;
 using TheWaningBorder.Core;
 
 namespace TheWaningBorder.Data
@@ -146,6 +147,74 @@ namespace TheWaningBorder.Data
                                     int crystal = 0, int veilsteel = 0, int glow = 0)
         {
             _byId[id] = Cost.Of(supplies, iron, crystal, veilsteel, glow);
+        }
+
+        /// <summary>
+        /// Reverse-map a built building entity to its cost-table ID using the
+        /// tag components that BuildingFactory stamped at creation time. Returns
+        /// null if no known tag is present (e.g. legacy or sect-unique entities).
+        ///
+        /// Centralized here so SelfDestructSystem (refund-on-self-destruct),
+        /// SectRuinRefundSystem (Ruin Lv I 12% refund), and future cost-aware
+        /// readers all share one mapping. Wall-instance entities are mapped to
+        /// the per-culture wall ID since BuildCosts keys them per culture.
+        /// (task-063 phase 2d)
+        /// </summary>
+        public static string IdFromEntity(EntityManager em, Entity entity)
+        {
+            // Era 1 core
+            if (em.HasComponent<HallTag>(entity)) return "Hall";
+            if (em.HasComponent<HutTag>(entity)) return "Hut";
+            if (em.HasComponent<GathererHutTag>(entity)) return "GatherersHut";
+            if (em.HasComponent<BarracksTag>(entity)) return "Barracks";
+
+            // Era 1 choice
+            if (em.HasComponent<ShrineTag>(entity)) return "ShrineOfAhridan";
+            if (em.HasComponent<TempleOfRidanTag>(entity)
+                || em.HasComponent<TempleTag>(entity)) return "TempleOfRidan";
+            if (em.HasComponent<VaultTag>(entity)) return "VaultOfAlmierra";
+            if (em.HasComponent<FiendstoneKeepTag>(entity)) return "FiendstoneKeep";
+
+            // Runai
+            if (em.HasComponent<OutpostTag>(entity)) return "Runai_Outpost";
+            if (em.HasComponent<TradeHubTag>(entity)) return "Runai_TradeHub";
+            if (em.HasComponent<BazaarTag>(entity)) return "ThessarasBazaar";
+            if (em.HasComponent<SiegeWorkshopTag>(entity)) return "Runai_SiegeWorkshop";
+
+            // Alanthor
+            if (em.HasComponent<SmelterTag>(entity)) return "Alanthor_Smelter";
+            if (em.HasComponent<CrucibleTag>(entity)) return "Alanthor_Crucible";
+            if (em.HasComponent<WatchTowerTag>(entity)) return "Alanthor_Tower";
+            if (em.HasComponent<GarrisonTag>(entity)) return "Alanthor_Garrison";
+            if (em.HasComponent<RoyalStableTag>(entity)) return "Alanthor_Stable";
+            if (em.HasComponent<SiegeYardTag>(entity)) return "Alanthor_SiegeYard";
+
+            // Feraldis
+            if (em.HasComponent<HuntingLodgeTag>(entity)) return "Feraldis_HuntingLodge";
+            if (em.HasComponent<LoggingStationTag>(entity)) return "Feraldis_LoggingStation";
+            if (em.HasComponent<WarbrandFoundryTag>(entity)) return "Feraldis_Foundry";
+            if (em.HasComponent<LonghouseTag>(entity)) return "Feraldis_Longhouse";
+            if (em.HasComponent<TotemTowerTag>(entity)) return "Feraldis_Tower";
+            if (em.HasComponent<FerSiegeYardTag>(entity)) return "Feraldis_SiegeYard";
+
+            // Walls / wall instances — map to the generic Alanthor wall ID; refund
+            // here is small and identical across cultures, so a per-culture branch
+            // is overkill until Phase 5 polish.
+            if (em.HasComponent<WallTowerTag>(entity)) return "Alanthor_WallTower";
+            if (em.HasComponent<WallGateTag>(entity)) return "Alanthor_WallGate";
+            if (em.HasComponent<WallInstanceTag>(entity)
+                || em.HasComponent<WallTag>(entity)
+                || em.HasComponent<WallHubTag>(entity)
+                || em.HasComponent<WallSegmentTag>(entity)) return "Alanthor_Wall";
+
+            // Chapels: SectConfig owns their ids; resolve via ChapelTag.SectId.
+            if (em.HasComponent<ChapelTag>(entity))
+            {
+                var sectId = em.GetComponentData<ChapelTag>(entity).SectId.ToString();
+                return TheWaningBorder.Economy.SectConfig.ChapelIdFor(sectId);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Economy/WarSectCostHelper.cs
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs
@@ -1,0 +1,73 @@
+// WarSectCostHelper.cs
+// Discount-helper for War's Lv I "Forged in Battle" passive (military -5% cost).
+// Used at every unit-train Spend call site in the UI / AI to keep the
+// discount uniform without sprinkling SectQuery checks everywhere.
+//
+// Per-level scaling (Phase 4):
+//   Lv I  : -5% cost,  +15% train speed,  +0.5%/produced (cap +12%)
+//   Lv II : -10% cost, +25% train speed,  +1%/produced  (cap +25%)
+//   Lv III: -15% cost, +35% train speed,  +1.5%/produced (cap +35%)
+// Phase 2d wires Lv I only — the cost discount + the train-speed discount
+// (in TrainingSystem). The "+%/produced" bonus is deferred until Phase 4
+// (it needs a per-faction produced-counter component).
+//
+// task-063 phase 2d.
+//
+// Location: Assets/Scripts/Economy/WarSectCostHelper.cs
+
+using Unity.Entities;
+using TheWaningBorder.Core;
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// Cost-modifier helpers for War's military discount. Stateless.
+    /// </summary>
+    public static class WarSectCostHelper
+    {
+        /// <summary>
+        /// Lv I cost multiplier: 0.95 (i.e. -5%). Phase 4 will read SectQuery.LevelOf
+        /// and pick the right per-level multiplier.
+        /// </summary>
+        private const float CostMultiplierLv1 = 0.95f;
+
+        /// <summary>
+        /// Returns the cost the faction should be charged for training
+        /// <paramref name="unitId"/>. Applies War's military discount if the
+        /// faction has War adopted AND the unit is a military class.
+        /// Non-military units (workers / scouts / support) pay the base cost.
+        /// </summary>
+        public static Cost MilitaryDiscount(EntityManager em, Faction faction, string unitId, in Cost baseCost)
+        {
+            if (!IsMilitaryUnit(unitId)) return baseCost;
+            if (!SectQuery.IsAdoptedAtLeast(em, faction,
+                    SectConfig.War, SectLeverKind.Passive)) return baseCost;
+            return Scale(baseCost, CostMultiplierLv1);
+        }
+
+        /// <summary>
+        /// True if a unit id is a military class (melee / ranged / siege).
+        /// Sect units are special — see SectUniqueUnitTag check at runtime.
+        /// </summary>
+        public static bool IsMilitaryUnit(string unitId)
+        {
+            if (string.IsNullOrEmpty(unitId)) return false;
+            var cls = TheWaningBorder.Entities.UnitFactory.GetUnitClass(unitId);
+            return cls == UnitClass.Melee
+                || cls == UnitClass.Ranged
+                || cls == UnitClass.Siege;
+        }
+
+        private static Cost Scale(in Cost c, float mult)
+        {
+            return new Cost
+            {
+                Supplies  = (int)(c.Supplies  * mult),
+                Iron      = (int)(c.Iron      * mult),
+                Crystal   = (int)(c.Crystal   * mult),
+                Veilsteel = (int)(c.Veilsteel * mult),
+                Glow      = (int)(c.Glow      * mult),
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Economy/WarSectCostHelper.cs.meta
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b3c7a5d2e8f4f1564a8c6d1b3e9f7c2

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -116,6 +116,26 @@ namespace TheWaningBorder.Systems.Combat
                 }
             }
 
+            // Ruin Lv I "Profane Hands" passive: Ruin-adopted attackers deal
+            // +25% damage to enemy buildings. The 12% cost-refund-on-destruction
+            // half lives in SectRuinRefundSystem. Friendly-fire on own buildings
+            // is rare but explicitly excluded — the bonus only applies when
+            // attacker faction != target faction. Phase 4 scales the multiplier
+            // to 1.40× / 1.60× for Lv II / Lv III. (task-063 phase 2d)
+            if (em.HasComponent<BuildingTag>(target)
+                && em.HasComponent<FactionTag>(attacker)
+                && em.HasComponent<FactionTag>(target))
+            {
+                var atkFac = em.GetComponentData<FactionTag>(attacker).Value;
+                var tgtFac = em.GetComponentData<FactionTag>(target).Value;
+                if (atkFac != tgtFac
+                    && SectQuery.IsAdoptedAtLeast(em, atkFac,
+                        SectConfig.Ruin, SectLeverKind.Passive))
+                {
+                    final = (int)(final * 1.25f);
+                }
+            }
+
             // Wrath Lv I "Spite of the Forsaken" passive: attacker deals
             // +0.5% damage per 5% HP missing (max +9.5% at 1 HP). The blood-
             // pool half (+10% in pools at Lv I) lives behind Phase 3 and is
@@ -161,6 +181,23 @@ namespace TheWaningBorder.Systems.Combat
                     : voidStrike.BonusDamage;
                 final += (int)bonus;
                 ecb.RemoveComponent<VoidStrikeBuff>(attacker);
+            }
+
+            // Reclamation Lv I "Curse-Hardened" passive (combat half): defender
+            // takes -25% damage from Crystal-faction PvE attackers. Applied last
+            // so the reduction comes off the final post-bonus number — same
+            // intent as a flat resistance. The cursed-ground DoT half is hooked
+            // separately in CursedGroundDamageSystem (it bypasses this helper).
+            // Phase 4 scales reduction to 35% / 50% for Lv II / Lv III.
+            // (task-063 phase 2d)
+            if (em.HasComponent<CrystalTag>(attacker)
+                && em.HasComponent<FactionTag>(target)
+                && SectQuery.IsAdoptedAtLeast(em,
+                    em.GetComponentData<FactionTag>(target).Value,
+                    SectConfig.Reclamation, SectLeverKind.Passive))
+            {
+                final = (int)(final * 0.75f);
+                if (final < 1) final = 1;
             }
 
             return final;

--- a/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
@@ -3,6 +3,7 @@ using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
+using TheWaningBorder.Economy;
 
 namespace TheWaningBorder.Systems.Creatures
 {
@@ -52,6 +53,7 @@ namespace TheWaningBorder.Systems.Creatures
             }
 
             // Apply damage to non-crystal units standing on cursed ground
+            var em = state.EntityManager;
             foreach (var (health, unitTransform, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<LocalTransform>>()
                 .WithAll<UnitTag>()
@@ -71,6 +73,19 @@ namespace TheWaningBorder.Systems.Creatures
                     {
                         // Apply one tick of damage (DPS * tick interval)
                         int damage = math.max(1, (int)(groundDPS[i].DamagePerSecond * DamageTickInterval));
+
+                        // Reclamation Lv I "Curse-Hardened" passive: Reclamation-
+                        // adopted factions take -25% from Crystal-Curse PvE.
+                        // Mirrors the combat-path reduction in CombatDamageHelper.
+                        // (task-063 phase 2d)
+                        if (em.HasComponent<FactionTag>(entity)
+                            && SectQuery.IsAdoptedAtLeast(em,
+                                em.GetComponentData<FactionTag>(entity).Value,
+                                SectConfig.Reclamation, SectLeverKind.Passive))
+                        {
+                            damage = math.max(1, (int)(damage * 0.75f));
+                        }
+
                         ref var hp = ref health.ValueRW;
                         hp.Value = math.max(0, hp.Value - damage);
                         break; // Only take damage from one tile per tick

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
@@ -1,0 +1,73 @@
+// SectFortitudeHpSystem.cs
+// Implements Fortitude's Lv I "Veiled Stone" passive (walls/towers +12% HP).
+// Mirrors SectWitnessVisionSystem's stamp-and-apply pattern: scans walls
+// (WallTag) and towers (WatchTowerTag, TotemTowerTag, WallTowerTag) of
+// Fortitude-adopted factions that don't yet carry FortitudeHpApplied, and
+// multiplies both Health.Max and Health.Value by the Lv I factor (×1.12).
+//
+// Tower range +0.5 (the second half of the Lv I lever) is deferred — tower
+// fire range is read in BuildingCombatSystem and will need a per-faction
+// scalar. Phase 4 / Phase 5.
+//
+// task-063 phase 2d.
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectFortitudeHpSystem : ISystem
+    {
+        // Lv I factor. Phase 4: 1.25× / 1.40× for Lv II / Lv III.
+        private const float HpMultiplierLv1 = 1.12f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BuildingTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+
+            foreach (var (health, faction, entity) in SystemAPI
+                .Query<RefRW<Health>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<FortitudeHpApplied>()
+                .WithEntityAccess())
+            {
+                // Only apply to walls + towers — the Lv I lever specifies them.
+                bool isWallOrTower =
+                    em.HasComponent<WallTag>(entity)
+                 || em.HasComponent<WallHubTag>(entity)
+                 || em.HasComponent<WallInstanceTag>(entity)
+                 || em.HasComponent<WallTowerTag>(entity)
+                 || em.HasComponent<WatchTowerTag>(entity)
+                 || em.HasComponent<TotemTowerTag>(entity);
+                if (!isWallOrTower) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Fortitude, SectLeverKind.Passive)) continue;
+
+                var hp = health.ValueRO;
+                int newMax = (int)(hp.Max * HpMultiplierLv1);
+                int newVal = (int)(hp.Value * HpMultiplierLv1);
+                health.ValueRW.Max = newMax;
+                health.ValueRW.Value = newVal;
+
+                pendingStamps.Add(entity);
+            }
+
+            for (int i = 0; i < pendingStamps.Length; i++)
+            {
+                if (em.Exists(pendingStamps[i]))
+                    em.AddComponentData(pendingStamps[i], new FortitudeHpApplied { AppliedLevel = 1 });
+            }
+            pendingStamps.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c8e5b3a4d9f7261e3a4b2c5d8e9f1a4

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
@@ -1,0 +1,79 @@
+// SectRuinRefundSystem.cs
+// Implements Ruin's Lv I "Profane Hands" passive (the 12%-refund-on-destruction
+// half). Mirrors PillageSystem: ticks before DeathSystem, scans entities at
+// Health <= 0 that haven't entered the death-animation pipeline yet, and if
+// the killer faction has Ruin adopted AND the dead entity is an enemy
+// building, credits the killer with 12% of the building's build cost.
+//
+// The +25% damage-vs-buildings half lives in CombatDamageHelper.ApplyBonusDamageOnHit.
+//
+// No-stack note: design rule #3 says Renewal/Ruin/Reclamation refunds don't
+// stack. Renewal Lv I refunds 12% of cost on UNIT death (deferred to a later
+// phase — see SectRenewalAutoRepairSystem.cs); Ruin Lv I refunds 12% on
+// BUILDING death. They never compete on the same entity, so no per-event
+// guard component is needed at Lv I. If Phase 4 introduces a sect that also
+// pays out on building destruction, a RefundConsumed marker should be added
+// here BEFORE the second sect is wired up.
+//
+// task-063 phase 2d.
+//
+// Location: Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Data;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectRuinRefundSystem : ISystem
+    {
+        // Lv I refund factor. Phase 4: 0.18 / 0.25 for Lv II / Lv III.
+        private const float RefundFraction = 0.12f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastDamager, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastDamagedByFaction>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<DeathAnimationState, BuildingCollapseState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction killerFaction = lastDamager.ValueRO.Value;
+                Faction victimFaction = faction.ValueRO.Value;
+
+                // Skip own-faction kills (denies refund-farming demolitions).
+                if (killerFaction == victimFaction) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
+                        SectConfig.Ruin, SectLeverKind.Passive)) continue;
+
+                string buildingId = BuildCosts.IdFromEntity(em, entity);
+                if (buildingId == null) continue;
+                if (!BuildCosts.TryGet(buildingId, out var cost)) continue;
+
+                var refund = Cost.Of(
+                    supplies:  (int)(cost.Supplies  * RefundFraction),
+                    iron:      (int)(cost.Iron      * RefundFraction),
+                    crystal:   (int)(cost.Crystal   * RefundFraction),
+                    veilsteel: (int)(cost.Veilsteel * RefundFraction),
+                    glow:      (int)(cost.Glow      * RefundFraction)
+                );
+
+                FactionEconomy.Add(em, killerFaction, refund);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c2e8b7d9a3f615284a7c3d1b6e8f4a9

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -89,6 +89,17 @@ namespace TheWaningBorder.Systems.Training
                     if (FactionColors.GetFactionCulture(buildingFaction) == Cultures.Feraldis)
                         trainingTime *= 1.75f;
 
+                    // Sect of War Lv I: military units train 15% faster.
+                    // (task-063 phase 2d) — Phase 4 scales to 25% / 35% for Lv II/III.
+                    bool isMilitary = UnitFactory.GetUnitClass(unitId) == UnitClass.Melee
+                                   || UnitFactory.GetUnitClass(unitId) == UnitClass.Ranged
+                                   || UnitFactory.GetUnitClass(unitId) == UnitClass.Siege;
+                    if (isMilitary && SectQuery.IsAdoptedAtLeast(state.EntityManager, buildingFaction,
+                            SectConfig.War, SectLeverKind.Passive))
+                    {
+                        trainingTime *= 0.85f; // -15% time = ×0.85
+                    }
+
                     ts.ValueRW.Busy = 1;
                     ts.ValueRW.Remaining = trainingTime;
                 }

--- a/Assets/Scripts/UI/Panels/EntityActionPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityActionPanel.cs
@@ -344,8 +344,10 @@ namespace TheWaningBorder.UI.Panels
                     return;
                 }
 
-                // Deduct cost when adding to queue
-                if (!FactionEconomy.Spend(em, faction, button.Cost))
+                // Deduct cost when adding to queue. War Lv I -5% discount applies
+                // to military units only (task-063 phase 2d).
+                var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                if (!FactionEconomy.Spend(em, faction, trainCost))
                 {
                     PlayerNotificationSystem.NotifyError("Not enough resources");
                     return;
@@ -441,7 +443,8 @@ namespace TheWaningBorder.UI.Panels
                         return;
                     }
 
-                    if (!FactionEconomy.Spend(em, faction, button.Cost))
+                    var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                    if (!FactionEconomy.Spend(em, faction, trainCost))
                     {
                         PlayerNotificationSystem.NotifyError("Not enough resources");
                         return;
@@ -807,7 +810,8 @@ namespace TheWaningBorder.UI.Panels
                         return;
                     }
 
-                    if (!FactionEconomy.Spend(em, faction, button.Cost))
+                    var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                    if (!FactionEconomy.Spend(em, faction, trainCost))
                     {
                         PlayerNotificationSystem.NotifyError("Not enough resources");
                         return;


### PR DESCRIPTION
## Summary
- War 'Forged in Battle' Lv I: military units cost -5% supplies and train +15% faster. WarSectCostHelper centralizes the discount across 3 EntityActionPanel spend sites; TrainingSystem multiplies trainingTime by 0.85.
- Fortitude 'Veiled Stone' Lv I: walls + hubs + instances + towers of Fortitude factions get HP x 1.12 (Max + Value), stamped with FortitudeHpApplied for Phase 4 diff upgrades.
- Ruin 'Profane Hands' Lv I: +25% damage to enemy buildings (CombatDamageHelper), +12% cost refund on destruction (new SectRuinRefundSystem, mirrors PillageSystem pre-DeathSystem hook). BuildCosts.IdFromEntity centralizes the entity->cost-id mapping.
- Reclamation 'Curse-Hardened' Lv I: -25% damage from Crystal PvE attackers (combat path + cursed-ground DoT path).
- No-stack rule (Renewal/Ruin/Reclamation): Renewal pays on unit deaths, Ruin pays on buildings — they never compete on the same entity, so no per-event guard at Lv I.

## Test plan
- [ ] War: train a Swordsman with War-adopted faction, confirm 95% supplies cost in EntityActionPanel.
- [ ] War: confirm visibly faster training (compare unit-train timer with/without War adoption).
- [ ] Fortitude: build a wall + watchtower as Fortitude-adopted, confirm HP shows 1.12x the base.
- [ ] Ruin: kill an enemy GathererHut as Ruin-adopted, confirm 12% supplies/iron credited.
- [ ] Ruin: Ruin units swing enemy buildings, confirm ~+25% damage per swing.
- [ ] Reclamation: stand a Reclamation unit on cursed ground, confirm DoT ~75% of normal.
- [ ] Reclamation: take damage from a Veilstinger as Reclamation-adopted, confirm reduced incoming damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)