### PR TITLE
feat(sect): task-063 phase 5 — Building/Unit/Active-Power levers

### DIFF
--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -190,3 +190,29 @@ public struct BloodPool : IComponentData
 /// is no longer in a pool.
 /// </summary>
 public struct InBloodPool : IComponentData { }
+
+/// <summary>
+/// Per-unit buffer recording which sect Unit-lever bumps have already
+/// been applied to this unit. <see cref="SectIndex"/> is the [0..11]
+/// index into <see cref="TheWaningBorder.Economy.SectConfig.AllSectIds"/>;
+/// <see cref="Level"/> is the lever level applied. SectUnitLeverSystem
+/// reads this to skip already-stamped entries and to compute the diff
+/// when the lever level on the faction rises (task-063 phase 5 + phase 4).
+/// </summary>
+public struct SectUnitLeverApplied : IBufferElementData
+{
+    public byte SectIndex;
+    public byte Level;
+}
+
+/// <summary>
+/// Per-faction-per-sect cooldown tracker for the Active Power lever
+/// (task-063 phase 5). Stamped on the faction bank entity when the
+/// power is fired; SectActivePowerSystem ticks the timer and removes
+/// the component when ready. UI gates the Fire button on absence.
+/// </summary>
+public struct SectActivePowerCooldown : IBufferElementData
+{
+    public byte SectIndex;
+    public float Remaining;
+}

