### PR TITLE
feat(sect): task-063 phase 4 + Ash Lv I

### DIFF
--- a/Assets/Scripts/Economy/WarSectCostHelper.cs
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs
@@ -26,10 +26,25 @@ namespace TheWaningBorder.Economy
     public static class WarSectCostHelper
     {
         /// <summary>
-        /// Lv I cost multiplier: 0.95 (i.e. -5%). Phase 4 will read SectQuery.LevelOf
-        /// and pick the right per-level multiplier.
+        /// Per-level cost multiplier — Lv I/II/III give -5/-10/-15%.
         /// </summary>
-        private const float CostMultiplierLv1 = 0.95f;
+        public static float CostMultiplierFor(byte level) => level switch
+        {
+            2 => 0.90f,
+            3 => 0.85f,
+            _ => 0.95f,
+        };
+
+        /// <summary>
+        /// Per-level training-time multiplier — Lv I/II/III give -15/-25/-35%.
+        /// Read by TrainingSystem when computing the per-unit train cooldown.
+        /// </summary>
+        public static float TrainTimeMultiplierFor(byte level) => level switch
+        {
+            2 => 0.75f,
+            3 => 0.65f,
+            _ => 0.85f,
+        };
 
         /// <summary>
         /// Returns the cost the faction should be charged for training
@@ -40,9 +55,9 @@ namespace TheWaningBorder.Economy
         public static Cost MilitaryDiscount(EntityManager em, Faction faction, string unitId, in Cost baseCost)
         {
             if (!IsMilitaryUnit(unitId)) return baseCost;
-            if (!SectQuery.IsAdoptedAtLeast(em, faction,
-                    SectConfig.War, SectLeverKind.Passive)) return baseCost;
-            return Scale(baseCost, CostMultiplierLv1);
+            byte level = SectQuery.LevelOf(em, faction, SectConfig.War, SectLeverKind.Passive);
+            if (level == 0) return baseCost;
+            return Scale(baseCost, CostMultiplierFor(level));
         }
 
         /// <summary>

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -122,58 +122,86 @@ namespace TheWaningBorder.Systems.Combat
                 }
             }
 
-            // Ruin Lv I "Profane Hands" passive: Ruin-adopted attackers deal
-            // +25% damage to enemy buildings. The 12% cost-refund-on-destruction
-            // half lives in SectRuinRefundSystem. Friendly-fire on own buildings
-            // is rare but explicitly excluded — the bonus only applies when
-            // attacker faction != target faction. Phase 4 scales the multiplier
-            // to 1.40× / 1.60× for Lv II / Lv III. (task-063 phase 2d)
+            // Ruin "Profane Hands": Ruin-adopted attackers deal +25/40/60%
+            // damage to enemy buildings. Refund-on-destroy half lives in
+            // SectRuinRefundSystem. Friendly fire is excluded. (task-063
+            // phase 2d / phase 4 scaling)
             if (em.HasComponent<BuildingTag>(target)
                 && em.HasComponent<FactionTag>(attacker)
                 && em.HasComponent<FactionTag>(target))
             {
                 var atkFac = em.GetComponentData<FactionTag>(attacker).Value;
                 var tgtFac = em.GetComponentData<FactionTag>(target).Value;
-                if (atkFac != tgtFac
-                    && SectQuery.IsAdoptedAtLeast(em, atkFac,
-                        SectConfig.Ruin, SectLeverKind.Passive))
+                if (atkFac != tgtFac)
                 {
-                    final = (int)(final * 1.25f);
+                    byte ruinLevel = SectQuery.LevelOf(em, atkFac,
+                        SectConfig.Ruin, SectLeverKind.Passive);
+                    if (ruinLevel > 0)
+                    {
+                        float ruinMult = ruinLevel switch
+                        {
+                            2 => 1.40f,
+                            3 => 1.60f,
+                            _ => 1.25f,
+                        };
+                        final = (int)(final * ruinMult);
+                    }
                 }
             }
 
-            // Antiquity Lv I "Tally of the Lost" passive: +1% per logged kill
-            // of the *target's* UnitClass on this attacker (capped at +10% per
-            // class — the cap lives in SectAntiquityTallySystem). Phase 4
-            // raises both the per-kill bonus and the cap. (task-063 phase 2e)
+            // Antiquity "Tally of the Lost": +N% per logged kill of the
+            // target's UnitClass; per-kill bonus scales with lever level.
+            // (task-063 phase 2e / phase 4 scaling)
             if (em.HasComponent<AntiquityKills>(attacker)
-                && em.HasComponent<UnitTag>(target))
+                && em.HasComponent<UnitTag>(target)
+                && em.HasComponent<FactionTag>(attacker))
             {
-                var kills = em.GetComponentData<AntiquityKills>(attacker);
-                var tgtClass = em.GetComponentData<UnitTag>(target).Class;
-                byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
-                if (n > 0)
-                    final = (int)(final * (1f + 0.01f * n));
+                byte antiqLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(attacker).Value,
+                    SectConfig.Antiquity, SectLeverKind.Passive);
+                if (antiqLevel > 0)
+                {
+                    var kills = em.GetComponentData<AntiquityKills>(attacker);
+                    var tgtClass = em.GetComponentData<UnitTag>(target).Class;
+                    byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
+                    if (n > 0)
+                    {
+                        float perKill = antiqLevel switch
+                        {
+                            2 => 0.015f,
+                            3 => 0.020f,
+                            _ => 0.010f,
+                        };
+                        final = (int)(final * (1f + perKill * n));
+                    }
+                }
             }
 
