### PR TITLE
feat(sect): task-063 phase 2e — Antiquity + Silence Lv I

### DIFF
--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -117,3 +117,54 @@ public struct VenerationFervor : IComponentData
     /// <summary>Seconds remaining before the stack expires (refreshed each kill).</summary>
     public float TimeRemaining;
 }
+
+/// <summary>
+/// Antiquity's "Tally of the Lost" passive (task-063 sect Lv I).
+/// Per-attacker, per-victim-class kill counter — each kill of a given
+/// <see cref="UnitClass"/> grants the killer +1% damage on future hits
+/// against that class, capped per-class. Lv I cap is 10 kills (so the
+/// max bonus per class is +10%).
+///
+/// Layout: one byte per UnitClass (0..7) for an 8-byte total — a
+/// DynamicBuffer would have been overkill since the class count is fixed
+/// and tiny. Phase 4 raises the cap and per-kill bonus.
+///
+/// Stamped lazily by SectAntiquityTallySystem the first time the unit
+/// makes a relevant kill; consumed by CombatDamageHelper on every hit.
+/// </summary>
+public struct AntiquityKills : IComponentData
+{
+    public byte Melee;
+    public byte Ranged;
+    public byte Siege;
+    public byte Support;
+    public byte Magic;
+    public byte Economy;
+    public byte Miner;
+    public byte Scout;
+}
+
+/// <summary>
+/// Silence's "Steadfast Vigil" passive (task-063 sect Lv I).
+/// Tracks how long this unit has been holding position (HoldPositionTag).
+/// Refreshed every frame by SectSilenceVigilSystem while the tag is
+/// present; removed (along with <see cref="SilenceVigilArmor"/>) the
+/// frame the tag drops, so the bonus fades the instant the unit moves.
+/// </summary>
+public struct SilenceVigilState : IComponentData
+{
+    /// <summary>Seconds spent in HoldPosition stance.</summary>
+    public float TimeInStance;
+}
+
+/// <summary>
+/// Active armor bump from Silence's Steadfast Vigil. Consumed by
+/// CombatDamageHelper.GetSpellBuffArmorBonus alongside SpellBuff.ArmorBonus
+/// so the matrix damage formula sees the buff. Lives behind a dedicated
+/// component (rather than SpellBuff) so it can be cleared cleanly when
+/// the unit moves — SpellBuff would leak its longest-running field.
+/// </summary>
+public struct SilenceVigilArmor : IComponentData
+{
+    public int Bonus;
+}

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -5,6 +5,7 @@
 using Unity.Entities;
 using Unity.Mathematics;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Sect;
 
 namespace TheWaningBorder.Systems.Combat
 {
@@ -31,16 +32,21 @@ namespace TheWaningBorder.Systems.Combat
     public static class CombatDamageHelper
     {
         /// <summary>
-        /// Returns the SpellBuff.ArmorBonus on the target (0 if no SpellBuff).
-        /// Callers MUST add this to the defender's defense value before running
-        /// the damage-type x armor-type matrix. Wired into Melee/Ranged combat
-        /// so abilities like StoneheartBastion's +3 armor aura actually fire.
-        /// (task-062 C-1)
+        /// Returns extra armor on the target — sums SpellBuff.ArmorBonus and
+        /// SilenceVigilArmor.Bonus. Callers MUST add this to the defender's
+        /// defense value before running the damage-type x armor-type matrix.
+        /// Wired into Melee/Ranged combat so abilities like StoneheartBastion's
+        /// +3 armor aura and Silence's "Steadfast Vigil" stance bonus actually
+        /// fire. (task-062 C-1, task-063 phase 2e)
         /// </summary>
         public static int GetSpellBuffArmorBonus(EntityManager em, Entity target)
         {
-            if (!em.HasComponent<SpellBuff>(target)) return 0;
-            return (int)em.GetComponentData<SpellBuff>(target).ArmorBonus;
+            int bonus = 0;
+            if (em.HasComponent<SpellBuff>(target))
+                bonus += (int)em.GetComponentData<SpellBuff>(target).ArmorBonus;
+            if (em.HasComponent<SilenceVigilArmor>(target))
+                bonus += em.GetComponentData<SilenceVigilArmor>(target).Bonus;
+            return bonus;
         }
 
         /// <summary>
@@ -134,6 +140,20 @@ namespace TheWaningBorder.Systems.Combat
                 {
                     final = (int)(final * 1.25f);
                 }
+            }
+
+            // Antiquity Lv I "Tally of the Lost" passive: +1% per logged kill
+            // of the *target's* UnitClass on this attacker (capped at +10% per
+            // class — the cap lives in SectAntiquityTallySystem). Phase 4
+            // raises both the per-kill bonus and the cap. (task-063 phase 2e)
+            if (em.HasComponent<AntiquityKills>(attacker)
+                && em.HasComponent<UnitTag>(target))
+            {
+                var kills = em.GetComponentData<AntiquityKills>(attacker);
+                var tgtClass = em.GetComponentData<UnitTag>(target).Class;
+                byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
+                if (n > 0)
+                    final = (int)(final * (1f + 0.01f * n));
             }
 
             // Wrath Lv I "Spite of the Forsaken" passive: attacker deals

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
@@ -1,0 +1,107 @@
+// SectAntiquityTallySystem.cs
+// Implements Antiquity's Lv I "Tally of the Lost" passive: each kill the
+// attacker makes is logged into a per-UnitClass counter on the attacker
+// (the AntiquityKills component). CombatDamageHelper reads those counters
+// on every hit and grants +1% per logged kill of the *target's* class,
+// capped at +10% (Lv I). Phase 4 raises both the per-kill bonus and the
+// cap.
+//
+// Hook: same death-event pattern as SectVenerationFervorSystem. Runs
+// before DeathSystem, scans entities at Health <= 0 with no death-marker,
+// reads LastAttackerEntity, increments the killer's class counter for
+// the dead unit's UnitClass.
+//
+// task-063 phase 2e.
+//
+// Location: Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectAntiquityTallySystem : ISystem
+    {
+        // Lv I cap. Phase 4: 16 / 25 for Lv II / Lv III.
+        private const byte KillCap = 10;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastAttacker, victimUnit, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastAttackerEntity>, RefRO<UnitTag>>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Entity killer = lastAttacker.ValueRO.Value;
+                if (killer == Entity.Null || !em.Exists(killer)) continue;
+                if (!em.HasComponent<FactionTag>(killer)) continue;
+                if (!em.HasComponent<UnitTag>(killer)) continue;
+
+                Faction killerFaction = em.GetComponentData<FactionTag>(killer).Value;
+                if (em.HasComponent<FactionTag>(entity)
+                    && em.GetComponentData<FactionTag>(entity).Value == killerFaction) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
+                        SectConfig.Antiquity, SectLeverKind.Passive)) continue;
+
+                var victimClass = victimUnit.ValueRO.Class;
+
+                // Stamp lazily on first relevant kill.
+                if (!em.HasComponent<AntiquityKills>(killer))
+                    em.AddComponentData(killer, new AntiquityKills());
+
+                var kills = em.GetComponentData<AntiquityKills>(killer);
+                Increment(ref kills, victimClass);
+                em.SetComponentData(killer, kills);
+            }
+        }
+
+        private static void Increment(ref AntiquityKills k, UnitClass cls)
+        {
+            switch (cls)
+            {
+                case UnitClass.Melee:   if (k.Melee   < KillCap) k.Melee++;   break;
+                case UnitClass.Ranged:  if (k.Ranged  < KillCap) k.Ranged++;  break;
+                case UnitClass.Siege:   if (k.Siege   < KillCap) k.Siege++;   break;
+                case UnitClass.Support: if (k.Support < KillCap) k.Support++; break;
+                case UnitClass.Magic:   if (k.Magic   < KillCap) k.Magic++;   break;
+                case UnitClass.Economy: if (k.Economy < KillCap) k.Economy++; break;
+                case UnitClass.Miner:   if (k.Miner   < KillCap) k.Miner++;   break;
+                case UnitClass.Scout:   if (k.Scout   < KillCap) k.Scout++;   break;
+            }
+        }
+
+        /// <summary>
+        /// Read the per-class kill count for a unit. Returns 0 if the attacker
+        /// has no AntiquityKills component yet. Public so CombatDamageHelper
+        /// can fold the bonus in without duplicating the switch.
+        /// </summary>
+        public static byte KillsAgainst(in AntiquityKills k, UnitClass cls)
+        {
+            switch (cls)
+            {
+                case UnitClass.Melee:   return k.Melee;
+                case UnitClass.Ranged:  return k.Ranged;
+                case UnitClass.Siege:   return k.Siege;
+                case UnitClass.Support: return k.Support;
+                case UnitClass.Magic:   return k.Magic;
+                case UnitClass.Economy: return k.Economy;
+                case UnitClass.Miner:   return k.Miner;
+                case UnitClass.Scout:   return k.Scout;
+                default: return 0;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d3f1c4a7b2e9163528a4d6c9f1b3e57

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
@@ -1,0 +1,105 @@
+// SectSilenceVigilSystem.cs
+// Implements Silence's Lv I "Steadfast Vigil" passive: a unit holding
+// position (HoldPositionTag) belonging to a Silence-adopted faction
+// accumulates a defense bonus that ramps over time. The bonus is exposed
+// via the SilenceVigilArmor component, which CombatDamageHelper.GetSpellBuffArmorBonus
+// folds into the matrix damage formula on the defender side.
+//
+// Ramp (Lv I): 0..2s held = 0 armor, 2..6s = linear 0 -> +6, 6s+ = +6.
+// Phase 4 raises the cap and shortens the warm-up window.
+//
+// On HoldPosition release the system removes both SilenceVigilState and
+// SilenceVigilArmor on the same frame so the bonus drops the instant
+// the unit moves — preventing a "carry the buff out of the stance" leak
+// that would happen if we mirrored the bonus into a SpellBuff with a
+// non-zero TimeRemaining.
+//
+// task-063 phase 2e.
+//
+// Location: Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectSilenceVigilSystem : ISystem
+    {
+        // Lv I tuning. Phase 4: faster warm-up + higher cap for Lv II / Lv III.
+        private const float WarmupSeconds = 2f;
+        private const float RampSeconds   = 4f;   // ramp window AFTER warm-up
+        private const int   ArmorCap      = 6;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<HoldPositionTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            var em = state.EntityManager;
+
+            // Ramp: tick TimeInStance, then write the matching armor bump.
+            // Skip units whose faction doesn't have Silence adopted — for
+            // them the state simply never gets stamped.
+            foreach (var (faction, entity) in SystemAPI
+                .Query<RefRO<FactionTag>>()
+                .WithAll<HoldPositionTag, UnitTag>()
+                .WithEntityAccess())
+            {
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Silence, SectLeverKind.Passive)) continue;
+
+                float t;
+                if (em.HasComponent<SilenceVigilState>(entity))
+                {
+                    var st = em.GetComponentData<SilenceVigilState>(entity);
+                    st.TimeInStance += dt;
+                    em.SetComponentData(entity, st);
+                    t = st.TimeInStance;
+                }
+                else
+                {
+                    em.AddComponentData(entity, new SilenceVigilState { TimeInStance = dt });
+                    t = dt;
+                }
+
+                int bonus;
+                if (t < WarmupSeconds) bonus = 0;
+                else if (t >= WarmupSeconds + RampSeconds) bonus = ArmorCap;
+                else
+                {
+                    float fraction = (t - WarmupSeconds) / RampSeconds;
+                    bonus = (int)(fraction * ArmorCap);
+                }
+
+                if (em.HasComponent<SilenceVigilArmor>(entity))
+                    em.SetComponentData(entity, new SilenceVigilArmor { Bonus = bonus });
+                else if (bonus > 0)
+                    em.AddComponentData(entity, new SilenceVigilArmor { Bonus = bonus });
+            }
+
+            // Sweep: any unit that has SilenceVigilState/Armor but is no
+            // longer holding position must lose both immediately.
+            var toClear = new NativeList<Entity>(8, Allocator.Temp);
+            foreach (var (st, entity) in SystemAPI
+                .Query<RefRO<SilenceVigilState>>()
+                .WithNone<HoldPositionTag>()
+                .WithEntityAccess())
+            {
+                toClear.Add(entity);
+            }
+            for (int i = 0; i < toClear.Length; i++)
+            {
+                var e = toClear[i];
+                if (!em.Exists(e)) continue;
+                if (em.HasComponent<SilenceVigilState>(e)) em.RemoveComponent<SilenceVigilState>(e);
+                if (em.HasComponent<SilenceVigilArmor>(e)) em.RemoveComponent<SilenceVigilArmor>(e);
+            }
+            toClear.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e1a8b6f3d2c4915e8b3a7c2f4d6e198


### PR DESCRIPTION
## Summary
- Antiquity 'Tally of the Lost' Lv I: per-attacker, per-victim-class kill counter (8-byte AntiquityKills, one byte per UnitClass). SectAntiquityTallySystem mirrors SectVenerationFervorSystem's death-event hook; CombatDamageHelper applies +1% per logged kill of the target's class on every hit, cap +10%/class.
- Silence 'Steadfast Vigil' Lv I: HoldPositionTag units of Silence-adopted factions accumulate +armor over time (0..+6 over a 2s warm-up + 4s ramp). SilenceVigilState tracks time, SilenceVigilArmor exposes the bonus, GetSpellBuffArmorBonus folds it into the matrix damage formula. Both components clear the frame HoldPositionTag drops — the bonus fades the instant the unit moves.
- This closes Phase 2 of task-063 (all 12 sect Lv I passives shipped). Phase 3 is the Feraldis blood-pool layer, Phase 4 is Lv II/III scaling.

## Test plan
- [ ] Antiquity: kill 3 enemy Archers (Ranged) as an Antiquity-adopted faction, then attack a 4th — confirm ~+3% damage (vs Archers only, not vs Melee).
- [ ] Antiquity: per-class is per-attacker — different units of the same faction should each have their own kill streak.
- [ ] Antiquity: cap at 10 — make 12+ kills of one class, confirm bonus stops growing past +10%.
- [ ] Silence: hold position with a Silence-adopted unit; first 2s should show no defense change, then armor ramps until ~6s.
- [ ] Silence: move the unit — armor bonus should drop instantly on the next hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)