--- a/Assets/Scripts/Economy/SectLeverEffects.cs
+++ b/Assets/Scripts/Economy/SectLeverEffects.cs
@@ -1,0 +1,169 @@
+// SectLeverEffects.cs
+// Per-sect data tables for the Building / Unit / Active-Power levers
+// (task-063 phase 5). The Passive lever has its own per-sect ECS systems
+// (SectFortitudeHpSystem, SectVenerationFervorSystem, etc.) because each
+// passive has its own bespoke trigger and side effects. The other three
+// levers are implemented uniformly:
+//
+//   - Building lever: chapel emits a faction-wide aura to allied units in
+//     range of the chapel. Each sect's aura is a SpellBuff parameter set
+//     (damage / armor / speed / reflect) plus a flat HP regen.
+//
+//   - Unit lever: per-faction passive bonus applied to a designated
+//     UnitClass when the lever is at Lv 1+. Stat-bump only — no new
+//     entity types or ability adds at this phase.
+//
+//   - Active Power lever: a per-sect triggered ability with a cooldown.
+//     The kind enum dispatches to a small switch in SectActivePowerSystem.
+//
+// All values scale Lv I → II → III by a per-axis multiplier exposed via
+// LevelScalar, so callers don't have to maintain three tables per sect.
+//
+// Location: Assets/Scripts/Economy/SectLeverEffects.cs
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// Aura emitted by a sect's chapel (Building lever). Fields map directly
+    /// onto SpellBuff so the existing combat-pipeline readers consume them.
+    /// </summary>
+    public struct SectAuraSpec
+    {
+        public float Radius;
+        public float DamageMultiplier;  // 1.0 = no change
+        public int   ArmorBonus;        // flat add to defense
+        public float SpeedMultiplier;   // 1.0 = no change (move-speed plumbing partial)
+        public float DamageReflect;     // 0..1 fraction
+        public int   HpRegenPerSecond;  // applied by SectBuildingLeverSystem
+    }
+
+    /// <summary>
+    /// Per-sect Unit-lever bonus — read at combat sites by stat consumers.
+    /// Class -1 means "all units of the faction".
+    /// </summary>
+    public struct SectUnitLeverSpec
+    {
+        public int   AppliesToClass;    // UnitClass cast to int, or -1 for all
+        public float DamageMultiplier;  // 1.0 = no change
+        public int   ArmorBonus;        // flat
+        public float HpMultiplier;      // 1.0 = no change (applied at spawn / first-hit stamp)
+    }
+
+    /// <summary>
+    /// Discriminator for active-power dispatch.
+    /// </summary>
+    public enum SectActivePowerKind : byte
+    {
+        None = 0,
+        SmiteCircle,        // burst damage in circle (default for offensive sects)
+        HealCircle,         // heal allied units
+        ArmorCircle,        // grant armor SpellBuff
+        DamageCircle,       // grant damage SpellBuff
+        SpeedCircle,        // grant speed SpellBuff
+        BurningCircle,      // spawn BurningGround tiles
+        RevealCircle,       // FoW reveal area
+        SpawnPyre,          // spawn one BurningGround at center
+    }
+
+    public struct SectActivePowerSpec
+    {
+        public SectActivePowerKind Kind;
+        public float Radius;
+        public float Magnitude;       // damage / heal / armor amount
+        public float Duration;        // seconds (where applicable)
+        public float Cooldown;        // base cooldown — Phase 4 reduces with level
+    }
+
+    /// <summary>
+    /// Per-sect lookup tables + level-scaling helper.
+    /// </summary>
+    public static class SectLeverEffects
+    {
+        /// <summary>
+        /// Magnitude multiplier per lever level. Lv I = 1.00, Lv II = 1.5,
+        /// Lv III = 2.0 — applied by the consuming systems on the relevant
+        /// axes (damage / armor / regen). Cooldowns scale inversely.
+        /// </summary>
+        public static float LevelScalar(byte level) => level switch
+        {
+            2 => 1.5f,
+            3 => 2.0f,
+            _ => 1.0f,
+        };
+
+        public static SectAuraSpec AuraOf(string sectId)
+        {
+            // Default: small benign aura. Per-sect overrides below.
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.05f };
+                case SectConfig.Renewal:
+                    return new SectAuraSpec { Radius = 10f, HpRegenPerSecond = 1 };
+                case SectConfig.Fortitude:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 2 };
+                case SectConfig.Reclamation:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 1, HpRegenPerSecond = 1 };
+                case SectConfig.Silence:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 3 };
+                case SectConfig.Justice:
+                    return new SectAuraSpec { Radius = 9f, DamageMultiplier = 1.05f, ArmorBonus = 1 };
+                case SectConfig.Veneration:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.05f };
+                case SectConfig.Witness:
+                    return new SectAuraSpec { Radius = 12f, DamageMultiplier = 1.03f };
+                case SectConfig.War:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.08f };
+                case SectConfig.Ash:
+                    return new SectAuraSpec { Radius = 6f, DamageReflect = 0.10f };
+                case SectConfig.Ruin:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.06f };
+                case SectConfig.Wrath:
+                    return new SectAuraSpec { Radius = 7f, DamageMultiplier = 1.05f, DamageReflect = 0.05f };
+                default:
+                    return default;
+            }
+        }
+
+        public static SectUnitLeverSpec UnitOf(string sectId)
+        {
+            // Class indices match the UnitClass enum (Melee 0..Scout 7).
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:   return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Renewal:     return new SectUnitLeverSpec { AppliesToClass = -1, HpMultiplier = 1.05f };
+                case SectConfig.Fortitude:   return new SectUnitLeverSpec { AppliesToClass = 0,  ArmorBonus = 3 };  // melee +armor
+                case SectConfig.Reclamation: return new SectUnitLeverSpec { AppliesToClass = 6,  ArmorBonus = 5 };  // miners +armor
+                case SectConfig.Silence:     return new SectUnitLeverSpec { AppliesToClass = 1,  DamageMultiplier = 1.06f }; // ranged
+                case SectConfig.Justice:     return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Veneration:  return new SectUnitLeverSpec { AppliesToClass = 0,  DamageMultiplier = 1.05f };
+                case SectConfig.Witness:     return new SectUnitLeverSpec { AppliesToClass = 7,  HpMultiplier = 1.10f }; // scouts
+                case SectConfig.War:         return new SectUnitLeverSpec { AppliesToClass = 0,  DamageMultiplier = 1.06f, ArmorBonus = 1 };
+                case SectConfig.Ash:         return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Ruin:        return new SectUnitLeverSpec { AppliesToClass = 2,  DamageMultiplier = 1.10f }; // siege
+                case SectConfig.Wrath:       return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.05f };
+                default: return default;
+            }
+        }
+
+        public static SectActivePowerSpec ActiveOf(string sectId)
+        {
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:   return new SectActivePowerSpec { Kind = SectActivePowerKind.RevealCircle,  Radius = 12f, Duration = 8f, Cooldown = 90f };
+                case SectConfig.Renewal:     return new SectActivePowerSpec { Kind = SectActivePowerKind.HealCircle,    Radius = 8f,  Magnitude = 50f, Cooldown = 90f };
+                case SectConfig.Fortitude:   return new SectActivePowerSpec { Kind = SectActivePowerKind.ArmorCircle,   Radius = 8f,  Magnitude = 5f,  Duration = 12f, Cooldown = 120f };
+                case SectConfig.Reclamation: return new SectActivePowerSpec { Kind = SectActivePowerKind.HealCircle,    Radius = 6f,  Magnitude = 30f, Cooldown = 75f };
+                case SectConfig.Silence:     return new SectActivePowerSpec { Kind = SectActivePowerKind.SpeedCircle,   Radius = 8f,  Magnitude = 1.20f, Duration = 8f, Cooldown = 90f };
+                case SectConfig.Justice:     return new SectActivePowerSpec { Kind = SectActivePowerKind.SmiteCircle,   Radius = 6f,  Magnitude = 60f, Cooldown = 120f };
+                case SectConfig.Veneration:  return new SectActivePowerSpec { Kind = SectActivePowerKind.DamageCircle,  Radius = 8f,  Magnitude = 1.20f, Duration = 10f, Cooldown = 120f };
+                case SectConfig.Witness:     return new SectActivePowerSpec { Kind = SectActivePowerKind.RevealCircle,  Radius = 16f, Duration = 12f, Cooldown = 75f };
+                case SectConfig.War:         return new SectActivePowerSpec { Kind = SectActivePowerKind.DamageCircle,  Radius = 8f,  Magnitude = 1.25f, Duration = 8f,  Cooldown = 120f };
+                case SectConfig.Ash:         return new SectActivePowerSpec { Kind = SectActivePowerKind.BurningCircle, Radius = 6f,  Magnitude = 8f,  Duration = 6f,  Cooldown = 120f };
+                case SectConfig.Ruin:        return new SectActivePowerSpec { Kind = SectActivePowerKind.SmiteCircle,   Radius = 8f,  Magnitude = 80f, Cooldown = 150f };
+                case SectConfig.Wrath:       return new SectActivePowerSpec { Kind = SectActivePowerKind.SpawnPyre,     Radius = 4f,  Magnitude = 6f,  Duration = 8f,  Cooldown = 120f };
+                default: return default;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Economy/SectLeverEffects.cs.meta
+++ b/Assets/Scripts/Economy/SectLeverEffects.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f7b2a1c8e5d4960127b6d4a8f3c1e9d

--- a/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
@@ -1,0 +1,265 @@
+// SectActivePowerSystem.cs
+// Active-Power lever dispatch (task-063 phase 5). Each adopted sect
+// exposes one triggered ability per the SectLeverEffects.ActiveOf table;
+// players (and AI) request a cast via SectActivePowerHelper.Fire which
+// validates cooldown + lever level, deducts the cooldown, and then
+// dispatches to the per-kind handler in SwitchOnKind.
+//
+// The cooldown lives in a DynamicBuffer<SectActivePowerCooldown> on the
+// faction bank entity so all 12 sects' timers per faction live in one
+// place. SectActivePowerSystem ticks all cooldowns and prunes entries
+// at zero.
+//
+// Magnitudes scale with the Active-Power lever level via
+// SectLeverEffects.LevelScalar; cooldowns scale inversely.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectActivePowerSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            // No specific RequireForUpdate — runs every tick to bleed cooldowns.
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            foreach (var (cooldowns, entity) in SystemAPI
+                .Query<DynamicBuffer<SectActivePowerCooldown>>()
+                .WithEntityAccess())
+            {
+                for (int i = cooldowns.Length - 1; i >= 0; i--)
+                {
+                    var cd = cooldowns[i];
+                    cd.Remaining -= dt;
+                    if (cd.Remaining <= 0f)
+                        cooldowns.RemoveAtSwapBack(i);
+                    else
+                        cooldowns[i] = cd;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Static helper for firing a sect's Active Power. UI buttons /
+    /// hotkeys / AI all funnel through Fire so the cooldown + spec
+    /// lookup live in one place.
+    /// </summary>
+    public static class SectActivePowerHelper
+    {
+        /// <summary>
+        /// Returns the remaining cooldown for the faction's sect Active
+        /// Power, or 0 if ready (or if the lever isn't bought).
+        /// </summary>
+        public static float CooldownRemaining(EntityManager em, Faction faction, string sectId)
+        {
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (sectIdx < 0) return float.MaxValue;
+            if (!FactionEconomy.TryGetBank(em, faction, out var bank)) return float.MaxValue;
+            if (!em.HasBuffer<SectActivePowerCooldown>(bank)) return 0f;
+            var buf = em.GetBuffer<SectActivePowerCooldown>(bank);
+            for (int i = 0; i < buf.Length; i++)
+                if (buf[i].SectIndex == sectIdx) return buf[i].Remaining;
+            return 0f;
+        }
+
+        public static bool CanFire(EntityManager em, Faction faction, string sectId)
+        {
+            byte level = SectQuery.LevelOf(em, faction, sectId, SectLeverKind.ActivePower);
+            if (level == 0) return false;
+            return CooldownRemaining(em, faction, sectId) <= 0f;
+        }
+
+        /// <summary>
+        /// Attempt to fire <paramref name="sectId"/>'s Active Power for
+        /// <paramref name="faction"/> at <paramref name="targetPos"/>.
+        /// Returns true if the cast succeeded (cooldown is set and the
+        /// effect was dispatched), false otherwise.
+        /// </summary>
+        public static bool Fire(EntityManager em, Faction faction, string sectId, float3 targetPos)
+        {
+            byte level = SectQuery.LevelOf(em, faction, sectId, SectLeverKind.ActivePower);
+            if (level == 0) return false;
+            if (CooldownRemaining(em, faction, sectId) > 0f) return false;
+
+            var spec = SectLeverEffects.ActiveOf(sectId);
+            if (spec.Kind == SectActivePowerKind.None) return false;
+
+            // Magnitude scales with level; cooldown scales inversely.
+            float scalar = SectLeverEffects.LevelScalar(level);
+            float radius = spec.Radius;
+            float magnitude = spec.Magnitude * scalar;
+            float duration = spec.Duration;
+            float cooldown = spec.Cooldown / scalar;
+
+            DispatchEffect(em, faction, spec.Kind, targetPos, radius, magnitude, duration);
+
+            // Stamp cooldown.
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (FactionEconomy.TryGetBank(em, faction, out var bank))
+            {
+                DynamicBuffer<SectActivePowerCooldown> buf;
+                if (!em.HasBuffer<SectActivePowerCooldown>(bank))
+                    buf = em.AddBuffer<SectActivePowerCooldown>(bank);
+                else
+                    buf = em.GetBuffer<SectActivePowerCooldown>(bank);
+
+                bool found = false;
+                for (int i = 0; i < buf.Length; i++)
+                {
+                    if (buf[i].SectIndex == sectIdx)
+                    {
+                        buf[i] = new SectActivePowerCooldown { SectIndex = (byte)sectIdx, Remaining = cooldown };
+                        found = true; break;
+                    }
+                }
+                if (!found)
+                    buf.Add(new SectActivePowerCooldown { SectIndex = (byte)sectIdx, Remaining = cooldown });
+            }
+            return true;
+        }
+
+        private static void DispatchEffect(EntityManager em, Faction faction,
+            SectActivePowerKind kind, float3 pos, float radius, float magnitude, float duration)
+        {
+            switch (kind)
+            {
+                case SectActivePowerKind.SmiteCircle:
+                    ApplyCircleDamage(em, faction, pos, radius, (int)magnitude);
+                    break;
+                case SectActivePowerKind.HealCircle:
+                    ApplyCircleHeal(em, faction, pos, radius, (int)magnitude);
+                    break;
+                case SectActivePowerKind.ArmorCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { ArmorBonus = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.DamageCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { DamageMultiplier = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.SpeedCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { SpeedMultiplier = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.BurningCircle:
+                case SectActivePowerKind.SpawnPyre:
+                    SpawnBurning(em, faction, pos, radius, magnitude, duration);
+                    break;
+                case SectActivePowerKind.RevealCircle:
+                    SpawnReveal(em, faction, pos, radius, duration);
+                    break;
+            }
+        }
+
+        private static void ApplyCircleDamage(EntityManager em, Faction faction,
+            float3 center, float radius, int dmg)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value == faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                var hp = em.GetComponentData<Health>(e);
+                hp.Value = math.max(0, hp.Value - dmg);
+                em.SetComponentData(e, hp);
+            }
+        }
+
+        private static void ApplyCircleHeal(EntityManager em, Faction faction,
+            float3 center, float radius, int amount)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value != faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                var hp = em.GetComponentData<Health>(e);
+                if (hp.Value <= 0) continue;
+                hp.Value = math.min(hp.Max, hp.Value + amount);
+                em.SetComponentData(e, hp);
+            }
+        }
+
+        private static void ApplyCircleBuff(EntityManager em, Faction faction,
+            float3 center, float radius, SpellBuff buff)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value != faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                TheWaningBorder.Systems.Combat.CombatDamageHelper.MergeSpellBuff(em, ecb, e, buff);
+            }
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+
+        private static void SpawnBurning(EntityManager em, Faction faction,
+            float3 center, float radius, float dps, float duration)
+        {
+            var pyre = em.CreateEntity(
+                typeof(BurningGround), typeof(LocalTransform), typeof(FactionTag));
+            em.SetComponentData(pyre, new BurningGround
+            {
+                DPS = dps,
+                TimeRemaining = duration,
+                Radius = radius,
+            });
+            em.SetComponentData(pyre, LocalTransform.FromPositionRotationScale(
+                center, quaternion.identity, 1f));
+            em.SetComponentData(pyre, new FactionTag { Value = faction });
+        }
+
+        private static void SpawnReveal(EntityManager em, Faction faction,
+            float3 center, float radius, float duration)
+        {
+            // Stub: a fog-of-war reveal needs FogOfWarSystem support that's
+            // out of scope here. Future Phase 5 polish will add a SectReveal
+            // entity that FogOfWarSystem honors. For now, scout-LOS bumps
+            // implemented elsewhere cover the core intent.
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d8a3c2f1b6e5921e7a4b8c2d1f3e895

--- a/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
@@ -1,0 +1,146 @@
+// SectBuildingLeverSystem.cs
+// Generic chapel-aura system for the Building lever (task-063 phase 5).
+//
+// Each chapel scans for nearby allied units once per frame and refreshes
+// a SpellBuff (or HP regen) on each, with the aura parameters drawn from
+// SectLeverEffects.AuraOf(sectId). The aura magnitudes scale with the
+// faction's Building lever level via SectLeverEffects.LevelScalar.
+//
+// SpellBuff is refreshed every frame with TimeRemaining = 0.5s, so units
+// stepping out of the aura lose the buff within half a second
+// (SpellBuffSystem ticks the field down). The HP regen is applied
+// directly inline, capped at MaxHP.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectBuildingLeverSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ChapelTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // Snapshot all chapels and their auras once per tick.
+            var chapelPositions = new NativeList<float3>(Allocator.Temp);
+            var chapelFactions  = new NativeList<Faction>(Allocator.Temp);
+            var chapelAuras     = new NativeList<SectAuraSpec>(Allocator.Temp);
+
+            foreach (var (chapel, transform, faction, entity) in SystemAPI
+                .Query<RefRO<ChapelTag>, RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<UnderConstruction>()
+                .WithEntityAccess())
+            {
+                string sectId = chapel.ValueRO.SectId.ToString();
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    sectId, SectLeverKind.Building);
+                if (level == 0) continue;
+
+                var aura = SectLeverEffects.AuraOf(sectId);
+                if (aura.Radius <= 0f) continue;
+
+                float scalar = SectLeverEffects.LevelScalar(level);
+                aura.DamageMultiplier = aura.DamageMultiplier > 1f
+                    ? 1f + (aura.DamageMultiplier - 1f) * scalar : aura.DamageMultiplier;
+                aura.SpeedMultiplier = aura.SpeedMultiplier > 1f
+                    ? 1f + (aura.SpeedMultiplier - 1f) * scalar : aura.SpeedMultiplier;
+                aura.ArmorBonus = (int)(aura.ArmorBonus * scalar);
+                aura.DamageReflect = aura.DamageReflect * scalar;
+                aura.HpRegenPerSecond = (int)(aura.HpRegenPerSecond * scalar);
+
+                chapelPositions.Add(transform.ValueRO.Position);
+                chapelFactions.Add(faction.ValueRO.Value);
+                chapelAuras.Add(aura);
+            }
+
+            if (chapelPositions.Length == 0)
+            {
+                chapelPositions.Dispose();
+                chapelFactions.Dispose();
+                chapelAuras.Dispose();
+                return;
+            }
+
+            // For each ally unit in range of any of its faction's chapels,
+            // refresh SpellBuff with the merged max-of-fields semantics.
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            foreach (var (faction, transform, health, entity) in SystemAPI
+                .Query<RefRO<FactionTag>, RefRO<LocalTransform>, RefRW<Health>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                Faction unitFaction = faction.ValueRO.Value;
+                float3 unitPos = transform.ValueRO.Position;
+
+                // Combine all in-range chapel auras into a single best-of buff.
+                SectAuraSpec best = default;
+                bool any = false;
+                for (int i = 0; i < chapelPositions.Length; i++)
+                {
+                    if (chapelFactions[i] != unitFaction) continue;
+                    var ca = chapelAuras[i];
+                    if (math.distance(unitPos, chapelPositions[i]) > ca.Radius) continue;
+                    any = true;
+                    if (ca.DamageMultiplier > best.DamageMultiplier) best.DamageMultiplier = ca.DamageMultiplier;
+                    if (ca.ArmorBonus > best.ArmorBonus)             best.ArmorBonus       = ca.ArmorBonus;
+                    if (ca.SpeedMultiplier > best.SpeedMultiplier)   best.SpeedMultiplier  = ca.SpeedMultiplier;
+                    if (ca.DamageReflect > best.DamageReflect)       best.DamageReflect    = ca.DamageReflect;
+                    if (ca.HpRegenPerSecond > best.HpRegenPerSecond) best.HpRegenPerSecond = ca.HpRegenPerSecond;
+                }
+                if (!any) continue;
+
+                // Refresh SpellBuff (MergeSpellBuff takes max of every field).
+                if (best.DamageMultiplier > 0f
+                    || best.ArmorBonus > 0
+                    || best.SpeedMultiplier > 0f
+                    || best.DamageReflect > 0f)
+                {
+                    var incoming = new SpellBuff
+                    {
+                        DamageMultiplier = best.DamageMultiplier,
+                        ArmorBonus       = best.ArmorBonus,
+                        SpeedMultiplier  = best.SpeedMultiplier,
+                        DamageReflect    = best.DamageReflect,
+                        TimeRemaining    = 0.5f, // refreshed every frame
+                    };
+                    TheWaningBorder.Systems.Combat.CombatDamageHelper
+                        .MergeSpellBuff(em, ecb, entity, incoming);
+                }
+
+                // Inline HP regen — bounded by MaxHP, applied per dt.
+                if (best.HpRegenPerSecond > 0
+                    && health.ValueRO.Value > 0
+                    && health.ValueRO.Value < health.ValueRO.Max)
+                {
+                    int delta = (int)math.ceil(best.HpRegenPerSecond * dt);
+                    if (delta < 1) delta = 1;
+                    int newHp = math.min(health.ValueRO.Max, health.ValueRO.Value + delta);
+                    health.ValueRW.Value = newHp;
+                }
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+            chapelPositions.Dispose();
+            chapelFactions.Dispose();
+            chapelAuras.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d8c4f5e3a2b694712f8c5d9b3a7e426

--- a/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
@@ -1,0 +1,166 @@
+// SectUnitLeverSystem.cs
+// Generic stat-bump applier for the Unit lever (task-063 phase 5).
+//
+// For each faction × sect with the Unit lever at Lv 1+, scans units of
+// that faction matching the spec's UnitClass and applies the per-sect
+// bump (HP / armor / damage). Stamped via SectUnitLeverApplied so each
+// unit is processed exactly once per (sect-id, level) pair. Phase 4
+// scaling diff is applied when the lever level on the faction rises.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectUnitLeverSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Per-faction × per-sect, walk the matching units once.
+            // Inner loop is small (at most 8 sects × number-of-factions),
+            // so the cost per tick is dominated by the unit query.
+            for (int sectIdx = 0; sectIdx < SectConfig.SectCount; sectIdx++)
+            {
+                string sectId = SectConfig.IdAt(sectIdx);
+                var spec = SectLeverEffects.UnitOf(sectId);
+                // Skip sects whose Unit-lever spec is empty / default.
+                if (spec.DamageMultiplier == 0f && spec.ArmorBonus == 0 && spec.HpMultiplier == 0f) continue;
+
+                ApplyForSect(ref state, em, sectId, spec);
+            }
+        }
+
+        private static void ApplyForSect(ref SystemState state, EntityManager em,
+            string sectId, in SectUnitLeverSpec spec)
+        {
+            // Stamp encodes (sectIndex << 4) | level so re-application on
+            // upgrade is a simple inequality check.
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (sectIdx < 0) return;
+
+            // Pass 1: never-stamped units of this sect.
+            var pendingNew = new NativeList<Entity>(Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(Allocator.Temp);
+
+            foreach (var (unit, faction, entity) in SystemAPI
+                .Query<RefRO<UnitTag>, RefRO<FactionTag>>()
+                .WithEntityAccess())
+            {
+                if (spec.AppliesToClass >= 0 && (int)unit.ValueRO.Class != spec.AppliesToClass)
+                    continue;
+
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    sectId, SectLeverKind.Unit);
+                if (level == 0) continue;
+
+                // Existing stamp: skip if this sect already at the same or higher level.
+                if (HasStampForSect(em, entity, sectIdx, out byte appliedLevel)
+                    && appliedLevel >= level) continue;
+
+                pendingNew.Add(entity);
+                pendingNewLevels.Add(level);
+            }
+
+            for (int i = 0; i < pendingNew.Length; i++)
+            {
+                var e = pendingNew[i];
+                if (!em.Exists(e)) continue;
+
+                byte applied = HasStampForSect(em, e, sectIdx, out byte prev) ? prev : (byte)0;
+                byte newLevel = pendingNewLevels[i];
+
+                float scalar = SectLeverEffects.LevelScalar(newLevel)
+                              / (applied > 0 ? SectLeverEffects.LevelScalar(applied) : 1f);
+
+                ApplyDelta(em, e, spec, scalar);
+                SetStampForSect(em, e, sectIdx, newLevel);
+            }
+
+            pendingNew.Dispose();
+            pendingNewLevels.Dispose();
+        }
+
+        // Stamp uses a DynamicBuffer<SectUnitLeverApplied> per unit so each
+        // sect's level can be tracked independently (a unit's faction may
+        // have multiple sects with the same UnitClass target).
+        private static bool HasStampForSect(EntityManager em, Entity entity, int sectIdx, out byte level)
+        {
+            level = 0;
+            if (!em.HasBuffer<SectUnitLeverApplied>(entity)) return false;
+            var buf = em.GetBuffer<SectUnitLeverApplied>(entity);
+            for (int i = 0; i < buf.Length; i++)
+            {
+                if (buf[i].SectIndex == sectIdx) { level = buf[i].Level; return true; }
+            }
+            return false;
+        }
+
+        private static void SetStampForSect(EntityManager em, Entity entity, int sectIdx, byte level)
+        {
+            DynamicBuffer<SectUnitLeverApplied> buf;
+            if (!em.HasBuffer<SectUnitLeverApplied>(entity))
+                buf = em.AddBuffer<SectUnitLeverApplied>(entity);
+            else
+                buf = em.GetBuffer<SectUnitLeverApplied>(entity);
+            for (int i = 0; i < buf.Length; i++)
+            {
+                if (buf[i].SectIndex == sectIdx)
+                {
+                    buf[i] = new SectUnitLeverApplied { SectIndex = (byte)sectIdx, Level = level };
+                    return;
+                }
+            }
+            buf.Add(new SectUnitLeverApplied { SectIndex = (byte)sectIdx, Level = level });
+        }
+
+        private static void ApplyDelta(EntityManager em, Entity entity,
+            in SectUnitLeverSpec spec, float scalar)
+        {
+            // HP — multiplicative on Max + Value.
+            if (math.abs(spec.HpMultiplier - 1f) > 0.001f && em.HasComponent<Health>(entity))
+            {
+                var hp = em.GetComponentData<Health>(entity);
+                float diff = 1f + (spec.HpMultiplier - 1f) * scalar;
+                hp.Max   = (int)(hp.Max   * diff);
+                hp.Value = (int)(hp.Value * diff);
+                em.SetComponentData(entity, hp);
+            }
+
+            // Armor — flat add to all defense channels.
+            if (spec.ArmorBonus > 0 && em.HasComponent<Defense>(entity))
+            {
+                var def = em.GetComponentData<Defense>(entity);
+                int bump = (int)(spec.ArmorBonus * scalar);
+                def.Melee  += bump;
+                def.Ranged += bump;
+                def.Siege  += bump;
+                def.Magic  += bump;
+                em.SetComponentData(entity, def);
+            }
+
+            // Damage — multiplicative on Damage component.
+            if (math.abs(spec.DamageMultiplier - 1f) > 0.001f && em.HasComponent<Damage>(entity))
+            {
+                var dmg = em.GetComponentData<Damage>(entity);
+                float diff = 1f + (spec.DamageMultiplier - 1f) * scalar;
+                dmg.Value = (int)(dmg.Value * diff);
+                em.SetComponentData(entity, dmg);
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b6e8f1a4c5d3712f9a8c2b6e1d4f573

--- a/Assets/Scripts/UI/Panels/SectAdoptionPanel.cs
+++ b/Assets/Scripts/UI/Panels/SectAdoptionPanel.cs
@@ -17,6 +17,7 @@
 using UnityEngine;
 using Unity.Entities;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Sect;
 using TheWaningBorder.UI.Common;
 using EntityWorld = Unity.Entities.World;
 
@@ -120,9 +121,36 @@ namespace TheWaningBorder.UI.Panels
                 DrawLeverButton(em, faction, sectId, SectLeverKind.Building,    "B", sect.BuildingLevel);
                 DrawLeverButton(em, faction, sectId, SectLeverKind.Unit,        "U", sect.UnitLevel);
                 DrawLeverButton(em, faction, sectId, SectLeverKind.ActivePower, "A", sect.ActivePowerLevel);
+
+                // Fire button — only shown for sects with the Active Power
+                // lever bought. Casts the power at the temple's position; a
+                // future polish pass will add a target-cursor mode.
+                // (task-063 phase 5)
+                if (sect.ActivePowerLevel > 0)
+                {
+                    DrawFireButton(em, faction, sectId, temple);
+                }
             }
 
             GUILayout.EndHorizontal();
+        }
+
+        private static void DrawFireButton(
+            EntityManager em, Faction faction, string sectId, Entity temple)
+        {
+            float remaining = SectActivePowerHelper.CooldownRemaining(em, faction, sectId);
+            bool ready = remaining <= 0f;
+            GUI.enabled = ready;
+            string label = ready ? "Fire" : $"{(int)remaining}s";
+            if (GUILayout.Button(label, GUILayout.Width(64)))
+            {
+                if (em.HasComponent<Unity.Transforms.LocalTransform>(temple))
+                {
+                    var t = em.GetComponentData<Unity.Transforms.LocalTransform>(temple);
+                    SectActivePowerHelper.Fire(em, faction, sectId, t.Position);
+                }
+            }
+            GUI.enabled = true;
         }
 
         private static void DrawLeverButton(


### PR DESCRIPTION
## Summary
- Closes the remaining 3 levers (Building / Unit / Active Power) for **all 12 sects** using a generic, data-driven approach. Per-sect content lives in **SectLeverEffects.cs** (one switch per lever kind), so the 12 sects light up at once without 36 bespoke ECS systems.

### Building lever — chapel auras (SectBuildingLeverSystem)
- Each chapel emits a per-sect aura (damage / armor / speed / reflect / HP regen) to allied units in range. Magnitudes scale via SectLeverEffects.LevelScalar.
- SpellBuff is refreshed each tick with TimeRemaining=0.5s so the aura fades on step-out.
- All 12 sect aura specs in SectLeverEffects.AuraOf.

### Unit lever — per-class stat bumps (SectUnitLeverSystem)
- For each faction × sect with Unit lever Lv 1+, scans matching UnitClass and applies per-sect HP/armor/damage bump.
- Stamped via DynamicBuffer<SectUnitLeverApplied>, so re-application on lever upgrade applies just the diff.
- All 12 sect specs in SectLeverEffects.UnitOf.

### Active Power lever — triggered abilities (SectActivePowerSystem)
- 8 power kinds: Smite/Heal/Armor/Damage/Speed/Burning/Reveal/Pyre.
- SectActivePowerHelper.Fire validates lever level + cooldown, dispatches to the kind handler, stamps cooldown on the faction bank's DynamicBuffer<SectActivePowerCooldown>.
- SectAdoptionPanel gains a Fire button per adopted sect (cast originates at the temple position).
- All 12 sect specs in SectLeverEffects.ActiveOf.

## Test plan
- [ ] Adopt any sect, upgrade Building lever, build the chapel, walk an ally near it — verify the SpellBuff aura takes hold.
- [ ] Same chapel: walk the ally out of range and confirm the buff fades within ~0.5s.
- [ ] Unit lever: upgrade for a sect targeting Melee class, train a Swordsman — confirm HP / damage / armor stat bump.
- [ ] Unit lever upgrade: bump Lv I → Lv II, observe additional bump applied (diff, not re-multiplied from scratch).
- [ ] Active Power: adopt + buy ActivePower lever, click Fire in the panel — observe effect (e.g. damage circle, heal circle, burning patch).
- [ ] Cooldown: button shows remaining seconds while active and re-enables when expired.

## Out of scope
- Target-cursor mode for Active Powers (uses temple position for now).
- Reveal-circle FoW integration is stubbed; scout LoS bumps elsewhere cover the core intent.
- Per-sect tunings are first-pass — balance polish is Phase 5 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)