-            // Wrath Lv I "Spite of the Forsaken" passive: attacker deals
-            // +0.5% damage per 5% HP missing (max +9.5% at 1 HP). The blood-
-            // pool half (+10% in pools at Lv I) lives behind Phase 3 and is
-            // not applied here. Phase 4 scales the per-stack bonus to 1% / 1.5%
-            // for Lv II / Lv III. (task-063 phase 2c)
+            // Wrath "Spite of the Forsaken": +N% per 5% HP missing on the
+            // attacker. Lv I 0.5% per 5% (max +9.5%). Lv II 1% (max +19%).
+            // Lv III 1.5% (max +28.5%). Blood-pool half lives in Phase 3.
+            // (task-063 phase 2c / phase 4 scaling)
             if (em.HasComponent<FactionTag>(attacker)
-                && em.HasComponent<Health>(attacker)
-                && SectQuery.IsAdoptedAtLeast(em,
-                    em.GetComponentData<FactionTag>(attacker).Value,
-                    SectConfig.Wrath, SectLeverKind.Passive))
+                && em.HasComponent<Health>(attacker))
             {
-                var hp = em.GetComponentData<Health>(attacker);
-                if (hp.Max > 0 && hp.Value < hp.Max)
+                byte wrathLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(attacker).Value,
+                    SectConfig.Wrath, SectLeverKind.Passive);
+                if (wrathLevel > 0)
                 {
-                    float fractionMissing = 1f - (float)hp.Value / hp.Max;
-                    // 0.5% per 5% missing == 0.1× the missing fraction.
-                    float bonus = fractionMissing * 0.10f;
-                    final = (int)(final * (1f + bonus));
+                    var hp = em.GetComponentData<Health>(attacker);
+                    if (hp.Max > 0 && hp.Value < hp.Max)
+                    {
+                        float fractionMissing = 1f - (float)hp.Value / hp.Max;
+                        // Per-level scalar on the fraction-missing.
+                        float scalar = wrathLevel switch
+                        {
+                            2 => 0.20f,
+                            3 => 0.30f,
+                            _ => 0.10f,
+                        };
+                        final = (int)(final * (1f + fractionMissing * scalar));
+                    }
                 }
             }
 
@@ -203,21 +231,28 @@ namespace TheWaningBorder.Systems.Combat
                 ecb.RemoveComponent<VoidStrikeBuff>(attacker);
             }
 
-            // Reclamation Lv I "Curse-Hardened" passive (combat half): defender
-            // takes -25% damage from Crystal-faction PvE attackers. Applied last
-            // so the reduction comes off the final post-bonus number — same
-            // intent as a flat resistance. The cursed-ground DoT half is hooked
-            // separately in CursedGroundDamageSystem (it bypasses this helper).
-            // Phase 4 scales reduction to 35% / 50% for Lv II / Lv III.
-            // (task-063 phase 2d)
+            // Reclamation "Curse-Hardened" (combat half): defender takes -25/35/50%
+            // damage from Crystal-faction PvE attackers. Applied last so the
+            // reduction comes off the final post-bonus number — same intent as
+            // a flat resistance. The cursed-ground DoT half is in
+            // CursedGroundDamageSystem. (task-063 phase 2d / phase 4 scaling)
             if (em.HasComponent<CrystalTag>(attacker)
-                && em.HasComponent<FactionTag>(target)
-                && SectQuery.IsAdoptedAtLeast(em,
-                    em.GetComponentData<FactionTag>(target).Value,
-                    SectConfig.Reclamation, SectLeverKind.Passive))
+                && em.HasComponent<FactionTag>(target))
             {
-                final = (int)(final * 0.75f);
-                if (final < 1) final = 1;
+                byte reclLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(target).Value,
+                    SectConfig.Reclamation, SectLeverKind.Passive);
+                if (reclLevel > 0)
+                {
+                    float reclMult = reclLevel switch
+                    {
+                        2 => 0.65f,
+                        3 => 0.50f,
+                        _ => 0.75f,
+                    };
+                    final = (int)(final * reclMult);
+                    if (final < 1) final = 1;
+                }
             }
 
             return final;

--- a/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
@@ -74,16 +74,25 @@ namespace TheWaningBorder.Systems.Creatures
                         // Apply one tick of damage (DPS * tick interval)
                         int damage = math.max(1, (int)(groundDPS[i].DamagePerSecond * DamageTickInterval));
 
