### PR TITLE
feat(audit): close audit gaps #1–#5

### DIFF
--- a/Assets/Scripts/Bootstrap/GameBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/GameBootstrap.cs
@@ -180,6 +180,7 @@ namespace TheWaningBorder.Bootstrap
             managersGO.AddComponent<UnifiedUIManager>();         // Entity info + action panels
             managersGO.AddComponent<BuilderCommandPanel>();      // Building placement preview
             managersGO.AddComponent<ResourceHUD>();              // Resource display
+            managersGO.AddComponent<ReligionHUD>();              // Top-center sect-slot HUD (audit fix #3)
             managersGO.AddComponent<MinimapRenderer>();          // Minimap display
             managersGO.AddComponent<FloatingIncomeDisplay>();   // BFME2-style floating income text
             managersGO.AddComponent<ProjectileVisualSystem>();   // Arrow projectile visuals

--- a/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
@@ -1,0 +1,65 @@
+// GlowAbilityCommand.cs
+// Activates a Lv 5 unit's Glow Ability — fast HP regen burst for 6 seconds
+// (60s cooldown). The +30% attack-rate half of the spec is partial: it's
+// folded into a SpellBuff multiplier here, but the attack-cooldown read
+// path doesn't yet honor that field, so the speed half lands in Phase 5
+// polish when MeleeCombatSystem / RangedCombatSystem wire the cooldown
+// reduction. The HP-regen half is fully effective via UnitRankSystem.
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Core.Commands.Types
+{
+    public enum GlowAbilityResult
+    {
+        Ok = 0,
+        NotMaxRank,
+        OnCooldown,
+        AlreadyActive,
+        Invalid,
+    }
+
+    public static class GlowAbilityCommandHelper
+    {
+        public static GlowAbilityResult Execute(EntityManager em, Entity unit)
+        {
+            if (!em.Exists(unit)) return GlowAbilityResult.Invalid;
+            if (!em.HasComponent<UnitRank>(unit)) return GlowAbilityResult.NotMaxRank;
+
+            var rank = em.GetComponentData<UnitRank>(unit).Value;
+            if (rank < UnitRankConfig.MaxRank) return GlowAbilityResult.NotMaxRank;
+
+            GlowAbilityState state = default;
+            if (em.HasComponent<GlowAbilityState>(unit))
+                state = em.GetComponentData<GlowAbilityState>(unit);
+
+            if (state.ActiveRemaining > 0f) return GlowAbilityResult.AlreadyActive;
+            if (state.CooldownRemaining > 0f) return GlowAbilityResult.OnCooldown;
+
+            state.ActiveRemaining   = UnitRankConfig.GlowAbilityActiveDuration;
+            state.CooldownRemaining = UnitRankConfig.GlowAbilityCooldown;
+            if (em.HasComponent<GlowAbilityState>(unit))
+                em.SetComponentData(unit, state);
+            else
+                em.AddComponentData(unit, state);
+
+            // Mirror the burst into SpellBuff so combat-pipeline readers
+            // (DamageMultiplier proxy for +attack-rate) see the boost. The
+            // proper attack-cooldown reduction is Phase 5 polish.
+            var buff = new SpellBuff
+            {
+                DamageMultiplier = 1.30f,
+                TimeRemaining = UnitRankConfig.GlowAbilityActiveDuration,
+            };
+            using var ecb = new Unity.Entities.EntityCommandBuffer(Unity.Collections.Allocator.Temp);
+            TheWaningBorder.Systems.Combat.CombatDamageHelper.MergeSpellBuff(em, ecb, unit, buff);
+            ecb.Playback(em);
+            return GlowAbilityResult.Ok;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs.meta
+++ b/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f8c1a4b6d2e9750a8c3b6d4e2f1a685

--- a/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
@@ -1,0 +1,66 @@
+// UnitRankCommand.cs
+// Promote a single military unit to its next rank, charging the
+// per-rank cost gate (Supplies / Crystal / Veilsteel / Glow).
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Core.Commands.Types
+{
+    /// <summary>
+    /// Result of a UnitRankCommandHelper.Execute call.
+    /// </summary>
+    public enum UnitRankPromoteResult
+    {
+        Ok = 0,
+        NotMilitary,
+        AlreadyMaxed,
+        CannotAfford,
+        Invalid,
+    }
+
+    /// <summary>
+    /// Helper class for promoting units. The command path doesn't need an
+    /// ECS component since promotion is a one-shot transaction (no per-frame
+    /// consumer would inspect a queued component).
+    /// </summary>
+    public static class UnitRankCommandHelper
+    {
+        public static UnitRankPromoteResult Execute(EntityManager em, Entity unit)
+        {
+            if (!em.Exists(unit)) return UnitRankPromoteResult.Invalid;
+            if (!em.HasComponent<UnitTag>(unit)) return UnitRankPromoteResult.NotMilitary;
+
+            var unitTag = em.GetComponentData<UnitTag>(unit);
+            if (unitTag.Class != UnitClass.Melee
+                && unitTag.Class != UnitClass.Ranged
+                && unitTag.Class != UnitClass.Siege)
+                return UnitRankPromoteResult.NotMilitary;
+
+            byte currentRank = 1;
+            if (em.HasComponent<UnitRank>(unit))
+                currentRank = em.GetComponentData<UnitRank>(unit).Value;
+            if (currentRank < 1) currentRank = 1;
+            if (currentRank >= UnitRankConfig.MaxRank) return UnitRankPromoteResult.AlreadyMaxed;
+
+            byte targetRank = (byte)(currentRank + 1);
+            var cost = UnitRankConfig.CostFor(targetRank);
+
+            if (!em.HasComponent<FactionTag>(unit)) return UnitRankPromoteResult.Invalid;
+            var faction = em.GetComponentData<FactionTag>(unit).Value;
+
+            if (!FactionEconomy.Spend(em, faction, cost))
+                return UnitRankPromoteResult.CannotAfford;
+
+            if (em.HasComponent<UnitRank>(unit))
+                em.SetComponentData(unit, new UnitRank { Value = targetRank });
+            else
+                em.AddComponentData(unit, new UnitRank { Value = targetRank });
+
+            return UnitRankPromoteResult.Ok;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs.meta
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d6b9c2a8e1f5703a9c5b8d3e7f2c194

--- a/Assets/Scripts/Core/Components/BattalionComponents.cs
+++ b/Assets/Scripts/Core/Components/BattalionComponents.cs
@@ -60,7 +60,7 @@ public struct BattalionMemberData : IComponentData
 /// </summary>
 public enum BattalionStance : byte
 {
-    Default = 0,    // Auto-acquire within LOS, pursue up to 25 units from guard point, then return
+    Default = 0,    // Auto-acquire within LOS, pursue for 5 seconds outside the guard leash, then return
     Defensive = 1,  // No auto-acquire; return fire only if attacker is within attack range
     Aggressive = 2  // Auto-acquire and pursue without distance limit (existing behavior)
 }
@@ -72,6 +72,19 @@ public enum BattalionStance : byte
 public struct BattalionStanceData : IComponentData
 {
     public BattalionStance Value;
+}
+
+/// <summary>
+/// Marks a Default-stance battalion member that is currently pursuing an
+/// enemy outside its leader's guard leash. Used to time-bound the chase
+/// to 5 seconds (per the design spec) before forcing the unit back to
+/// the guard point. Stamped by TargetingSystem when pursuit starts;
+/// removed when the unit re-enters the leash radius or when 5s elapses.
+/// </summary>
+public struct DefaultStancePursuit : IComponentData
+{
+    /// <summary>SystemAPI.Time.ElapsedTime when pursuit began.</summary>
+    public double StartedAt;
 }
 
 /// <summary>

--- a/Assets/Scripts/Core/Components/UnitComponents.cs
+++ b/Assets/Scripts/Core/Components/UnitComponents.cs
@@ -27,6 +27,46 @@ public struct UnitTag : IComponentData
     public UnitClass Class;
 }
 
+/// <summary>
+/// Veteran rank for military units (1..5 per the design spec). Lv 1 is the
+/// default for newly-trained units; Lv 2-5 are bought via UnitRankCommand
+/// at the cost gates Supplies / Crystal / Veilsteel / Glow respectively.
+///
+/// Per-level stat scaling (UnitRankConfig.MultiplierFor):
+///   Lv 1: 1.00× attack/defense/LOS (base)
+///   Lv 2: 1.10× attack/defense
+///   Lv 3: 1.15× attack/defense, 1.20× LOS
+///   Lv 4: 1.20× attack/defense/LOS + Lv4 HP regen + small AOE on death
+///   Lv 5: 1.25× attack/defense/LOS + Lv5 push-back AOE on death + GlowAbility
+///
+/// Stamp-and-apply pattern: UnitRankSystem reads UnitRankApplied to compute
+/// the diff factor (stats[new]/stats[applied]) and updates the stamp.
+/// (Audit fix #1)
+/// </summary>
+public struct UnitRank : IComponentData
+{
+    public byte Value; // 1..5
+}
+
+/// <summary>
+/// Last-applied rank stamp for diff scaling.
+/// </summary>
+public struct UnitRankApplied : IComponentData
+{
+    public byte Value;
+}
+
+/// <summary>
+/// Lv 5 GlowAbility — when Active is non-zero, the unit is in the 6-second
+/// burst window (fast HP regen mirrored into SpellBuff). Cooldown counts
+/// down between casts. Stamped lazily on first activation.
+/// </summary>
+public struct GlowAbilityState : IComponentData
+{
+    public float ActiveRemaining;   // Seconds left in the burst (0 = not active)
+    public float CooldownRemaining; // Seconds until castable again (0 = ready)
+}
+
 // ==================== Unit Type Tags ====================
 
 /// <summary>Marks a unit as capable of constructing buildings.</summary>

--- a/Assets/Scripts/Core/Settings/GameSettings.cs
+++ b/Assets/Scripts/Core/Settings/GameSettings.cs
@@ -103,6 +103,16 @@ public static class GameSettings
     /// <summary>Start every faction with 100,000 of each resource (debug / sandbox).</summary>
     public static bool MaxStartingResources = false;
 
+    // ==================== Selection Settings ====================
+
+    /// <summary>
+    /// Smart military drag-select: when ON, a click-and-drag rectangle that
+    /// contains both military and economic units selects only the military
+    /// units (workers / scouts are excluded). When OFF, the rectangle selects
+    /// every selectable entity it covers.
+    /// </summary>
+    public static bool SmartMilitaryDrag = true;
+
     // ==================== Map Settings ====================
 
     /// <summary>Half the map size (total map = 2 * MapHalfSize).</summary>

--- a/Assets/Scripts/Economy/UnitRankConfig.cs
+++ b/Assets/Scripts/Economy/UnitRankConfig.cs
@@ -1,0 +1,70 @@
+// UnitRankConfig.cs
+// Static tuning for the Lv 1..5 unit veteran-rank system.
+//
+// Costs (per single unit promotion):
+//   Lv 1 → Lv 2 :  50 supplies
+//   Lv 2 → Lv 3 :  25 crystal
+//   Lv 3 → Lv 4 :  15 veilsteel
+//   Lv 4 → Lv 5 :   5 glow
+//
+// Stat scalars (multiplier from base):
+//   Lv 1 : 1.00 / 1.00 / 1.00  (atk / def / LOS)
+//   Lv 2 : 1.10 / 1.10 / 1.00
+//   Lv 3 : 1.15 / 1.15 / 1.20
+//   Lv 4 : 1.20 / 1.20 / 1.20  + Lv 4 HP regen
+//   Lv 5 : 1.25 / 1.25 / 1.25  + Lv 5 push-back AOE on death + Glow Ability
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Economy/UnitRankConfig.cs
+
+using TheWaningBorder.Core;
+
+namespace TheWaningBorder.Economy
+{
+    public static class UnitRankConfig
+    {
+        public const byte MaxRank = 5;
+
+        // Lv4 / Lv5 features
+        public const float Lv4HpRegenPerSecond = 1f;
+        public const int   Lv4DeathAoeDamage = 25;
+        public const float Lv4DeathAoeRadius = 4f;
+
+        public const int   Lv5DeathAoeDamage = 50;
+        public const float Lv5DeathAoeRadius = 6f;
+        public const float Lv5PushDistance   = 4f;
+
+        public const float GlowAbilityActiveDuration = 6f;
+        public const float GlowAbilityCooldown       = 60f;
+        public const int   GlowAbilityRegenPerSec    = 5;
+
+        public static Cost CostFor(byte targetRank) => targetRank switch
+        {
+            2 => Cost.Of(supplies: 50),
+            3 => Cost.Of(crystal: 25),
+            4 => Cost.Of(veilsteel: 15),
+            5 => Cost.Of(glow: 5),
+            _ => default,
+        };
+
+        public static float AttackMultiplierFor(byte rank) => rank switch
+        {
+            2 => 1.10f,
+            3 => 1.15f,
+            4 => 1.20f,
+            5 => 1.25f,
+            _ => 1.00f,
+        };
+
+        public static float DefenseMultiplierFor(byte rank) => AttackMultiplierFor(rank);
+
+        public static float LineOfSightMultiplierFor(byte rank) => rank switch
+        {
+            3 => 1.20f,
+            4 => 1.20f,
+            5 => 1.25f,
+            _ => 1.00f,
+        };
+    }
+}

--- a/Assets/Scripts/Economy/UnitRankConfig.cs.meta
+++ b/Assets/Scripts/Economy/UnitRankConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e9a3b1c2d4f5806a8c4d2e1f9b6a373

--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -236,6 +236,14 @@ namespace TheWaningBorder.Input
                 IssueStanceToSelection(BattalionStance.Defensive);
             }
 
+            // B - Cycle through idle builders (workers with no BuildOrder/RepairOrder).
+            // Each press selects the next idle builder of the local player faction
+            // and centers the camera on it.
+            if (UnityEngine.Input.GetKeyDown(KeyCode.B))
+            {
+                CycleIdleBuilders();
+            }
+
             // Z - Toggle planning mode (BFME2); Enter also executes
             if (UnityEngine.Input.GetKeyDown(KeyCode.Z))
             {
@@ -1137,6 +1145,51 @@ namespace TheWaningBorder.Input
             return TargetType.Ground;
         }
         
+        // ═══════════════════════════════════════════════════════════════════════
+        // BUILDER CYCLE
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Last-cycled builder, so subsequent presses advance through the list
+        // instead of re-selecting the same unit.
+        private static int _builderCycleIndex = -1;
+
+        /// <summary>
+        /// Selects the next idle builder of the local player faction (and
+        /// centers the camera on it). An "idle" builder is one with the
+        /// CanBuild component and no active BuildOrder or RepairOrder.
+        /// Press repeatedly to cycle. (Spec: 'b' cycles through idle builders.)
+        /// </summary>
+        private void CycleIdleBuilders()
+        {
+            var query = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<CanBuild>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+
+            var idle = new List<Entity>();
+            foreach (var e in entities)
+            {
+                if (_em.GetComponentData<FactionTag>(e).Value != GameSettings.LocalPlayerFaction)
+                    continue;
+                if (_em.HasComponent<BuildOrder>(e)) continue;
+                if (_em.HasComponent<RepairOrder>(e)) continue;
+                idle.Add(e);
+            }
+
+            if (idle.Count == 0) return;
+
+            _builderCycleIndex = (_builderCycleIndex + 1) % idle.Count;
+            var pick = idle[_builderCycleIndex];
+
+            SelectionSystem.ClearSelection();
+            SelectionSystem.AddToSelection(pick);
+
+            var pos = _em.GetComponentData<LocalTransform>(pick).Position;
+            GameCamera.FocusOn(new Vector3(pos.x, pos.y, pos.z));
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // CAPABILITY DETECTION
         // ═══════════════════════════════════════════════════════════════════════

--- a/Assets/Scripts/Input/SelectionSystem.cs
+++ b/Assets/Scripts/Input/SelectionSystem.cs
@@ -450,8 +450,10 @@ namespace TheWaningBorder.Input
                 _selection.AddRange(units);
             }
 
-            // Among units, prioritize military over economic
-            if (units.Count > 1)
+            // Among units, prioritize military over economic — gated on the
+            // SmartMilitaryDrag toggle. When OFF, mixed-unit drags keep
+            // every entity the rectangle covered.
+            if (units.Count > 1 && GameSettings.SmartMilitaryDrag)
             {
                 var military = new List<Entity>();
                 var economic = new List<Entity>();
@@ -460,14 +462,13 @@ namespace TheWaningBorder.Input
                 {
                     if (!_em.HasComponent<UnitTag>(e)) continue;
                     var cls = _em.GetComponentData<UnitTag>(e).Class;
-                    // Earlier missing braces put EVERY unit into `military`, so
-                    // the post-filter that should drop economic units when
-                    // soldiers are present (lines below) replaced _selection
-                    // with itself. Box-selecting 5 builders + 5 swordsmen
-                    // returned all 10 instead of just the 5 swordsmen.
-                    // (task-053 F-4 / task-060 F-1)
+                    // The original code was missing an `else` here, so every
+                    // economic unit was also added to `military` and the
+                    // priority filter never dropped them. (task-060 F-1
+                    // claimed a fix that didn't actually land — fixed now.)
                     if (cls == UnitClass.Economy || cls == UnitClass.Miner)
                         economic.Add(e);
+                    else
                         military.Add(e);
                 }
 

--- a/Assets/Scripts/Systems/Combat/TargetingSystem.cs
+++ b/Assets/Scripts/Systems/Combat/TargetingSystem.cs
@@ -29,6 +29,8 @@ namespace TheWaningBorder.Systems.Combat
         private const float GuardReturnThreshold = 2f;
         private const float BattalionDefaultLeash = 25f;
         private const float DefaultMeleeRange = 1.5f;
+        // Default-stance pursuit time cap (spec: pursue 5s outside leash, then return).
+        private const double DefaultPursuitDuration = 5.0;
 
         // Fix #207: spatial-hash cell size for the enemy scan.
         // Cell=20 means a unit with LOS<=20 only visits a 3x3 neighborhood
@@ -385,7 +387,11 @@ namespace TheWaningBorder.Systems.Combat
                     }
                     else if (stance == BattalionStance.Default)
                     {
-                        // Default stance battalion member: check distance from leader's guard point
+                        // Default stance: time-bounded pursuit. Once the unit
+                        // strays beyond the guard leash, give it 5 seconds to
+                        // chase before forcing a return to the guard point.
+                        // Inside the leash, no constraint applies and any
+                        // existing pursuit timer is cleared.
                         var memberData = em.GetComponentData<BattalionMemberData>(entity);
                         if (em.Exists(memberData.Leader) && em.HasComponent<GuardPoint>(memberData.Leader))
                         {
@@ -395,8 +401,33 @@ namespace TheWaningBorder.Systems.Combat
                                 var distFromLeaderGuard = DistXZ(myPos, leaderGuard.Position);
                                 if (distFromLeaderGuard > BattalionDefaultLeash)
                                 {
-                                    // Too far from leader's guard point — do not acquire target
-                                    continue;
+                                    double now = state.WorldUnmanaged.Time.ElapsedTime;
+                                    if (em.HasComponent<DefaultStancePursuit>(entity))
+                                    {
+                                        var pursuit = em.GetComponentData<DefaultStancePursuit>(entity);
+                                        if (now - pursuit.StartedAt > DefaultPursuitDuration)
+                                        {
+                                            // Chase ran out — return to guard, drop target.
+                                            ecb.SetComponent(entity, new Target { Value = Entity.Null });
+                                            if (em.HasComponent<DesiredDestination>(entity))
+                                                ecb.SetComponent(entity, new DesiredDestination
+                                                    { Position = leaderGuard.Position, Has = 1 });
+                                            else
+                                                ecb.AddComponent(entity, new DesiredDestination
+                                                    { Position = leaderGuard.Position, Has = 1 });
+                                            ecb.RemoveComponent<DefaultStancePursuit>(entity);
+                                            continue;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        ecb.AddComponent(entity, new DefaultStancePursuit { StartedAt = now });
+                                    }
+                                }
+                                else if (em.HasComponent<DefaultStancePursuit>(entity))
+                                {
+                                    // Back in leash — fresh 5s on the next chase.
+                                    ecb.RemoveComponent<DefaultStancePursuit>(entity);
                                 }
                             }
                         }

--- a/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
@@ -1,0 +1,103 @@
+// UnitRankDeathEffectsSystem.cs
+// On-death AOE for Lv 4+ veteran units. Mirrors PillageSystem's death-event
+// hook (runs before DeathSystem with WithNone<DeathAnimationState>).
+//
+// Lv 4: small magical explosion, AOE damage to nearby enemies.
+// Lv 5: medium explosion, more damage + push-back (sets DesiredDestination
+//       on nearby enemies away from the death position).
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Combat
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct UnitRankDeathEffectsSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitRank>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Snapshot dead Lv 4+ units before applying AOE so the iteration
+            // doesn't see effects we cause.
+            var explosions = new NativeList<float3>(Allocator.Temp);
+            var explosionFactions = new NativeList<Faction>(Allocator.Temp);
+            var explosionRanks = new NativeList<byte>(Allocator.Temp);
+
+            foreach (var (health, transform, faction, rank) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<FactionTag>, RefRO<UnitRank>>()
+                .WithAll<UnitTag>()
+                .WithNone<DeathAnimationState>())
+            {
+                if (health.ValueRO.Value > 0) continue;
+                if (rank.ValueRO.Value < 4) continue;
+
+                explosions.Add(transform.ValueRO.Position);
+                explosionFactions.Add(faction.ValueRO.Value);
+                explosionRanks.Add(rank.ValueRO.Value);
+            }
+
+            for (int i = 0; i < explosions.Length; i++)
+            {
+                ApplyExplosion(em, explosions[i], explosionFactions[i], explosionRanks[i]);
+            }
+
+            explosions.Dispose();
+            explosionFactions.Dispose();
+            explosionRanks.Dispose();
+        }
+
+        private static void ApplyExplosion(EntityManager em, float3 center, Faction owner, byte rank)
+        {
+            int dmg    = rank >= 5 ? UnitRankConfig.Lv5DeathAoeDamage : UnitRankConfig.Lv4DeathAoeDamage;
+            float r    = rank >= 5 ? UnitRankConfig.Lv5DeathAoeRadius : UnitRankConfig.Lv4DeathAoeRadius;
+            bool push  = rank >= 5;
+            float r2   = r * r;
+
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value == owner) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                float distSqr = dx * dx + dz * dz;
+                if (distSqr > r2) continue;
+
+                var hp = em.GetComponentData<Health>(e);
+                hp.Value = math.max(0, hp.Value - dmg);
+                em.SetComponentData(e, hp);
+
+                if (push && distSqr > 0.001f)
+                {
+                    float dist = math.sqrt(distSqr);
+                    float3 awayDir = new float3(dx / dist, 0f, dz / dist);
+                    float3 pushTarget = p + awayDir * UnitRankConfig.Lv5PushDistance;
+                    if (em.HasComponent<DesiredDestination>(e))
+                        em.SetComponentData(e, new DesiredDestination { Position = pushTarget, Has = 1 });
+                    // Don't add DesiredDestination to entities that don't have it
+                    // (mostly buildings filtered out by UnitTag query already).
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs.meta
+++ b/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c7e4a8b1d3f5926e8c5b4d2a7f1e463

--- a/Assets/Scripts/Systems/Combat/UnitRankSystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitRankSystem.cs
@@ -1,0 +1,131 @@
+// UnitRankSystem.cs
+// Applies the per-rank stat diff to military units (Damage, Defense, LineOfSight)
+// and ticks Lv4+ HP regen. Pairs with UnitRankCommandHelper for the upgrade
+// transaction and UnitRankDeathEffectsSystem for the on-death AOE.
+//
+// Stamp pattern (mirrors SectFortitudeHpSystem): UnitRankApplied tracks the
+// last-applied rank. Each tick, units whose UnitRank.Value > UnitRankApplied.Value
+// get the (newFactor / oldFactor) diff applied and the stamp bumped.
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Systems/Combat/UnitRankSystem.cs
+
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Combat
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct UnitRankSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // ── Rank stamping + stat diffs ─────────────────────────────────
+            foreach (var (rank, entity) in SystemAPI
+                .Query<RefRO<UnitRank>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                byte newRank = rank.ValueRO.Value;
+                if (newRank < 1) newRank = 1;
+
+                byte oldRank = 0;
+                if (em.HasComponent<UnitRankApplied>(entity))
+                    oldRank = em.GetComponentData<UnitRankApplied>(entity).Value;
+
+                if (newRank == oldRank) continue;
+
+                ApplyRankDiff(em, entity, oldRank, newRank);
+                if (em.HasComponent<UnitRankApplied>(entity))
+                    em.SetComponentData(entity, new UnitRankApplied { Value = newRank });
+                else
+                    em.AddComponentData(entity, new UnitRankApplied { Value = newRank });
+            }
+
+            // ── Lv 4+ HP regen ────────────────────────────────────────────
+            foreach (var (rank, health) in SystemAPI
+                .Query<RefRO<UnitRank>, RefRW<Health>>()
+                .WithAll<UnitTag>())
+            {
+                if (rank.ValueRO.Value < 4) continue;
+                if (health.ValueRO.Value <= 0) continue;
+                if (health.ValueRO.Value >= health.ValueRO.Max) continue;
+
+                float regen = UnitRankConfig.Lv4HpRegenPerSecond * dt;
+                int delta = (int)math.ceil(regen);
+                if (delta < 1) delta = 0; // sub-1 rounds to nothing — accumulates over multiple ticks
+                if (delta > 0)
+                    health.ValueRW.Value = math.min(health.ValueRO.Max, health.ValueRO.Value + delta);
+            }
+
+            // ── Glow Ability tick ─────────────────────────────────────────
+            foreach (var (glow, health, entity) in SystemAPI
+                .Query<RefRW<GlowAbilityState>, RefRW<Health>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                if (glow.ValueRO.ActiveRemaining > 0f)
+                {
+                    glow.ValueRW.ActiveRemaining = math.max(0f, glow.ValueRO.ActiveRemaining - dt);
+                    // Burst HP regen while active.
+                    if (health.ValueRO.Value > 0 && health.ValueRO.Value < health.ValueRO.Max)
+                    {
+                        int bonus = (int)math.ceil(UnitRankConfig.GlowAbilityRegenPerSec * dt);
+                        if (bonus > 0)
+                            health.ValueRW.Value = math.min(health.ValueRO.Max, health.ValueRO.Value + bonus);
+                    }
+                }
+                if (glow.ValueRO.CooldownRemaining > 0f)
+                {
+                    glow.ValueRW.CooldownRemaining = math.max(0f, glow.ValueRO.CooldownRemaining - dt);
+                }
+            }
+        }
+
+        private static void ApplyRankDiff(EntityManager em, Entity entity,
+            byte oldRank, byte newRank)
+        {
+            float atkDiff = UnitRankConfig.AttackMultiplierFor(newRank)
+                          / UnitRankConfig.AttackMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+            float defDiff = UnitRankConfig.DefenseMultiplierFor(newRank)
+                          / UnitRankConfig.DefenseMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+            float losDiff = UnitRankConfig.LineOfSightMultiplierFor(newRank)
+                          / UnitRankConfig.LineOfSightMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+
+            if (math.abs(atkDiff - 1f) > 0.001f && em.HasComponent<Damage>(entity))
+            {
+                var d = em.GetComponentData<Damage>(entity);
+                d.Value = (int)(d.Value * atkDiff);
+                em.SetComponentData(entity, d);
+            }
+
+            if (math.abs(defDiff - 1f) > 0.001f && em.HasComponent<Defense>(entity))
+            {
+                var def = em.GetComponentData<Defense>(entity);
+                def.Melee  = (int)(def.Melee  * defDiff);
+                def.Ranged = (int)(def.Ranged * defDiff);
+                def.Siege  = (int)(def.Siege  * defDiff);
+                def.Magic  = (int)(def.Magic  * defDiff);
+                em.SetComponentData(entity, def);
+            }
+
+            if (math.abs(losDiff - 1f) > 0.001f && em.HasComponent<LineOfSight>(entity))
+            {
+                var los = em.GetComponentData<LineOfSight>(entity);
+                los.Radius *= losDiff;
+                em.SetComponentData(entity, los);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/UnitRankSystem.cs.meta
+++ b/Assets/Scripts/Systems/Combat/UnitRankSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b8d2a6e3c9f7148e4b1c5d9a2f6b384

--- a/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
+++ b/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
@@ -1,0 +1,63 @@
+// GlowIncomeSystem.cs
+// Credits Glow to the killer faction when an Elite crystal unit dies
+// (Veilstinger / Godsplinter). Mirrors PillageSystem's death-event hook
+// — runs before DeathSystem with WithNone<DeathAnimationState> so each
+// kill pays exactly once.
+//
+// "Elite" identification: any CrystalUnitTag entity that also carries
+// VeilstingerState or GodsplinterState. Cadaver-spawned crystal mobs
+// don't count — they have CrystalUnitTag but neither named state.
+//
+// Salvage + craft Glow paths are out of scope here; this covers the
+// kill-reward lane only.
+//
+// Audit fix #2.
+//
+// Location: Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct GlowIncomeSystem : ISystem
+    {
+        // Reward per kill.  Phase-5 polish may differentiate Veilstinger vs
+        // Godsplinter, but for now both pay the same modest amount.
+        private const int VeilstingerGlow = 2;
+        private const int GodsplinterGlow = 5;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastDamager, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastDamagedByFaction>, RefRO<FactionTag>>()
+                .WithAll<CrystalUnitTag>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction killer = lastDamager.ValueRO.Value;
+                if (faction.ValueRO.Value == killer) continue; // shouldn't happen
+
+                int glow;
+                if (em.HasComponent<GodsplinterState>(entity)) glow = GodsplinterGlow;
+                else if (em.HasComponent<VeilstingerState>(entity)) glow = VeilstingerGlow;
+                else continue; // not Elite
+
+                FactionEconomy.Add(em, killer, Cost.Of(glow: glow));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs.meta
+++ b/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a4e2c6f1d3b5917e3b7a8c4d6f2e951

--- a/Assets/Scripts/UI/HUD/ReligionHUD.cs
+++ b/Assets/Scripts/UI/HUD/ReligionHUD.cs
@@ -1,0 +1,190 @@
+// File: Assets/Scripts/UI/HUD/ReligionHUD.cs
+// Top-center HUD strip showing the local player's 6 sect chapel slots.
+// Hidden whenever the player has anything selected — matches the spec
+// behaviour ("when nothing is selected: top-center Religion HUD").
+//
+// Each slot shows: empty / building / adopted-with-letter (A/R/F/Re/S/J/V/W/W/A/R/W).
+// Adopted slots gain a small Fire button when the sect's Active Power
+// lever is bought; the cast originates at the temple position (a future
+// pass adds target-cursor mode).
+//
+// Audit fix #3.
+
+using System.Collections.Generic;
+using Unity.Entities;
+using Unity.Transforms;
+using UnityEngine;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Input;
+using TheWaningBorder.Systems.Sect;
+using EntityWorld = Unity.Entities.World;
+
+namespace TheWaningBorder.UI.HUD
+{
+    public class ReligionHUD : MonoBehaviour
+    {
+        public const float SlotWidth = 72f;
+        public const float SlotHeight = 56f;
+        public const float SlotSpacing = 4f;
+        public const float TopMargin = 14f;
+        private const int SlotCount = 6;
+
+        private EntityWorld _world;
+        private EntityManager _em;
+
+        private GUIStyle _slotStyle;
+        private GUIStyle _slotEmptyStyle;
+        private GUIStyle _fireBtnStyle;
+        private bool _stylesBuilt;
+
+        private void Awake()
+        {
+            _world = EntityWorld.DefaultGameObjectInjectionWorld;
+            if (_world != null && _world.IsCreated)
+                _em = _world.EntityManager;
+        }
+
+        private void OnGUI()
+        {
+            if (_world == null || !_world.IsCreated) return;
+            if (_em.Equals(default(EntityManager))) _em = _world.EntityManager;
+
+            // Hide whenever the player has anything selected.
+            if (SelectionSystem.CurrentSelection != null
+                && SelectionSystem.CurrentSelection.Count > 0)
+                return;
+
+            BuildStyles();
+
+            var faction = GameSettings.LocalPlayerFaction;
+            if (!TryGetTemple(faction, out var temple))
+            {
+                DrawNoTempleHint();
+                return;
+            }
+
+            DrawSlots(faction, temple);
+        }
+
+        private void DrawNoTempleHint()
+        {
+            float total = SlotWidth * SlotCount + SlotSpacing * (SlotCount - 1);
+            float x = (Screen.width - total) * 0.5f;
+            var rect = new Rect(x, TopMargin, total, SlotHeight);
+            GUI.Label(rect, "Religion HUD: build a Temple of Ridan to enable sect adoption.", _slotStyle);
+        }
+
+        private void DrawSlots(Faction faction, Entity temple)
+        {
+            if (!_em.HasBuffer<TempleChapelSlot>(temple)) return;
+            var slots = _em.GetBuffer<TempleChapelSlot>(temple);
+
+            float total = SlotWidth * SlotCount + SlotSpacing * (SlotCount - 1);
+            float x0 = (Screen.width - total) * 0.5f;
+            float y = TopMargin;
+
+            for (int i = 0; i < SlotCount; i++)
+            {
+                var rect = new Rect(x0 + i * (SlotWidth + SlotSpacing), y, SlotWidth, SlotHeight);
+                if (i >= slots.Length) { GUI.Label(rect, $"Slot {i + 1}", _slotEmptyStyle); continue; }
+
+                var slot = slots[i];
+                if (slot.State == 0)
+                {
+                    GUI.Label(rect, $"Slot {i + 1}\n(empty)", _slotEmptyStyle);
+                    continue;
+                }
+                if (slot.State == 1)
+                {
+                    int pct = slot.BuildTime > 0 ? (int)(100f * slot.BuildProgress / slot.BuildTime) : 0;
+                    GUI.Label(rect, $"{ShortName(slot.SectId.ToString())}\n{pct}%", _slotStyle);
+                    continue;
+                }
+
+                // State 2 — chapel complete, sect adopted.
+                string sectId = slot.SectId.ToString();
+                GUI.Label(rect, ShortName(sectId), _slotStyle);
+
+                // Fire button if the Active Power lever is bought.
+                byte apLevel = SectQuery.LevelOf(_em, faction, sectId, SectLeverKind.ActivePower);
+                if (apLevel > 0)
+                {
+                    var btnRect = new Rect(rect.x + 4, rect.y + 28, rect.width - 8, 22);
+                    float remaining = SectActivePowerHelper.CooldownRemaining(_em, faction, sectId);
+                    bool ready = remaining <= 0f;
+                    GUI.enabled = ready;
+                    string label = ready ? "Fire" : $"{(int)remaining}s";
+                    if (GUI.Button(btnRect, label, _fireBtnStyle))
+                    {
+                        if (_em.HasComponent<LocalTransform>(temple))
+                        {
+                            var t = _em.GetComponentData<LocalTransform>(temple);
+                            SectActivePowerHelper.Fire(_em, faction, sectId, t.Position);
+                        }
+                    }
+                    GUI.enabled = true;
+                }
+            }
+        }
+
+        private bool TryGetTemple(Faction faction, out Entity temple)
+        {
+            temple = Entity.Null;
+            var query = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<TempleOfRidanTag>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var entities = query.ToEntityArray(Unity.Collections.Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (_em.GetComponentData<FactionTag>(entities[i]).Value == faction)
+                {
+                    temple = entities[i];
+                    return true;
+                }
+            }
+            // Fallback to TempleTag (legacy alias).
+            var legacyQuery = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<TempleTag>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var legacy = legacyQuery.ToEntityArray(Unity.Collections.Allocator.Temp);
+            for (int i = 0; i < legacy.Length; i++)
+            {
+                if (_em.GetComponentData<FactionTag>(legacy[i]).Value == faction)
+                {
+                    temple = legacy[i];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static string ShortName(string sectId)
+        {
+            // SectConfig ids look like "Sect_Antiquity" — strip the prefix.
+            if (string.IsNullOrEmpty(sectId)) return string.Empty;
+            const string p = "Sect_";
+            return sectId.StartsWith(p) ? sectId.Substring(p.Length) : sectId;
+        }
+
+        private void BuildStyles()
+        {
+            if (_stylesBuilt) return;
+            _slotStyle = new GUIStyle(GUI.skin.box)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 12,
+                wordWrap = true,
+            };
+            _slotEmptyStyle = new GUIStyle(_slotStyle)
+            {
+                fontStyle = FontStyle.Italic,
+            };
+            _fireBtnStyle = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 11,
+            };
+            _stylesBuilt = true;
+        }
+    }
+}

--- a/Assets/Scripts/UI/HUD/ReligionHUD.cs.meta
+++ b/Assets/Scripts/UI/HUD/ReligionHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c1b8a3e9d2f4715238d6c4f2a8b1e75

--- a/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
@@ -248,12 +248,89 @@ namespace TheWaningBorder.UI.Panels
             // Trade lane caravan countdown (Runai Trading Posts)
             DrawTradeLaneCountdown();
 
+            // Veteran rank promotion + Glow Ability (audit fix #1)
+            DrawUnitRankSection();
+
             GUILayout.Space(10);
 
             // Description
             GUILayout.Label(info.Description, _descStyle);
 
             GUILayout.EndArea();
+        }
+
+        /// <summary>
+        /// Veteran rank UI for the selected military unit. Shows the current
+        /// rank and a "Promote — N <resource>" button that consumes the
+        /// per-rank cost. At Lv 5 a Glow button replaces the promote.
+        /// (Audit fix #1)
+        /// </summary>
+        private void DrawUnitRankSection()
+        {
+            var entity = UnifiedUIManager.GetFirstSelectedEntity();
+            var em = UnifiedUIManager.GetEntityManager();
+            if (entity == Entity.Null || em.Equals(default(EntityManager))) return;
+            if (!em.HasComponent<UnitTag>(entity)) return;
+
+            var cls = em.GetComponentData<UnitTag>(entity).Class;
+            bool military = cls == UnitClass.Melee
+                         || cls == UnitClass.Ranged
+                         || cls == UnitClass.Siege;
+            if (!military) return;
+
+            // Player must own the unit to promote/cast.
+            if (!em.HasComponent<FactionTag>(entity)) return;
+            if (em.GetComponentData<FactionTag>(entity).Value != GameSettings.LocalPlayerFaction) return;
+
+            byte rank = 1;
+            if (em.HasComponent<UnitRank>(entity))
+                rank = em.GetComponentData<UnitRank>(entity).Value;
+            if (rank < 1) rank = 1;
+
+            GUILayout.Space(5);
+            GUILayout.Label($"Rank: {rank}", Styles.Label);
+
+            if (rank < TheWaningBorder.Economy.UnitRankConfig.MaxRank)
+            {
+                byte target = (byte)(rank + 1);
+                var cost = TheWaningBorder.Economy.UnitRankConfig.CostFor(target);
+                string costLabel = CostLabel(cost);
+                bool canAfford = TheWaningBorder.Economy.FactionEconomy.CanAfford(em, GameSettings.LocalPlayerFaction, cost);
+                GUI.enabled = canAfford;
+                if (GUILayout.Button($"Promote → Lv {target} ({costLabel})", GUILayout.Width(220)))
+                {
+                    TheWaningBorder.Core.Commands.Types.UnitRankCommandHelper.Execute(em, entity);
+                }
+                GUI.enabled = true;
+            }
+            else
+            {
+                // Lv 5 — Glow Ability button.
+                GlowAbilityState glow = default;
+                if (em.HasComponent<GlowAbilityState>(entity))
+                    glow = em.GetComponentData<GlowAbilityState>(entity);
+
+                bool active = glow.ActiveRemaining > 0f;
+                bool ready = !active && glow.CooldownRemaining <= 0f;
+                GUI.enabled = ready;
+                string label = active
+                    ? $"Glow active ({glow.ActiveRemaining:F1}s)"
+                    : (ready ? "Glow Ability" : $"Glow ({glow.CooldownRemaining:F0}s)");
+                if (GUILayout.Button(label, GUILayout.Width(220)))
+                {
+                    TheWaningBorder.Core.Commands.Types.GlowAbilityCommandHelper.Execute(em, entity);
+                }
+                GUI.enabled = true;
+            }
+        }
+
+        private static string CostLabel(in TheWaningBorder.Core.Cost c)
+        {
+            if (c.Glow > 0)      return $"{c.Glow} Glow";
+            if (c.Veilsteel > 0) return $"{c.Veilsteel} Veilsteel";
+            if (c.Crystal > 0)   return $"{c.Crystal} Crystal";
+            if (c.Iron > 0)      return $"{c.Iron} Iron";
+            return $"{c.Supplies} Supplies";
         }
 
         // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
Five design-spec gaps from the audit, on one branch.

### #1 Unit Lv 1–5 veteran rank system (largest)
- New `UnitRank`, `UnitRankApplied`, `GlowAbilityState` components on military units.
- `UnitRankConfig` holds per-rank stat scalars (atk/def/LOS) + cost gates: Lv2 50 Supplies → Lv3 25 Crystal → Lv4 15 Veilsteel → Lv5 5 Glow.
- `UnitRankSystem` applies stat diffs on rank change (mirrors Fortitude HP / Witness vision stamp pattern), ticks Lv4+ HP regen, ticks Glow ability windows.
- `UnitRankDeathEffectsSystem`: Lv4+ AOE damage on death; Lv5 also push-back.
- `UnitRankCommandHelper` runs the Promote transaction; `GlowAbilityCommandHelper` triggers the 6s Lv5 burst.
- EntityInfoPanel gains a Promote / Glow button row when a single owned military unit is selected.
- **Partial:** the +30% attack-rate half of Glow Ability is folded into a SpellBuff DamageMultiplier proxy; the cooldown read paths in Melee/RangedCombatSystem don't yet honor SpellBuff.SpeedMultiplier (Phase-5 polish).
- **Not shipped:** drop-pile-on-death (any-player-pickup of consumed upgrade resources) — flagged as TODO.

### #2 Glow income from Elite crystal kills
- `GlowIncomeSystem` mirrors PillageSystem's pre-DeathSystem hook. Pays +5 Glow per Godsplinter kill, +2 per Veilstinger.
- Salvage + craft Glow paths still missing.

### #3 Religion HUD top-center
- New `ReligionHUD` MonoBehaviour, registered in GameBootstrap. Renders only when nothing is selected — shows the local faction's 6 chapel slots with sect short-name + Fire button per adopted sect that has Active Power bought.

### #4 Standard-stance 5s pursuit timer
- New `DefaultStancePursuit` component tracks pursuit start time. Default-stance battalion members chasing outside the 25-unit guard leash for >5s have their Target cleared and DesiredDestination forced back to the guard point.
- Distance leash now arms the timer rather than capping pursuit outright.

### #5 'b' idle-builder cycle + smart-drag toggle
- 'B' hotkey in RTSInputManager cycles through `CanBuild` units of the local faction with no `BuildOrder`/`RepairOrder`; selects + centers on the next idle builder.
- `GameSettings.SmartMilitaryDrag` toggle (default ON) gates the military/economic prioritization in `SelectionSystem.FilterBoxSelection`.
- **Bug fix:** the existing FilterBoxSelection priority code had a missing `else`, so every economic unit was added to both `military` and `economic` lists and the priority filter never dropped them. Box-selecting 5 builders + 5 swordsmen returned all 10 instead of just the 5 swordsmen. Now fixed.

## Test plan
- [ ] **#1 Promote**: train a Swordsman, click it, hit Promote → -50 supplies, rank → 2, +10% damage. Repeat through Lv 5.
- [ ] **#1 Lv 4 death**: kill a Lv 4 unit near enemies — confirm AOE damage hit.
- [ ] **#1 Lv 5 death**: kill a Lv 5 unit near enemies — confirm push-back (enemies given new DesiredDestination).
- [ ] **#1 Glow ability**: Lv 5 unit, click Glow — burst HP regen for 6s, then 60s cooldown.
- [ ] **#2 Glow drop**: kill a Godsplinter — +5 Glow visible in resource HUD.
- [ ] **#3 Religion HUD**: deselect everything; sect strip shows 6 slots top-center; build a chapel and confirm the slot fills.
- [ ] **#4 Pursuit timer**: pick a fight 30+ units from guard with a Default-stance battalion. After 5s the unit drops the chase and walks home.
- [ ] **#5 'B' key**: build 3 Builders, leave them idle, press B repeatedly — camera cycles between them.
- [ ] **#5 Smart drag**: with default ON, drag a rectangle covering 3 builders + 3 swordsmen — only swordsmen selected. Toggle off in code → all 6 selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)