-                        // Reclamation Lv I "Curse-Hardened" passive: Reclamation-
-                        // adopted factions take -25% from Crystal-Curse PvE.
+                        // Reclamation "Curse-Hardened" passive: Reclamation-
+                        // adopted factions take -25/35/50% from Crystal-Curse PvE.
                         // Mirrors the combat-path reduction in CombatDamageHelper.
-                        // (task-063 phase 2d)
-                        if (em.HasComponent<FactionTag>(entity)
-                            && SectQuery.IsAdoptedAtLeast(em,
-                                em.GetComponentData<FactionTag>(entity).Value,
-                                SectConfig.Reclamation, SectLeverKind.Passive))
+                        // (task-063 phase 2d / phase 4 scaling)
+                        if (em.HasComponent<FactionTag>(entity))
                         {
-                            damage = math.max(1, (int)(damage * 0.75f));
+                            byte reclLevel = SectQuery.LevelOf(em,
+                                em.GetComponentData<FactionTag>(entity).Value,
+                                SectConfig.Reclamation, SectLeverKind.Passive);
+                            if (reclLevel > 0)
+                            {
+                                float reclMult = reclLevel switch
+                                {
+                                    2 => 0.65f,
+                                    3 => 0.50f,
+                                    _ => 0.75f,
+                                };
+                                damage = math.max(1, (int)(damage * reclMult));
+                            }
                         }
 
                         ref var hp = ref health.ValueRW;

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
@@ -25,8 +25,12 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectAntiquityTallySystem : ISystem
     {
-        // Lv I cap. Phase 4: 16 / 25 for Lv II / Lv III.
-        private const byte KillCap = 10;
+        private static byte KillCapFor(byte level) => level switch
+        {
+            2 => 16,
+            3 => 25,
+            _ => 10,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -53,8 +57,9 @@ namespace TheWaningBorder.Systems.Sect
                 if (em.HasComponent<FactionTag>(entity)
                     && em.GetComponentData<FactionTag>(entity).Value == killerFaction) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Antiquity, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Antiquity, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 var victimClass = victimUnit.ValueRO.Class;
 
@@ -63,23 +68,23 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new AntiquityKills());
 
                 var kills = em.GetComponentData<AntiquityKills>(killer);
-                Increment(ref kills, victimClass);
+                Increment(ref kills, victimClass, KillCapFor(level));
                 em.SetComponentData(killer, kills);
             }
         }
 
-        private static void Increment(ref AntiquityKills k, UnitClass cls)
+        private static void Increment(ref AntiquityKills k, UnitClass cls, byte cap)
         {
             switch (cls)
             {
-                case UnitClass.Melee:   if (k.Melee   < KillCap) k.Melee++;   break;
-                case UnitClass.Ranged:  if (k.Ranged  < KillCap) k.Ranged++;  break;
-                case UnitClass.Siege:   if (k.Siege   < KillCap) k.Siege++;   break;
-                case UnitClass.Support: if (k.Support < KillCap) k.Support++; break;
-                case UnitClass.Magic:   if (k.Magic   < KillCap) k.Magic++;   break;
-                case UnitClass.Economy: if (k.Economy < KillCap) k.Economy++; break;
-                case UnitClass.Miner:   if (k.Miner   < KillCap) k.Miner++;   break;
-                case UnitClass.Scout:   if (k.Scout   < KillCap) k.Scout++;   break;
+                case UnitClass.Melee:   if (k.Melee   < cap) k.Melee++;   break;
+                case UnitClass.Ranged:  if (k.Ranged  < cap) k.Ranged++;  break;
+                case UnitClass.Siege:   if (k.Siege   < cap) k.Siege++;   break;
+                case UnitClass.Support: if (k.Support < cap) k.Support++; break;
+                case UnitClass.Magic:   if (k.Magic   < cap) k.Magic++;   break;
+                case UnitClass.Economy: if (k.Economy < cap) k.Economy++; break;
+                case UnitClass.Miner:   if (k.Miner   < cap) k.Miner++;   break;
+                case UnitClass.Scout:   if (k.Scout   < cap) k.Scout++;   break;
             }
         }
 

--- a/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
@@ -1,0 +1,106 @@
+// SectAshPyreSystem.cs
+// Implements Ash's Lv I "Pyre's Promise" passive: when a unit of an Ash-
+// adopted faction dies, it leaves a small burning-ground patch at its
+// death position — a low-DPS, short-lived AoE that damages enemies who
+// walk through it. Mirrors PillageSystem's death-event hook (runs before
+// DeathSystem with the WithNone marker so each death fires exactly once).
+//
+// Lv I tuning (overridden per-level by SectAshPyreSystem.GetTuning when
+// task-063 phase 4 lands):
+//   - DPS:      4
+//   - Duration: 3s
+//   - Radius:   2m
+//
+// task-063 phase 2f.
+//
+// Location: Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectAshPyreSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            var pyreSpawns = new NativeList<float3>(Allocator.Temp);
+            var pyreFactions = new NativeList<Faction>(Allocator.Temp);
+            var pyreDps = new NativeList<float>(Allocator.Temp);
+            var pyreRadius = new NativeList<float>(Allocator.Temp);
+            var pyreDuration = new NativeList<float>(Allocator.Temp);
+
+            foreach (var (health, transform, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<UnitTag>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction victimFaction = faction.ValueRO.Value;
+                byte level = SectQuery.LevelOf(em, victimFaction,
+                    SectConfig.Ash, SectLeverKind.Passive);
+                if (level == 0) continue;
+
+                GetTuning(level, out float dps, out float duration, out float radius);
+
+                pyreSpawns.Add(transform.ValueRO.Position);
+                pyreFactions.Add(victimFaction);
+                pyreDps.Add(dps);
+                pyreRadius.Add(radius);
+                pyreDuration.Add(duration);
+            }
+
+            for (int i = 0; i < pyreSpawns.Length; i++)
+            {
+                var pyre = em.CreateEntity(
+                    typeof(BurningGround),
+                    typeof(LocalTransform),
+                    typeof(FactionTag));
+                em.SetComponentData(pyre, new BurningGround
+                {
+                    DPS = pyreDps[i],
+                    TimeRemaining = pyreDuration[i],
+                    Radius = pyreRadius[i],
+                });
+                em.SetComponentData(pyre, LocalTransform.FromPositionRotationScale(
+                    pyreSpawns[i], quaternion.identity, 1f));
+                em.SetComponentData(pyre, new FactionTag { Value = pyreFactions[i] });
+            }
+
+            pyreSpawns.Dispose();
+            pyreFactions.Dispose();
+            pyreDps.Dispose();
+            pyreRadius.Dispose();
+            pyreDuration.Dispose();
+        }
+
+        /// <summary>
+        /// Per-level tuning. Lv I/II/III scale both potency and area.
+        /// (task-063 phase 4)
+        /// </summary>
+        public static void GetTuning(byte level, out float dps, out float duration, out float radius)
+        {
+            switch (level)
+            {
+                case 2:  dps = 7f; duration = 4f; radius = 2.5f; return;
+                case 3:  dps = 11f; duration = 5f; radius = 3f;  return;
+                default: dps = 4f; duration = 3f; radius = 2f;   return;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a4e2b9c5d1f6358247d3b8e1c6a4f95

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
@@ -20,8 +20,14 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectFortitudeHpSystem : ISystem
     {
-        // Lv I factor. Phase 4: 1.25× / 1.40× for Lv II / Lv III.
-        private const float HpMultiplierLv1 = 1.12f;
+        // Per-level HP multiplier. Phase 4 lever upgrades read AppliedLevel
+        // and apply the diff (factorAt(new) / factorAt(old)) — see below.
+        public static float MultiplierFor(byte level) => level switch
+        {
+            2 => 1.25f,
+            3 => 1.40f,
+            _ => 1.12f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -32,7 +38,9 @@ namespace TheWaningBorder.Systems.Sect
         {
             var em = state.EntityManager;
 
-            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+            // Pass 1: brand-new walls/towers that haven't received any HP bonus yet.
+            var pendingNewStamps = new NativeList<Entity>(8, Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(8, Allocator.Temp);
 
             foreach (var (health, faction, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<FactionTag>>()
@@ -50,24 +58,47 @@ namespace TheWaningBorder.Systems.Sect
                  || em.HasComponent<TotemTowerTag>(entity);
                 if (!isWallOrTower) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Fortitude, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Fortitude, SectLeverKind.Passive);
+                if (level == 0) continue;
 
+                float mult = MultiplierFor(level);
                 var hp = health.ValueRO;
-                int newMax = (int)(hp.Max * HpMultiplierLv1);
-                int newVal = (int)(hp.Value * HpMultiplierLv1);
-                health.ValueRW.Max = newMax;
-                health.ValueRW.Value = newVal;
+                health.ValueRW.Max   = (int)(hp.Max   * mult);
+                health.ValueRW.Value = (int)(hp.Value * mult);
 
-                pendingStamps.Add(entity);
+                pendingNewStamps.Add(entity);
+                pendingNewLevels.Add(level);
             }
 
-            for (int i = 0; i < pendingStamps.Length; i++)
+            for (int i = 0; i < pendingNewStamps.Length; i++)
             {
-                if (em.Exists(pendingStamps[i]))
-                    em.AddComponentData(pendingStamps[i], new FortitudeHpApplied { AppliedLevel = 1 });
+                if (em.Exists(pendingNewStamps[i]))
+                    em.AddComponentData(pendingNewStamps[i],
+                        new FortitudeHpApplied { AppliedLevel = pendingNewLevels[i] });
             }
-            pendingStamps.Dispose();
+            pendingNewStamps.Dispose();
+            pendingNewLevels.Dispose();
+
+            // Pass 2: already-stamped buildings whose faction's lever level
+            // has since increased. Apply the diff factor to bring them up
+            // to date and bump AppliedLevel. (task-063 phase 4)
+            foreach (var (health, faction, applied, entity) in SystemAPI
+                .Query<RefRW<Health>, RefRO<FactionTag>, RefRW<FortitudeHpApplied>>()
+                .WithAll<BuildingTag>()
+                .WithEntityAccess())
+            {
+                byte currentLevel = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Fortitude, SectLeverKind.Passive);
+                byte appliedLevel = applied.ValueRO.AppliedLevel;
+                if (currentLevel <= appliedLevel) continue;
+
+                float diffMult = MultiplierFor(currentLevel) / MultiplierFor(appliedLevel);
+                var hp = health.ValueRO;
+                health.ValueRW.Max   = (int)(hp.Max   * diffMult);
+                health.ValueRW.Value = (int)(hp.Value * diffMult);
+                applied.ValueRW.AppliedLevel = currentLevel;
+            }
         }
     }
 }

--- a/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
@@ -30,9 +30,16 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectJusticeMarkSystem : ISystem
     {
-        // Lv I tuning. Phase 4 will scale these via SectQuery.LevelOf.
+        // Mark duration is shared across levels — Phase 4 only scales the
+        // damage bonus per the Lv I/II/III spec (+10% / +20% / +30%).
         private const float MarkDuration = 30f;
-        private const float MarkDamageBonus = 0.10f; // +10% damage taken at Lv I
+
+        private static float DamageBonusFor(byte level) => level switch
+        {
+            2 => 0.20f,
+            3 => 0.30f,
+            _ => 0.10f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -79,13 +86,14 @@ namespace TheWaningBorder.Systems.Sect
                 if (avengerFaction == killerFaction) continue; // friendly fire — no mark
 
                 // Gate on the VICTIM's faction having Justice adopted.
-                if (!SectQuery.IsAdoptedAtLeast(em, avengerFaction,
-                        SectConfig.Justice, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, avengerFaction,
+                    SectConfig.Justice, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 var mark = new MarkedForSentence
                 {
                     MarkerFaction = avengerFaction,
-                    DamageBonus   = MarkDamageBonus,
+                    DamageBonus   = DamageBonusFor(level),
                     TimeRemaining = MarkDuration,
                 };
 

--- a/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
@@ -25,10 +25,17 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectRenewalAutoRepairSystem : ISystem
     {
-        // Lv I tuning. Phase 4: 25% / 40% per minute for Lv II / Lv III.
-        private const float RepairRatePerMinute = 0.12f;            // 12% of MaxHP per minute
+        // Out-of-combat threshold + tick interval are constant across levels.
+        // Repair-rate is per-level — Phase 4 scales per spec (12/25/40 %/min).
         private const float OutOfCombatThreshold = 5.0f;             // seconds without taking damage
         private const float TickInterval = 0.5f;                     // half-second tick (240 buildings @ 60fps would be wasteful)
+
+        private static float RepairRatePerMinuteFor(byte level) => level switch
+        {
+            2 => 0.25f,
+            3 => 0.40f,
+            _ => 0.12f,
+        };
 
         // Per-system tick accumulator.
         private float _tickTimer;
@@ -49,10 +56,6 @@ namespace TheWaningBorder.Systems.Sect
             var em = state.EntityManager;
             double now = SystemAPI.Time.ElapsedTime;
 
-            // Convert per-minute rate to per-tick HP delta.
-            // tickHp = MaxHP * 0.12 * (effectiveDt / 60).
-            float perTickFraction = RepairRatePerMinute * (effectiveDt / 60f);
-
             foreach (var (health, faction, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<FactionTag>>()
                 .WithAll<BuildingTag>()
@@ -62,8 +65,9 @@ namespace TheWaningBorder.Systems.Sect
                 if (health.ValueRO.Value <= 0) continue;
                 if (health.ValueRO.Value >= health.ValueRO.Max) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Renewal, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Renewal, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 // Out-of-combat gate: skip if damaged within the last threshold.
                 if (em.HasComponent<BuildingDamageState>(entity))
@@ -72,7 +76,8 @@ namespace TheWaningBorder.Systems.Sect
                     if (now - dmg.LastDamagedAt < OutOfCombatThreshold) continue;
                 }
 
-                // Tick repair. Round up so a low-Max building still gets at least 1 HP per tick.
+                // Per-level rate, then convert per-minute → per-tick HP delta.
+                float perTickFraction = RepairRatePerMinuteFor(level) * (effectiveDt / 60f);
                 int delta = (int)math.ceil(health.ValueRO.Max * perTickFraction);
                 if (delta < 1) delta = 1;
 

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
@@ -31,8 +31,13 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectRuinRefundSystem : ISystem
     {
-        // Lv I refund factor. Phase 4: 0.18 / 0.25 for Lv II / Lv III.
-        private const float RefundFraction = 0.12f;
+        // Per-level refund fraction.
+        private static float RefundFractionFor(byte level) => level switch
+        {
+            2 => 0.18f,
+            3 => 0.25f,
+            _ => 0.12f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -57,19 +62,21 @@ namespace TheWaningBorder.Systems.Sect
                 // Skip own-faction kills (denies refund-farming demolitions).
                 if (killerFaction == victimFaction) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Ruin, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Ruin, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 string buildingId = BuildCosts.IdFromEntity(em, entity);
                 if (buildingId == null) continue;
                 if (!BuildCosts.TryGet(buildingId, out var cost)) continue;
 
+                float frac = RefundFractionFor(level);
                 var refund = Cost.Of(
-                    supplies:  (int)(cost.Supplies  * RefundFraction),
-                    iron:      (int)(cost.Iron      * RefundFraction),
-                    crystal:   (int)(cost.Crystal   * RefundFraction),
-                    veilsteel: (int)(cost.Veilsteel * RefundFraction),
-                    glow:      (int)(cost.Glow      * RefundFraction)
+                    supplies:  (int)(cost.Supplies  * frac),
+                    iron:      (int)(cost.Iron      * frac),
+                    crystal:   (int)(cost.Crystal   * frac),
+                    veilsteel: (int)(cost.Veilsteel * frac),
+                    glow:      (int)(cost.Glow      * frac)
                 );
 
                 FactionEconomy.Add(em, killerFaction, refund);

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
@@ -27,10 +27,16 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectSilenceVigilSystem : ISystem
     {
-        // Lv I tuning. Phase 4: faster warm-up + higher cap for Lv II / Lv III.
-        private const float WarmupSeconds = 2f;
-        private const float RampSeconds   = 4f;   // ramp window AFTER warm-up
-        private const int   ArmorCap      = 6;
+        // Per-level tuning: warm-up shrinks and the cap grows with the lever.
+        private static void GetTuning(byte level, out float warmup, out float ramp, out int cap)
+        {
+            switch (level)
+            {
+                case 2:  warmup = 1.0f; ramp = 3.0f; cap = 10; return;
+                case 3:  warmup = 0.5f; ramp = 2.5f; cap = 15; return;
+                default: warmup = 2.0f; ramp = 4.0f; cap = 6;  return;
+            }
+        }
 
         public void OnCreate(ref SystemState state)
         {
@@ -50,8 +56,10 @@ namespace TheWaningBorder.Systems.Sect
                 .WithAll<HoldPositionTag, UnitTag>()
                 .WithEntityAccess())
             {
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Silence, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Silence, SectLeverKind.Passive);
+                if (level == 0) continue;
+                GetTuning(level, out float warmup, out float ramp, out int cap);
 
                 float t;
                 if (em.HasComponent<SilenceVigilState>(entity))
@@ -68,12 +76,12 @@ namespace TheWaningBorder.Systems.Sect
                 }
 
                 int bonus;
-                if (t < WarmupSeconds) bonus = 0;
-                else if (t >= WarmupSeconds + RampSeconds) bonus = ArmorCap;
+                if (t < warmup) bonus = 0;
+                else if (t >= warmup + ramp) bonus = cap;
                 else
                 {
-                    float fraction = (t - WarmupSeconds) / RampSeconds;
-                    bonus = (int)(fraction * ArmorCap);
+                    float fraction = (t - warmup) / ramp;
+                    bonus = (int)(fraction * cap);
                 }
 
                 if (em.HasComponent<SilenceVigilArmor>(entity))

--- a/Assets/Scripts/Systems/Sect/SectVenerationFervorSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectVenerationFervorSystem.cs
@@ -24,11 +24,20 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectVenerationFervorSystem : ISystem
     {
-        // Lv I tuning. Kept inline; Phase 4 will pull from SectDefinition.
-        private const byte  MaxStacks    = 8;        // caps the multiplier at +24% / +24%
-        private const float StackDuration = 3f;
-        private const float DamageBonusPerStack = 0.03f;
-        private const float AttackSpeedBonusPerStack = 0.03f;
+        // Stack count + duration are shared across levels; Phase 4 scales
+        // only the per-stack bonus values. Lv III adds a movement-speed
+        // stack — that lever is deferred to Phase 5 since the move-speed
+        // read points aren't yet wired through SpellBuff.SpeedMultiplier.
+        private const byte  MaxStacks     = 8;        // caps the multiplier at +(stack% × 8)
+        private const float StackDuration = 3f;       // Lv III bumps to 4s — applied below.
+
+        private static float DamageBonusPerStackFor(byte level) => level switch
+        {
+            2 => 0.05f,
+            3 => 0.07f,
+            _ => 0.03f,
+        };
+        private static float StackDurationFor(byte level) => level == 3 ? 4f : StackDuration;
 
         public void OnCreate(ref SystemState state)
         {
@@ -53,17 +62,18 @@ namespace TheWaningBorder.Systems.Sect
 
                 Faction killerFaction = em.GetComponentData<FactionTag>(killer).Value;
 
-                // Gate on Veneration adoption (any lever level on the Passive
-                // counts; Phase 4 reads the level to scale per-stack values).
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Veneration, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Veneration, SectLeverKind.Passive);
+                if (level == 0) continue;
+                float perStack = DamageBonusPerStackFor(level);
+                float duration = StackDurationFor(level);
 
                 // Add or refresh the stack.
                 if (em.HasComponent<VenerationFervor>(killer))
                 {
                     var fervor = em.GetComponentData<VenerationFervor>(killer);
                     if (fervor.Stacks < MaxStacks) fervor.Stacks++;
-                    fervor.TimeRemaining = StackDuration;
+                    fervor.TimeRemaining = duration;
                     em.SetComponentData(killer, fervor);
                 }
                 else
@@ -71,26 +81,23 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new VenerationFervor
                     {
                         Stacks = 1,
-                        TimeRemaining = StackDuration,
+                        TimeRemaining = duration,
                     });
                 }
 
                 // Mirror the bonus into SpellBuff so existing combat-pipeline
                 // readers (CombatDamageHelper.ApplyBonusDamageOnHit reads
                 // SpellBuff.DamageMultiplier) see the boost. SpellBuff is the
-                // unified "outgoing damage modifier" channel; SpeedMultiplier
-                // doesn't directly affect attack speed in the current code,
-                // so the +attack-speed half of Fervor is handled separately
-                // in Phase 4 when the attack-cooldown read points get touched.
+                // unified "outgoing damage modifier" channel; the +attack-
+                // speed and Lv III +move halves remain Phase 5 work since
+                // those read points aren't wired through SpellBuff.
                 int newStacks = em.GetComponentData<VenerationFervor>(killer).Stacks;
-                float dmgMult = 1f + DamageBonusPerStack * newStacks;
+                float dmgMult = 1f + perStack * newStacks;
                 if (em.HasComponent<SpellBuff>(killer))
                 {
                     var buff = em.GetComponentData<SpellBuff>(killer);
-                    // Take the max so Fervor doesn't clobber a stronger
-                    // existing buff (e.g. an ally's Crystal Communion zone).
                     if (dmgMult > buff.DamageMultiplier) buff.DamageMultiplier = dmgMult;
-                    if (StackDuration > buff.TimeRemaining) buff.TimeRemaining = StackDuration;
+                    if (duration > buff.TimeRemaining) buff.TimeRemaining = duration;
                     em.SetComponentData(killer, buff);
                 }
                 else
@@ -98,7 +105,7 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new SpellBuff
                     {
                         DamageMultiplier = dmgMult,
-                        TimeRemaining    = StackDuration,
+                        TimeRemaining    = duration,
                     });
                 }
             }

--- a/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
@@ -26,8 +26,14 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectWitnessVisionSystem : ISystem
     {
-        // Lv I factor. Phase 4: 1.50× / 1.75× for Lv II / Lv III.
-        private const float VisionMultiplierLv1 = 1.25f;
+        // Per-level vision multiplier. Phase 4 reads AppliedLevel and applies
+        // the diff (factorAt(new) / factorAt(old)) on lever upgrade.
+        public static float MultiplierFor(byte level) => level switch
+        {
+            2 => 1.50f,
+            3 => 1.75f,
+            _ => 1.25f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -38,9 +44,9 @@ namespace TheWaningBorder.Systems.Sect
         {
             var em = state.EntityManager;
 
-            // Collect scouts that need the bonus stamped — defer the actual
-            // archetype mutation (AddComponent) until after the foreach.
-            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+            // Pass 1: brand-new scouts that haven't received the bonus yet.
+            var pendingNewStamps = new NativeList<Entity>(8, Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(8, Allocator.Temp);
 
             foreach (var (unit, faction, los, entity) in SystemAPI
                 .Query<RefRO<UnitTag>, RefRO<FactionTag>, RefRW<LineOfSight>>()
@@ -48,19 +54,39 @@ namespace TheWaningBorder.Systems.Sect
                 .WithEntityAccess())
             {
                 if (unit.ValueRO.Class != UnitClass.Scout) continue;
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Witness, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Witness, SectLeverKind.Passive);
+                if (level == 0) continue;
 
-                los.ValueRW.Radius *= VisionMultiplierLv1;
-                pendingStamps.Add(entity);
+                los.ValueRW.Radius *= MultiplierFor(level);
+                pendingNewStamps.Add(entity);
+                pendingNewLevels.Add(level);
             }
 
-            for (int i = 0; i < pendingStamps.Length; i++)
+            for (int i = 0; i < pendingNewStamps.Length; i++)
             {
-                if (em.Exists(pendingStamps[i]))
-                    em.AddComponentData(pendingStamps[i], new WitnessVisionApplied { AppliedLevel = 1 });
+                if (em.Exists(pendingNewStamps[i]))
+                    em.AddComponentData(pendingNewStamps[i],
+                        new WitnessVisionApplied { AppliedLevel = pendingNewLevels[i] });
             }
-            pendingStamps.Dispose();
+            pendingNewStamps.Dispose();
+            pendingNewLevels.Dispose();
+
+            // Pass 2: already-stamped scouts whose faction's lever level rose
+            // since stamping. Apply the diff factor and bump AppliedLevel.
+            // (task-063 phase 4)
+            foreach (var (faction, los, applied) in SystemAPI
+                .Query<RefRO<FactionTag>, RefRW<LineOfSight>, RefRW<WitnessVisionApplied>>())
+            {
+                byte currentLevel = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Witness, SectLeverKind.Passive);
+                byte appliedLevel = applied.ValueRO.AppliedLevel;
+                if (currentLevel <= appliedLevel) continue;
+
+                float diffMult = MultiplierFor(currentLevel) / MultiplierFor(appliedLevel);
+                los.ValueRW.Radius *= diffMult;
+                applied.ValueRW.AppliedLevel = currentLevel;
+            }
         }
     }
 }

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -89,15 +89,17 @@ namespace TheWaningBorder.Systems.Training
                     if (FactionColors.GetFactionCulture(buildingFaction) == Cultures.Feraldis)
                         trainingTime *= 1.75f;
 
-                    // Sect of War Lv I: military units train 15% faster.
-                    // (task-063 phase 2d) — Phase 4 scales to 25% / 35% for Lv II/III.
+                    // Sect of War: military units train -15/-25/-35% faster
+                    // (Lv I/II/III). (task-063 phase 2d / phase 4 scaling)
                     bool isMilitary = UnitFactory.GetUnitClass(unitId) == UnitClass.Melee
                                    || UnitFactory.GetUnitClass(unitId) == UnitClass.Ranged
                                    || UnitFactory.GetUnitClass(unitId) == UnitClass.Siege;
-                    if (isMilitary && SectQuery.IsAdoptedAtLeast(state.EntityManager, buildingFaction,
-                            SectConfig.War, SectLeverKind.Passive))
+                    if (isMilitary)
                     {
-                        trainingTime *= 0.85f; // -15% time = ×0.85
+                        byte warLevel = SectQuery.LevelOf(state.EntityManager, buildingFaction,
+                            SectConfig.War, SectLeverKind.Passive);
+                        if (warLevel > 0)
+                            trainingTime *= WarSectCostHelper.TrainTimeMultiplierFor(warLevel);
                     }
 
                     ts.ValueRW.Busy = 1;


### PR DESCRIPTION
## Summary
- Ships **Ash Lv I 'Pyre's Promise'** — the missing 12th Lv I passive. When a unit of an Ash-adopted faction dies, it leaves a small burning-ground patch (DPS 4, 3s, 2m radius) at its position.
- Adds **Phase 4 Lv II/III scaling** to every shipped Lv I passive. Each system reads SectQuery.LevelOf at the use site and switches on the byte. Fortitude + Witness use AppliedLevel diff handling so existing entities pick up upgrades cleanly. War cost + train-time multipliers centralize in WarSectCostHelper.

### Per-sect Lv I/II/III curve
| Sect | Lv I | Lv II | Lv III |
|------|------|-------|--------|
| Antiquity | +1%/kill, cap 10 | +1.5%, cap 16 | +2%, cap 25 |
| Renewal | 12%/min repair | 25%/min | 40%/min |
| Fortitude | x1.12 wall HP | x1.25 | x1.40 |
| Reclamation | -25% from Crystal | -35% | -50% |
| Silence | +6 armor, 6s ramp | +10, 4s | +15, 3s |
| Justice | +10% mark | +20% | +30% |
| Veneration | +3%/stack | +5% | +7% (4s) |
| Witness | x1.25 scout LoS | x1.50 | x1.75 |
| War | -5%/-15% | -10%/-25% | -15%/-35% |
| Ash | DPS 4/3s/2m | 7/4/2.5 | 11/5/3 |
| Ruin | +25% / 12% | +40% / 18% | +60% / 25% |
| Wrath | +0.5%/5% missing | +1% | +1.5% |

## Test plan
- [ ] Ash: kill an Ash-faction unit, confirm a brief burning patch appears at the death spot and damages enemies.
- [ ] Phase 4 — adopt + upgrade a sect's passive lever to Lv II / Lv III in turn, confirm the effect scales (e.g. Fortitude wall HP jumps when upgraded).
- [ ] Fortitude diff: build wall at Lv I, upgrade to Lv III — wall HP should bump up to 1.40/1.12 of the current value (not re-multiplied).
- [ ] Witness diff: same idea for scout LoS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)