### PR TITLE
release: develop → main (sect system + audit fixes)

### DIFF
--- a/Assets/Scripts/Bootstrap/GameBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/GameBootstrap.cs
@@ -180,6 +180,7 @@ namespace TheWaningBorder.Bootstrap
             managersGO.AddComponent<UnifiedUIManager>();         // Entity info + action panels
             managersGO.AddComponent<BuilderCommandPanel>();      // Building placement preview
             managersGO.AddComponent<ResourceHUD>();              // Resource display
+            managersGO.AddComponent<ReligionHUD>();              // Top-center sect-slot HUD (audit fix #3)
             managersGO.AddComponent<MinimapRenderer>();          // Minimap display
             managersGO.AddComponent<FloatingIncomeDisplay>();   // BFME2-style floating income text
             managersGO.AddComponent<ProjectileVisualSystem>();   // Arrow projectile visuals

--- a/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
@@ -1,0 +1,65 @@
+// GlowAbilityCommand.cs
+// Activates a Lv 5 unit's Glow Ability — fast HP regen burst for 6 seconds
+// (60s cooldown). The +30% attack-rate half of the spec is partial: it's
+// folded into a SpellBuff multiplier here, but the attack-cooldown read
+// path doesn't yet honor that field, so the speed half lands in Phase 5
+// polish when MeleeCombatSystem / RangedCombatSystem wire the cooldown
+// reduction. The HP-regen half is fully effective via UnitRankSystem.
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Core.Commands.Types
+{
+    public enum GlowAbilityResult
+    {
+        Ok = 0,
+        NotMaxRank,
+        OnCooldown,
+        AlreadyActive,
+        Invalid,
+    }
+
+    public static class GlowAbilityCommandHelper
+    {
+        public static GlowAbilityResult Execute(EntityManager em, Entity unit)
+        {
+            if (!em.Exists(unit)) return GlowAbilityResult.Invalid;
+            if (!em.HasComponent<UnitRank>(unit)) return GlowAbilityResult.NotMaxRank;
+
+            var rank = em.GetComponentData<UnitRank>(unit).Value;
+            if (rank < UnitRankConfig.MaxRank) return GlowAbilityResult.NotMaxRank;
+
+            GlowAbilityState state = default;
+            if (em.HasComponent<GlowAbilityState>(unit))
+                state = em.GetComponentData<GlowAbilityState>(unit);
+
+            if (state.ActiveRemaining > 0f) return GlowAbilityResult.AlreadyActive;
+            if (state.CooldownRemaining > 0f) return GlowAbilityResult.OnCooldown;
+
+            state.ActiveRemaining   = UnitRankConfig.GlowAbilityActiveDuration;
+            state.CooldownRemaining = UnitRankConfig.GlowAbilityCooldown;
+            if (em.HasComponent<GlowAbilityState>(unit))
+                em.SetComponentData(unit, state);
+            else
+                em.AddComponentData(unit, state);
+
+            // Mirror the burst into SpellBuff so combat-pipeline readers
+            // (DamageMultiplier proxy for +attack-rate) see the boost. The
+            // proper attack-cooldown reduction is Phase 5 polish.
+            var buff = new SpellBuff
+            {
+                DamageMultiplier = 1.30f,
+                TimeRemaining = UnitRankConfig.GlowAbilityActiveDuration,
+            };
+            using var ecb = new Unity.Entities.EntityCommandBuffer(Unity.Collections.Allocator.Temp);
+            TheWaningBorder.Systems.Combat.CombatDamageHelper.MergeSpellBuff(em, ecb, unit, buff);
+            ecb.Playback(em);
+            return GlowAbilityResult.Ok;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs.meta
+++ b/Assets/Scripts/Core/Commands/CommandTypes/GlowAbilityCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f8c1a4b6d2e9750a8c3b6d4e2f1a685

--- a/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
@@ -1,0 +1,66 @@
+// UnitRankCommand.cs
+// Promote a single military unit to its next rank, charging the
+// per-rank cost gate (Supplies / Crystal / Veilsteel / Glow).
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Core.Commands.Types
+{
+    /// <summary>
+    /// Result of a UnitRankCommandHelper.Execute call.
+    /// </summary>
+    public enum UnitRankPromoteResult
+    {
+        Ok = 0,
+        NotMilitary,
+        AlreadyMaxed,
+        CannotAfford,
+        Invalid,
+    }
+
+    /// <summary>
+    /// Helper class for promoting units. The command path doesn't need an
+    /// ECS component since promotion is a one-shot transaction (no per-frame
+    /// consumer would inspect a queued component).
+    /// </summary>
+    public static class UnitRankCommandHelper
+    {
+        public static UnitRankPromoteResult Execute(EntityManager em, Entity unit)
+        {
+            if (!em.Exists(unit)) return UnitRankPromoteResult.Invalid;
+            if (!em.HasComponent<UnitTag>(unit)) return UnitRankPromoteResult.NotMilitary;
+
+            var unitTag = em.GetComponentData<UnitTag>(unit);
+            if (unitTag.Class != UnitClass.Melee
+                && unitTag.Class != UnitClass.Ranged
+                && unitTag.Class != UnitClass.Siege)
+                return UnitRankPromoteResult.NotMilitary;
+
+            byte currentRank = 1;
+            if (em.HasComponent<UnitRank>(unit))
+                currentRank = em.GetComponentData<UnitRank>(unit).Value;
+            if (currentRank < 1) currentRank = 1;
+            if (currentRank >= UnitRankConfig.MaxRank) return UnitRankPromoteResult.AlreadyMaxed;
+
+            byte targetRank = (byte)(currentRank + 1);
+            var cost = UnitRankConfig.CostFor(targetRank);
+
+            if (!em.HasComponent<FactionTag>(unit)) return UnitRankPromoteResult.Invalid;
+            var faction = em.GetComponentData<FactionTag>(unit).Value;
+
+            if (!FactionEconomy.Spend(em, faction, cost))
+                return UnitRankPromoteResult.CannotAfford;
+
+            if (em.HasComponent<UnitRank>(unit))
+                em.SetComponentData(unit, new UnitRank { Value = targetRank });
+            else
+                em.AddComponentData(unit, new UnitRank { Value = targetRank });
+
+            return UnitRankPromoteResult.Ok;
+        }
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs.meta
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UnitRankCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d6b9c2a8e1f5703a9c5b8d3e7f2c194

--- a/Assets/Scripts/Core/Components/BattalionComponents.cs
+++ b/Assets/Scripts/Core/Components/BattalionComponents.cs
@@ -60,7 +60,7 @@ public struct BattalionMemberData : IComponentData
 /// </summary>
 public enum BattalionStance : byte
 {
-    Default = 0,    // Auto-acquire within LOS, pursue up to 25 units from guard point, then return
+    Default = 0,    // Auto-acquire within LOS, pursue for 5 seconds outside the guard leash, then return
     Defensive = 1,  // No auto-acquire; return fire only if attacker is within attack range
     Aggressive = 2  // Auto-acquire and pursue without distance limit (existing behavior)
 }
@@ -72,6 +72,19 @@ public enum BattalionStance : byte
 public struct BattalionStanceData : IComponentData
 {
     public BattalionStance Value;
+}
+
+/// <summary>
+/// Marks a Default-stance battalion member that is currently pursuing an
+/// enemy outside its leader's guard leash. Used to time-bound the chase
+/// to 5 seconds (per the design spec) before forcing the unit back to
+/// the guard point. Stamped by TargetingSystem when pursuit starts;
+/// removed when the unit re-enters the leash radius or when 5s elapses.
+/// </summary>
+public struct DefaultStancePursuit : IComponentData
+{
+    /// <summary>SystemAPI.Time.ElapsedTime when pursuit began.</summary>
+    public double StartedAt;
 }
 
 /// <summary>

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -168,3 +168,25 @@ public struct SilenceVigilArmor : IComponentData
 {
     public int Bonus;
 }
+
+/// <summary>
+/// Feraldis blood-pool entity (task-063 phase 3). Spawned at unit death
+/// positions when a Feraldis-cultured faction has reached Age II+. Self-
+/// decays via TimeRemaining; SectBloodPoolEffectSystem ticks the timer
+/// and destroys the entity at zero. Inhabited Feraldis units (any unit
+/// of a Feraldis Age II+ faction standing inside the pool's radius)
+/// get stamped with <see cref="InBloodPool"/> for the frame.
+/// </summary>
+public struct BloodPool : IComponentData
+{
+    public float Radius;
+    public float TimeRemaining;
+}
+
+/// <summary>
+/// Per-frame marker stamped on a unit currently inside any BloodPool.
+/// Read by CombatDamageHelper to layer the in-pool damage bonus on top
+/// of Wrath's Lv I HP-missing bonus. Removed the next frame the unit
+/// is no longer in a pool.
+/// </summary>
+public struct InBloodPool : IComponentData { }

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -190,3 +190,29 @@ public struct BloodPool : IComponentData
 /// is no longer in a pool.
 /// </summary>
 public struct InBloodPool : IComponentData { }
+
+/// <summary>
+/// Per-unit buffer recording which sect Unit-lever bumps have already
+/// been applied to this unit. <see cref="SectIndex"/> is the [0..11]
+/// index into <see cref="TheWaningBorder.Economy.SectConfig.AllSectIds"/>;
+/// <see cref="Level"/> is the lever level applied. SectUnitLeverSystem
+/// reads this to skip already-stamped entries and to compute the diff
+/// when the lever level on the faction rises (task-063 phase 5 + phase 4).
+/// </summary>
+public struct SectUnitLeverApplied : IBufferElementData
+{
+    public byte SectIndex;
+    public byte Level;
+}
+
+/// <summary>
+/// Per-faction-per-sect cooldown tracker for the Active Power lever
+/// (task-063 phase 5). Stamped on the faction bank entity when the
+/// power is fired; SectActivePowerSystem ticks the timer and removes
+/// the component when ready. UI gates the Fire button on absence.
+/// </summary>
+public struct SectActivePowerCooldown : IBufferElementData
+{
+    public byte SectIndex;
+    public float Remaining;
+}

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -54,6 +54,19 @@ public struct Invulnerable : IComponentData
 }
 
 /// <summary>
+/// Fortitude's "Veiled Stone" HP-bonus stamp (task-063 sect Lv I+).
+/// Stamped on a wall, wall hub, or tower entity once its <c>Health.Max</c>
+/// (and current <c>Value</c>, by the same fraction) has been multiplied
+/// by Fortitude's per-level HP factor. <c>AppliedLevel</c> records the
+/// level the bonus was applied at so Phase 4 lever upgrades can apply
+/// the diff (factorAtNewLevel / factorAtOldLevel) without re-scaling.
+/// </summary>
+public struct FortitudeHpApplied : IComponentData
+{
+    public byte AppliedLevel; // 1/2/3 — matches SectQuery.LevelOf
+}
+
+/// <summary>
 /// Witness's "All-Seeing" vision-bonus stamp (task-063 sect Lv I+).
 /// Stamped on a Scout entity once its LineOfSight.Radius has been multiplied
 /// by Witness's per-level vision factor. <c>AppliedLevel</c> records the

--- a/Assets/Scripts/Core/Components/SpellComponents.cs
+++ b/Assets/Scripts/Core/Components/SpellComponents.cs
@@ -117,3 +117,54 @@ public struct VenerationFervor : IComponentData
     /// <summary>Seconds remaining before the stack expires (refreshed each kill).</summary>
     public float TimeRemaining;
 }
+
+/// <summary>
+/// Antiquity's "Tally of the Lost" passive (task-063 sect Lv I).
+/// Per-attacker, per-victim-class kill counter — each kill of a given
+/// <see cref="UnitClass"/> grants the killer +1% damage on future hits
+/// against that class, capped per-class. Lv I cap is 10 kills (so the
+/// max bonus per class is +10%).
+///
+/// Layout: one byte per UnitClass (0..7) for an 8-byte total — a
+/// DynamicBuffer would have been overkill since the class count is fixed
+/// and tiny. Phase 4 raises the cap and per-kill bonus.
+///
+/// Stamped lazily by SectAntiquityTallySystem the first time the unit
+/// makes a relevant kill; consumed by CombatDamageHelper on every hit.
+/// </summary>
+public struct AntiquityKills : IComponentData
+{
+    public byte Melee;
+    public byte Ranged;
+    public byte Siege;
+    public byte Support;
+    public byte Magic;
+    public byte Economy;
+    public byte Miner;
+    public byte Scout;
+}
+
+/// <summary>
+/// Silence's "Steadfast Vigil" passive (task-063 sect Lv I).
+/// Tracks how long this unit has been holding position (HoldPositionTag).
+/// Refreshed every frame by SectSilenceVigilSystem while the tag is
+/// present; removed (along with <see cref="SilenceVigilArmor"/>) the
+/// frame the tag drops, so the bonus fades the instant the unit moves.
+/// </summary>
+public struct SilenceVigilState : IComponentData
+{
+    /// <summary>Seconds spent in HoldPosition stance.</summary>
+    public float TimeInStance;
+}
+
+/// <summary>
+/// Active armor bump from Silence's Steadfast Vigil. Consumed by
+/// CombatDamageHelper.GetSpellBuffArmorBonus alongside SpellBuff.ArmorBonus
+/// so the matrix damage formula sees the buff. Lives behind a dedicated
+/// component (rather than SpellBuff) so it can be cleared cleanly when
+/// the unit moves — SpellBuff would leak its longest-running field.
+/// </summary>
+public struct SilenceVigilArmor : IComponentData
+{
+    public int Bonus;
+}

--- a/Assets/Scripts/Core/Components/UnitComponents.cs
+++ b/Assets/Scripts/Core/Components/UnitComponents.cs
@@ -27,6 +27,46 @@ public struct UnitTag : IComponentData
     public UnitClass Class;
 }
 
+/// <summary>
+/// Veteran rank for military units (1..5 per the design spec). Lv 1 is the
+/// default for newly-trained units; Lv 2-5 are bought via UnitRankCommand
+/// at the cost gates Supplies / Crystal / Veilsteel / Glow respectively.
+///
+/// Per-level stat scaling (UnitRankConfig.MultiplierFor):
+///   Lv 1: 1.00× attack/defense/LOS (base)
+///   Lv 2: 1.10× attack/defense
+///   Lv 3: 1.15× attack/defense, 1.20× LOS
+///   Lv 4: 1.20× attack/defense/LOS + Lv4 HP regen + small AOE on death
+///   Lv 5: 1.25× attack/defense/LOS + Lv5 push-back AOE on death + GlowAbility
+///
+/// Stamp-and-apply pattern: UnitRankSystem reads UnitRankApplied to compute
+/// the diff factor (stats[new]/stats[applied]) and updates the stamp.
+/// (Audit fix #1)
+/// </summary>
+public struct UnitRank : IComponentData
+{
+    public byte Value; // 1..5
+}
+
+/// <summary>
+/// Last-applied rank stamp for diff scaling.
+/// </summary>
+public struct UnitRankApplied : IComponentData
+{
+    public byte Value;
+}
+
+/// <summary>
+/// Lv 5 GlowAbility — when Active is non-zero, the unit is in the 6-second
+/// burst window (fast HP regen mirrored into SpellBuff). Cooldown counts
+/// down between casts. Stamped lazily on first activation.
+/// </summary>
+public struct GlowAbilityState : IComponentData
+{
+    public float ActiveRemaining;   // Seconds left in the burst (0 = not active)
+    public float CooldownRemaining; // Seconds until castable again (0 = ready)
+}
+
 // ==================== Unit Type Tags ====================
 
 /// <summary>Marks a unit as capable of constructing buildings.</summary>

--- a/Assets/Scripts/Core/Settings/GameSettings.cs
+++ b/Assets/Scripts/Core/Settings/GameSettings.cs
@@ -103,6 +103,16 @@ public static class GameSettings
     /// <summary>Start every faction with 100,000 of each resource (debug / sandbox).</summary>
     public static bool MaxStartingResources = false;
 
+    // ==================== Selection Settings ====================
+
+    /// <summary>
+    /// Smart military drag-select: when ON, a click-and-drag rectangle that
+    /// contains both military and economic units selects only the military
+    /// units (workers / scouts are excluded). When OFF, the rectangle selects
+    /// every selectable entity it covers.
+    /// </summary>
+    public static bool SmartMilitaryDrag = true;
+
     // ==================== Map Settings ====================
 
     /// <summary>Half the map size (total map = 2 * MapHalfSize).</summary>

--- a/Assets/Scripts/Data/TechTree/BuildingCosts.cs
+++ b/Assets/Scripts/Data/TechTree/BuildingCosts.cs
@@ -4,6 +4,7 @@
 // Part of: Data/
 
 using System.Collections.Generic;
+using Unity.Entities;
 using TheWaningBorder.Core;
 
 namespace TheWaningBorder.Data
@@ -146,6 +147,74 @@ namespace TheWaningBorder.Data
                                     int crystal = 0, int veilsteel = 0, int glow = 0)
         {
             _byId[id] = Cost.Of(supplies, iron, crystal, veilsteel, glow);
+        }
+
+        /// <summary>
+        /// Reverse-map a built building entity to its cost-table ID using the
+        /// tag components that BuildingFactory stamped at creation time. Returns
+        /// null if no known tag is present (e.g. legacy or sect-unique entities).
+        ///
+        /// Centralized here so SelfDestructSystem (refund-on-self-destruct),
+        /// SectRuinRefundSystem (Ruin Lv I 12% refund), and future cost-aware
+        /// readers all share one mapping. Wall-instance entities are mapped to
+        /// the per-culture wall ID since BuildCosts keys them per culture.
+        /// (task-063 phase 2d)
+        /// </summary>
+        public static string IdFromEntity(EntityManager em, Entity entity)
+        {
+            // Era 1 core
+            if (em.HasComponent<HallTag>(entity)) return "Hall";
+            if (em.HasComponent<HutTag>(entity)) return "Hut";
+            if (em.HasComponent<GathererHutTag>(entity)) return "GatherersHut";
+            if (em.HasComponent<BarracksTag>(entity)) return "Barracks";
+
+            // Era 1 choice
+            if (em.HasComponent<ShrineTag>(entity)) return "ShrineOfAhridan";
+            if (em.HasComponent<TempleOfRidanTag>(entity)
+                || em.HasComponent<TempleTag>(entity)) return "TempleOfRidan";
+            if (em.HasComponent<VaultTag>(entity)) return "VaultOfAlmierra";
+            if (em.HasComponent<FiendstoneKeepTag>(entity)) return "FiendstoneKeep";
+
+            // Runai
+            if (em.HasComponent<OutpostTag>(entity)) return "Runai_Outpost";
+            if (em.HasComponent<TradeHubTag>(entity)) return "Runai_TradeHub";
+            if (em.HasComponent<BazaarTag>(entity)) return "ThessarasBazaar";
+            if (em.HasComponent<SiegeWorkshopTag>(entity)) return "Runai_SiegeWorkshop";
+
+            // Alanthor
+            if (em.HasComponent<SmelterTag>(entity)) return "Alanthor_Smelter";
+            if (em.HasComponent<CrucibleTag>(entity)) return "Alanthor_Crucible";
+            if (em.HasComponent<WatchTowerTag>(entity)) return "Alanthor_Tower";
+            if (em.HasComponent<GarrisonTag>(entity)) return "Alanthor_Garrison";
+            if (em.HasComponent<RoyalStableTag>(entity)) return "Alanthor_Stable";
+            if (em.HasComponent<SiegeYardTag>(entity)) return "Alanthor_SiegeYard";
+
+            // Feraldis
+            if (em.HasComponent<HuntingLodgeTag>(entity)) return "Feraldis_HuntingLodge";
+            if (em.HasComponent<LoggingStationTag>(entity)) return "Feraldis_LoggingStation";
+            if (em.HasComponent<WarbrandFoundryTag>(entity)) return "Feraldis_Foundry";
+            if (em.HasComponent<LonghouseTag>(entity)) return "Feraldis_Longhouse";
+            if (em.HasComponent<TotemTowerTag>(entity)) return "Feraldis_Tower";
+            if (em.HasComponent<FerSiegeYardTag>(entity)) return "Feraldis_SiegeYard";
+
+            // Walls / wall instances — map to the generic Alanthor wall ID; refund
+            // here is small and identical across cultures, so a per-culture branch
+            // is overkill until Phase 5 polish.
+            if (em.HasComponent<WallTowerTag>(entity)) return "Alanthor_WallTower";
+            if (em.HasComponent<WallGateTag>(entity)) return "Alanthor_WallGate";
+            if (em.HasComponent<WallInstanceTag>(entity)
+                || em.HasComponent<WallTag>(entity)
+                || em.HasComponent<WallHubTag>(entity)
+                || em.HasComponent<WallSegmentTag>(entity)) return "Alanthor_Wall";
+
+            // Chapels: SectConfig owns their ids; resolve via ChapelTag.SectId.
+            if (em.HasComponent<ChapelTag>(entity))
+            {
+                var sectId = em.GetComponentData<ChapelTag>(entity).SectId.ToString();
+                return TheWaningBorder.Economy.SectConfig.ChapelIdFor(sectId);
+            }
+
+            return null;
         }
 
         /// <summary>

--- a/Assets/Scripts/Economy/SectLeverEffects.cs
+++ b/Assets/Scripts/Economy/SectLeverEffects.cs
@@ -1,0 +1,169 @@
+// SectLeverEffects.cs
+// Per-sect data tables for the Building / Unit / Active-Power levers
+// (task-063 phase 5). The Passive lever has its own per-sect ECS systems
+// (SectFortitudeHpSystem, SectVenerationFervorSystem, etc.) because each
+// passive has its own bespoke trigger and side effects. The other three
+// levers are implemented uniformly:
+//
+//   - Building lever: chapel emits a faction-wide aura to allied units in
+//     range of the chapel. Each sect's aura is a SpellBuff parameter set
+//     (damage / armor / speed / reflect) plus a flat HP regen.
+//
+//   - Unit lever: per-faction passive bonus applied to a designated
+//     UnitClass when the lever is at Lv 1+. Stat-bump only — no new
+//     entity types or ability adds at this phase.
+//
+//   - Active Power lever: a per-sect triggered ability with a cooldown.
+//     The kind enum dispatches to a small switch in SectActivePowerSystem.
+//
+// All values scale Lv I → II → III by a per-axis multiplier exposed via
+// LevelScalar, so callers don't have to maintain three tables per sect.
+//
+// Location: Assets/Scripts/Economy/SectLeverEffects.cs
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// Aura emitted by a sect's chapel (Building lever). Fields map directly
+    /// onto SpellBuff so the existing combat-pipeline readers consume them.
+    /// </summary>
+    public struct SectAuraSpec
+    {
+        public float Radius;
+        public float DamageMultiplier;  // 1.0 = no change
+        public int   ArmorBonus;        // flat add to defense
+        public float SpeedMultiplier;   // 1.0 = no change (move-speed plumbing partial)
+        public float DamageReflect;     // 0..1 fraction
+        public int   HpRegenPerSecond;  // applied by SectBuildingLeverSystem
+    }
+
+    /// <summary>
+    /// Per-sect Unit-lever bonus — read at combat sites by stat consumers.
+    /// Class -1 means "all units of the faction".
+    /// </summary>
+    public struct SectUnitLeverSpec
+    {
+        public int   AppliesToClass;    // UnitClass cast to int, or -1 for all
+        public float DamageMultiplier;  // 1.0 = no change
+        public int   ArmorBonus;        // flat
+        public float HpMultiplier;      // 1.0 = no change (applied at spawn / first-hit stamp)
+    }
+
+    /// <summary>
+    /// Discriminator for active-power dispatch.
+    /// </summary>
+    public enum SectActivePowerKind : byte
+    {
+        None = 0,
+        SmiteCircle,        // burst damage in circle (default for offensive sects)
+        HealCircle,         // heal allied units
+        ArmorCircle,        // grant armor SpellBuff
+        DamageCircle,       // grant damage SpellBuff
+        SpeedCircle,        // grant speed SpellBuff
+        BurningCircle,      // spawn BurningGround tiles
+        RevealCircle,       // FoW reveal area
+        SpawnPyre,          // spawn one BurningGround at center
+    }
+
+    public struct SectActivePowerSpec
+    {
+        public SectActivePowerKind Kind;
+        public float Radius;
+        public float Magnitude;       // damage / heal / armor amount
+        public float Duration;        // seconds (where applicable)
+        public float Cooldown;        // base cooldown — Phase 4 reduces with level
+    }
+
+    /// <summary>
+    /// Per-sect lookup tables + level-scaling helper.
+    /// </summary>
+    public static class SectLeverEffects
+    {
+        /// <summary>
+        /// Magnitude multiplier per lever level. Lv I = 1.00, Lv II = 1.5,
+        /// Lv III = 2.0 — applied by the consuming systems on the relevant
+        /// axes (damage / armor / regen). Cooldowns scale inversely.
+        /// </summary>
+        public static float LevelScalar(byte level) => level switch
+        {
+            2 => 1.5f,
+            3 => 2.0f,
+            _ => 1.0f,
+        };
+
+        public static SectAuraSpec AuraOf(string sectId)
+        {
+            // Default: small benign aura. Per-sect overrides below.
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.05f };
+                case SectConfig.Renewal:
+                    return new SectAuraSpec { Radius = 10f, HpRegenPerSecond = 1 };
+                case SectConfig.Fortitude:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 2 };
+                case SectConfig.Reclamation:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 1, HpRegenPerSecond = 1 };
+                case SectConfig.Silence:
+                    return new SectAuraSpec { Radius = 8f, ArmorBonus = 3 };
+                case SectConfig.Justice:
+                    return new SectAuraSpec { Radius = 9f, DamageMultiplier = 1.05f, ArmorBonus = 1 };
+                case SectConfig.Veneration:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.05f };
+                case SectConfig.Witness:
+                    return new SectAuraSpec { Radius = 12f, DamageMultiplier = 1.03f };
+                case SectConfig.War:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.08f };
+                case SectConfig.Ash:
+                    return new SectAuraSpec { Radius = 6f, DamageReflect = 0.10f };
+                case SectConfig.Ruin:
+                    return new SectAuraSpec { Radius = 8f, DamageMultiplier = 1.06f };
+                case SectConfig.Wrath:
+                    return new SectAuraSpec { Radius = 7f, DamageMultiplier = 1.05f, DamageReflect = 0.05f };
+                default:
+                    return default;
+            }
+        }
+
+        public static SectUnitLeverSpec UnitOf(string sectId)
+        {
+            // Class indices match the UnitClass enum (Melee 0..Scout 7).
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:   return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Renewal:     return new SectUnitLeverSpec { AppliesToClass = -1, HpMultiplier = 1.05f };
+                case SectConfig.Fortitude:   return new SectUnitLeverSpec { AppliesToClass = 0,  ArmorBonus = 3 };  // melee +armor
+                case SectConfig.Reclamation: return new SectUnitLeverSpec { AppliesToClass = 6,  ArmorBonus = 5 };  // miners +armor
+                case SectConfig.Silence:     return new SectUnitLeverSpec { AppliesToClass = 1,  DamageMultiplier = 1.06f }; // ranged
+                case SectConfig.Justice:     return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Veneration:  return new SectUnitLeverSpec { AppliesToClass = 0,  DamageMultiplier = 1.05f };
+                case SectConfig.Witness:     return new SectUnitLeverSpec { AppliesToClass = 7,  HpMultiplier = 1.10f }; // scouts
+                case SectConfig.War:         return new SectUnitLeverSpec { AppliesToClass = 0,  DamageMultiplier = 1.06f, ArmorBonus = 1 };
+                case SectConfig.Ash:         return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.04f };
+                case SectConfig.Ruin:        return new SectUnitLeverSpec { AppliesToClass = 2,  DamageMultiplier = 1.10f }; // siege
+                case SectConfig.Wrath:       return new SectUnitLeverSpec { AppliesToClass = -1, DamageMultiplier = 1.05f };
+                default: return default;
+            }
+        }
+
+        public static SectActivePowerSpec ActiveOf(string sectId)
+        {
+            switch (sectId)
+            {
+                case SectConfig.Antiquity:   return new SectActivePowerSpec { Kind = SectActivePowerKind.RevealCircle,  Radius = 12f, Duration = 8f, Cooldown = 90f };
+                case SectConfig.Renewal:     return new SectActivePowerSpec { Kind = SectActivePowerKind.HealCircle,    Radius = 8f,  Magnitude = 50f, Cooldown = 90f };
+                case SectConfig.Fortitude:   return new SectActivePowerSpec { Kind = SectActivePowerKind.ArmorCircle,   Radius = 8f,  Magnitude = 5f,  Duration = 12f, Cooldown = 120f };
+                case SectConfig.Reclamation: return new SectActivePowerSpec { Kind = SectActivePowerKind.HealCircle,    Radius = 6f,  Magnitude = 30f, Cooldown = 75f };
+                case SectConfig.Silence:     return new SectActivePowerSpec { Kind = SectActivePowerKind.SpeedCircle,   Radius = 8f,  Magnitude = 1.20f, Duration = 8f, Cooldown = 90f };
+                case SectConfig.Justice:     return new SectActivePowerSpec { Kind = SectActivePowerKind.SmiteCircle,   Radius = 6f,  Magnitude = 60f, Cooldown = 120f };
+                case SectConfig.Veneration:  return new SectActivePowerSpec { Kind = SectActivePowerKind.DamageCircle,  Radius = 8f,  Magnitude = 1.20f, Duration = 10f, Cooldown = 120f };
+                case SectConfig.Witness:     return new SectActivePowerSpec { Kind = SectActivePowerKind.RevealCircle,  Radius = 16f, Duration = 12f, Cooldown = 75f };
+                case SectConfig.War:         return new SectActivePowerSpec { Kind = SectActivePowerKind.DamageCircle,  Radius = 8f,  Magnitude = 1.25f, Duration = 8f,  Cooldown = 120f };
+                case SectConfig.Ash:         return new SectActivePowerSpec { Kind = SectActivePowerKind.BurningCircle, Radius = 6f,  Magnitude = 8f,  Duration = 6f,  Cooldown = 120f };
+                case SectConfig.Ruin:        return new SectActivePowerSpec { Kind = SectActivePowerKind.SmiteCircle,   Radius = 8f,  Magnitude = 80f, Cooldown = 150f };
+                case SectConfig.Wrath:       return new SectActivePowerSpec { Kind = SectActivePowerKind.SpawnPyre,     Radius = 4f,  Magnitude = 6f,  Duration = 8f,  Cooldown = 120f };
+                default: return default;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Economy/SectLeverEffects.cs.meta
+++ b/Assets/Scripts/Economy/SectLeverEffects.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f7b2a1c8e5d4960127b6d4a8f3c1e9d

--- a/Assets/Scripts/Economy/UnitRankConfig.cs
+++ b/Assets/Scripts/Economy/UnitRankConfig.cs
@@ -1,0 +1,70 @@
+// UnitRankConfig.cs
+// Static tuning for the Lv 1..5 unit veteran-rank system.
+//
+// Costs (per single unit promotion):
+//   Lv 1 → Lv 2 :  50 supplies
+//   Lv 2 → Lv 3 :  25 crystal
+//   Lv 3 → Lv 4 :  15 veilsteel
+//   Lv 4 → Lv 5 :   5 glow
+//
+// Stat scalars (multiplier from base):
+//   Lv 1 : 1.00 / 1.00 / 1.00  (atk / def / LOS)
+//   Lv 2 : 1.10 / 1.10 / 1.00
+//   Lv 3 : 1.15 / 1.15 / 1.20
+//   Lv 4 : 1.20 / 1.20 / 1.20  + Lv 4 HP regen
+//   Lv 5 : 1.25 / 1.25 / 1.25  + Lv 5 push-back AOE on death + Glow Ability
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Economy/UnitRankConfig.cs
+
+using TheWaningBorder.Core;
+
+namespace TheWaningBorder.Economy
+{
+    public static class UnitRankConfig
+    {
+        public const byte MaxRank = 5;
+
+        // Lv4 / Lv5 features
+        public const float Lv4HpRegenPerSecond = 1f;
+        public const int   Lv4DeathAoeDamage = 25;
+        public const float Lv4DeathAoeRadius = 4f;
+
+        public const int   Lv5DeathAoeDamage = 50;
+        public const float Lv5DeathAoeRadius = 6f;
+        public const float Lv5PushDistance   = 4f;
+
+        public const float GlowAbilityActiveDuration = 6f;
+        public const float GlowAbilityCooldown       = 60f;
+        public const int   GlowAbilityRegenPerSec    = 5;
+
+        public static Cost CostFor(byte targetRank) => targetRank switch
+        {
+            2 => Cost.Of(supplies: 50),
+            3 => Cost.Of(crystal: 25),
+            4 => Cost.Of(veilsteel: 15),
+            5 => Cost.Of(glow: 5),
+            _ => default,
+        };
+
+        public static float AttackMultiplierFor(byte rank) => rank switch
+        {
+            2 => 1.10f,
+            3 => 1.15f,
+            4 => 1.20f,
+            5 => 1.25f,
+            _ => 1.00f,
+        };
+
+        public static float DefenseMultiplierFor(byte rank) => AttackMultiplierFor(rank);
+
+        public static float LineOfSightMultiplierFor(byte rank) => rank switch
+        {
+            3 => 1.20f,
+            4 => 1.20f,
+            5 => 1.25f,
+            _ => 1.00f,
+        };
+    }
+}

--- a/Assets/Scripts/Economy/UnitRankConfig.cs.meta
+++ b/Assets/Scripts/Economy/UnitRankConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e9a3b1c2d4f5806a8c4d2e1f9b6a373

--- a/Assets/Scripts/Economy/WarSectCostHelper.cs
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs
@@ -1,0 +1,73 @@
+// WarSectCostHelper.cs
+// Discount-helper for War's Lv I "Forged in Battle" passive (military -5% cost).
+// Used at every unit-train Spend call site in the UI / AI to keep the
+// discount uniform without sprinkling SectQuery checks everywhere.
+//
+// Per-level scaling (Phase 4):
+//   Lv I  : -5% cost,  +15% train speed,  +0.5%/produced (cap +12%)
+//   Lv II : -10% cost, +25% train speed,  +1%/produced  (cap +25%)
+//   Lv III: -15% cost, +35% train speed,  +1.5%/produced (cap +35%)
+// Phase 2d wires Lv I only — the cost discount + the train-speed discount
+// (in TrainingSystem). The "+%/produced" bonus is deferred until Phase 4
+// (it needs a per-faction produced-counter component).
+//
+// task-063 phase 2d.
+//
+// Location: Assets/Scripts/Economy/WarSectCostHelper.cs
+
+using Unity.Entities;
+using TheWaningBorder.Core;
+
+namespace TheWaningBorder.Economy
+{
+    /// <summary>
+    /// Cost-modifier helpers for War's military discount. Stateless.
+    /// </summary>
+    public static class WarSectCostHelper
+    {
+        /// <summary>
+        /// Lv I cost multiplier: 0.95 (i.e. -5%). Phase 4 will read SectQuery.LevelOf
+        /// and pick the right per-level multiplier.
+        /// </summary>
+        private const float CostMultiplierLv1 = 0.95f;
+
+        /// <summary>
+        /// Returns the cost the faction should be charged for training
+        /// <paramref name="unitId"/>. Applies War's military discount if the
+        /// faction has War adopted AND the unit is a military class.
+        /// Non-military units (workers / scouts / support) pay the base cost.
+        /// </summary>
+        public static Cost MilitaryDiscount(EntityManager em, Faction faction, string unitId, in Cost baseCost)
+        {
+            if (!IsMilitaryUnit(unitId)) return baseCost;
+            if (!SectQuery.IsAdoptedAtLeast(em, faction,
+                    SectConfig.War, SectLeverKind.Passive)) return baseCost;
+            return Scale(baseCost, CostMultiplierLv1);
+        }
+
+        /// <summary>
+        /// True if a unit id is a military class (melee / ranged / siege).
+        /// Sect units are special — see SectUniqueUnitTag check at runtime.
+        /// </summary>
+        public static bool IsMilitaryUnit(string unitId)
+        {
+            if (string.IsNullOrEmpty(unitId)) return false;
+            var cls = TheWaningBorder.Entities.UnitFactory.GetUnitClass(unitId);
+            return cls == UnitClass.Melee
+                || cls == UnitClass.Ranged
+                || cls == UnitClass.Siege;
+        }
+
+        private static Cost Scale(in Cost c, float mult)
+        {
+            return new Cost
+            {
+                Supplies  = (int)(c.Supplies  * mult),
+                Iron      = (int)(c.Iron      * mult),
+                Crystal   = (int)(c.Crystal   * mult),
+                Veilsteel = (int)(c.Veilsteel * mult),
+                Glow      = (int)(c.Glow      * mult),
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Economy/WarSectCostHelper.cs
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs
@@ -26,10 +26,25 @@ namespace TheWaningBorder.Economy
     public static class WarSectCostHelper
     {
         /// <summary>
-        /// Lv I cost multiplier: 0.95 (i.e. -5%). Phase 4 will read SectQuery.LevelOf
-        /// and pick the right per-level multiplier.
+        /// Per-level cost multiplier — Lv I/II/III give -5/-10/-15%.
         /// </summary>
-        private const float CostMultiplierLv1 = 0.95f;
+        public static float CostMultiplierFor(byte level) => level switch
+        {
+            2 => 0.90f,
+            3 => 0.85f,
+            _ => 0.95f,
+        };
+
+        /// <summary>
+        /// Per-level training-time multiplier — Lv I/II/III give -15/-25/-35%.
+        /// Read by TrainingSystem when computing the per-unit train cooldown.
+        /// </summary>
+        public static float TrainTimeMultiplierFor(byte level) => level switch
+        {
+            2 => 0.75f,
+            3 => 0.65f,
+            _ => 0.85f,
+        };
 
         /// <summary>
         /// Returns the cost the faction should be charged for training
@@ -40,9 +55,9 @@ namespace TheWaningBorder.Economy
         public static Cost MilitaryDiscount(EntityManager em, Faction faction, string unitId, in Cost baseCost)
         {
             if (!IsMilitaryUnit(unitId)) return baseCost;
-            if (!SectQuery.IsAdoptedAtLeast(em, faction,
-                    SectConfig.War, SectLeverKind.Passive)) return baseCost;
-            return Scale(baseCost, CostMultiplierLv1);
+            byte level = SectQuery.LevelOf(em, faction, SectConfig.War, SectLeverKind.Passive);
+            if (level == 0) return baseCost;
+            return Scale(baseCost, CostMultiplierFor(level));
         }
 
         /// <summary>

--- a/Assets/Scripts/Economy/WarSectCostHelper.cs.meta
+++ b/Assets/Scripts/Economy/WarSectCostHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b3c7a5d2e8f4f1564a8c6d1b3e9f7c2

--- a/Assets/Scripts/Input/RTSInputManager.cs
+++ b/Assets/Scripts/Input/RTSInputManager.cs
@@ -236,6 +236,14 @@ namespace TheWaningBorder.Input
                 IssueStanceToSelection(BattalionStance.Defensive);
             }
 
+            // B - Cycle through idle builders (workers with no BuildOrder/RepairOrder).
+            // Each press selects the next idle builder of the local player faction
+            // and centers the camera on it.
+            if (UnityEngine.Input.GetKeyDown(KeyCode.B))
+            {
+                CycleIdleBuilders();
+            }
+
             // Z - Toggle planning mode (BFME2); Enter also executes
             if (UnityEngine.Input.GetKeyDown(KeyCode.Z))
             {
@@ -1137,6 +1145,51 @@ namespace TheWaningBorder.Input
             return TargetType.Ground;
         }
         
+        // ═══════════════════════════════════════════════════════════════════════
+        // BUILDER CYCLE
+        // ═══════════════════════════════════════════════════════════════════════
+
+        // Last-cycled builder, so subsequent presses advance through the list
+        // instead of re-selecting the same unit.
+        private static int _builderCycleIndex = -1;
+
+        /// <summary>
+        /// Selects the next idle builder of the local player faction (and
+        /// centers the camera on it). An "idle" builder is one with the
+        /// CanBuild component and no active BuildOrder or RepairOrder.
+        /// Press repeatedly to cycle. (Spec: 'b' cycles through idle builders.)
+        /// </summary>
+        private void CycleIdleBuilders()
+        {
+            var query = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<CanBuild>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<LocalTransform>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+
+            var idle = new List<Entity>();
+            foreach (var e in entities)
+            {
+                if (_em.GetComponentData<FactionTag>(e).Value != GameSettings.LocalPlayerFaction)
+                    continue;
+                if (_em.HasComponent<BuildOrder>(e)) continue;
+                if (_em.HasComponent<RepairOrder>(e)) continue;
+                idle.Add(e);
+            }
+
+            if (idle.Count == 0) return;
+
+            _builderCycleIndex = (_builderCycleIndex + 1) % idle.Count;
+            var pick = idle[_builderCycleIndex];
+
+            SelectionSystem.ClearSelection();
+            SelectionSystem.AddToSelection(pick);
+
+            var pos = _em.GetComponentData<LocalTransform>(pick).Position;
+            GameCamera.FocusOn(new Vector3(pos.x, pos.y, pos.z));
+        }
+
         // ═══════════════════════════════════════════════════════════════════════
         // CAPABILITY DETECTION
         // ═══════════════════════════════════════════════════════════════════════

--- a/Assets/Scripts/Input/SelectionSystem.cs
+++ b/Assets/Scripts/Input/SelectionSystem.cs
@@ -450,8 +450,10 @@ namespace TheWaningBorder.Input
                 _selection.AddRange(units);
             }
 
-            // Among units, prioritize military over economic
-            if (units.Count > 1)
+            // Among units, prioritize military over economic — gated on the
+            // SmartMilitaryDrag toggle. When OFF, mixed-unit drags keep
+            // every entity the rectangle covered.
+            if (units.Count > 1 && GameSettings.SmartMilitaryDrag)
             {
                 var military = new List<Entity>();
                 var economic = new List<Entity>();
@@ -460,14 +462,13 @@ namespace TheWaningBorder.Input
                 {
                     if (!_em.HasComponent<UnitTag>(e)) continue;
                     var cls = _em.GetComponentData<UnitTag>(e).Class;
-                    // Earlier missing braces put EVERY unit into `military`, so
-                    // the post-filter that should drop economic units when
-                    // soldiers are present (lines below) replaced _selection
-                    // with itself. Box-selecting 5 builders + 5 swordsmen
-                    // returned all 10 instead of just the 5 swordsmen.
-                    // (task-053 F-4 / task-060 F-1)
+                    // The original code was missing an `else` here, so every
+                    // economic unit was also added to `military` and the
+                    // priority filter never dropped them. (task-060 F-1
+                    // claimed a fix that didn't actually land — fixed now.)
                     if (cls == UnitClass.Economy || cls == UnitClass.Miner)
                         economic.Add(e);
+                    else
                         military.Add(e);
                 }
 

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -5,6 +5,7 @@
 using Unity.Entities;
 using Unity.Mathematics;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Sect;
 
 namespace TheWaningBorder.Systems.Combat
 {
@@ -31,16 +32,21 @@ namespace TheWaningBorder.Systems.Combat
     public static class CombatDamageHelper
     {
         /// <summary>
-        /// Returns the SpellBuff.ArmorBonus on the target (0 if no SpellBuff).
-        /// Callers MUST add this to the defender's defense value before running
-        /// the damage-type x armor-type matrix. Wired into Melee/Ranged combat
-        /// so abilities like StoneheartBastion's +3 armor aura actually fire.
-        /// (task-062 C-1)
+        /// Returns extra armor on the target — sums SpellBuff.ArmorBonus and
+        /// SilenceVigilArmor.Bonus. Callers MUST add this to the defender's
+        /// defense value before running the damage-type x armor-type matrix.
+        /// Wired into Melee/Ranged combat so abilities like StoneheartBastion's
+        /// +3 armor aura and Silence's "Steadfast Vigil" stance bonus actually
+        /// fire. (task-062 C-1, task-063 phase 2e)
         /// </summary>
         public static int GetSpellBuffArmorBonus(EntityManager em, Entity target)
         {
-            if (!em.HasComponent<SpellBuff>(target)) return 0;
-            return (int)em.GetComponentData<SpellBuff>(target).ArmorBonus;
+            int bonus = 0;
+            if (em.HasComponent<SpellBuff>(target))
+                bonus += (int)em.GetComponentData<SpellBuff>(target).ArmorBonus;
+            if (em.HasComponent<SilenceVigilArmor>(target))
+                bonus += em.GetComponentData<SilenceVigilArmor>(target).Bonus;
+            return bonus;
         }
 
         /// <summary>
@@ -134,6 +140,20 @@ namespace TheWaningBorder.Systems.Combat
                 {
                     final = (int)(final * 1.25f);
                 }
+            }
+
+            // Antiquity Lv I "Tally of the Lost" passive: +1% per logged kill
+            // of the *target's* UnitClass on this attacker (capped at +10% per
+            // class — the cap lives in SectAntiquityTallySystem). Phase 4
+            // raises both the per-kill bonus and the cap. (task-063 phase 2e)
+            if (em.HasComponent<AntiquityKills>(attacker)
+                && em.HasComponent<UnitTag>(target))
+            {
+                var kills = em.GetComponentData<AntiquityKills>(attacker);
+                var tgtClass = em.GetComponentData<UnitTag>(target).Class;
+                byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
+                if (n > 0)
+                    final = (int)(final * (1f + 0.01f * n));
             }
 
             // Wrath Lv I "Spite of the Forsaken" passive: attacker deals

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -179,8 +179,10 @@ namespace TheWaningBorder.Systems.Combat
 
             // Wrath "Spite of the Forsaken": +N% per 5% HP missing on the
             // attacker. Lv I 0.5% per 5% (max +9.5%). Lv II 1% (max +19%).
-            // Lv III 1.5% (max +28.5%). Blood-pool half lives in Phase 3.
-            // (task-063 phase 2c / phase 4 scaling)
+            // Lv III 1.5% (max +28.5%). Stacks multiplicatively with the
+            // blood-pool bonus when the attacker is standing in a Feraldis
+            // pool (phase 3): +10/+15/+20% by lever level.
+            // (task-063 phase 2c / phase 4 scaling / phase 3)
             if (em.HasComponent<FactionTag>(attacker)
                 && em.HasComponent<Health>(attacker))
             {
@@ -193,7 +195,6 @@ namespace TheWaningBorder.Systems.Combat
                     if (hp.Max > 0 && hp.Value < hp.Max)
                     {
                         float fractionMissing = 1f - (float)hp.Value / hp.Max;
-                        // Per-level scalar on the fraction-missing.
                         float scalar = wrathLevel switch
                         {
                             2 => 0.20f,
@@ -201,6 +202,17 @@ namespace TheWaningBorder.Systems.Combat
                             _ => 0.10f,
                         };
                         final = (int)(final * (1f + fractionMissing * scalar));
+                    }
+
+                    if (em.HasComponent<InBloodPool>(attacker))
+                    {
+                        float poolMult = wrathLevel switch
+                        {
+                            2 => 1.15f,
+                            3 => 1.20f,
+                            _ => 1.10f,
+                        };
+                        final = (int)(final * poolMult);
                     }
                 }
             }

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -116,6 +116,26 @@ namespace TheWaningBorder.Systems.Combat
                 }
             }
 
+            // Ruin Lv I "Profane Hands" passive: Ruin-adopted attackers deal
+            // +25% damage to enemy buildings. The 12% cost-refund-on-destruction
+            // half lives in SectRuinRefundSystem. Friendly-fire on own buildings
+            // is rare but explicitly excluded — the bonus only applies when
+            // attacker faction != target faction. Phase 4 scales the multiplier
+            // to 1.40× / 1.60× for Lv II / Lv III. (task-063 phase 2d)
+            if (em.HasComponent<BuildingTag>(target)
+                && em.HasComponent<FactionTag>(attacker)
+                && em.HasComponent<FactionTag>(target))
+            {
+                var atkFac = em.GetComponentData<FactionTag>(attacker).Value;
+                var tgtFac = em.GetComponentData<FactionTag>(target).Value;
+                if (atkFac != tgtFac
+                    && SectQuery.IsAdoptedAtLeast(em, atkFac,
+                        SectConfig.Ruin, SectLeverKind.Passive))
+                {
+                    final = (int)(final * 1.25f);
+                }
+            }
+
             // Wrath Lv I "Spite of the Forsaken" passive: attacker deals
             // +0.5% damage per 5% HP missing (max +9.5% at 1 HP). The blood-
             // pool half (+10% in pools at Lv I) lives behind Phase 3 and is
@@ -161,6 +181,23 @@ namespace TheWaningBorder.Systems.Combat
                     : voidStrike.BonusDamage;
                 final += (int)bonus;
                 ecb.RemoveComponent<VoidStrikeBuff>(attacker);
+            }
+
+            // Reclamation Lv I "Curse-Hardened" passive (combat half): defender
+            // takes -25% damage from Crystal-faction PvE attackers. Applied last
+            // so the reduction comes off the final post-bonus number — same
+            // intent as a flat resistance. The cursed-ground DoT half is hooked
+            // separately in CursedGroundDamageSystem (it bypasses this helper).
+            // Phase 4 scales reduction to 35% / 50% for Lv II / Lv III.
+            // (task-063 phase 2d)
+            if (em.HasComponent<CrystalTag>(attacker)
+                && em.HasComponent<FactionTag>(target)
+                && SectQuery.IsAdoptedAtLeast(em,
+                    em.GetComponentData<FactionTag>(target).Value,
+                    SectConfig.Reclamation, SectLeverKind.Passive))
+            {
+                final = (int)(final * 0.75f);
+                if (final < 1) final = 1;
             }
 
             return final;

--- a/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
+++ b/Assets/Scripts/Systems/Combat/CombatDamageHelper.cs
@@ -122,58 +122,86 @@ namespace TheWaningBorder.Systems.Combat
                 }
             }
 
-            // Ruin Lv I "Profane Hands" passive: Ruin-adopted attackers deal
-            // +25% damage to enemy buildings. The 12% cost-refund-on-destruction
-            // half lives in SectRuinRefundSystem. Friendly-fire on own buildings
-            // is rare but explicitly excluded — the bonus only applies when
-            // attacker faction != target faction. Phase 4 scales the multiplier
-            // to 1.40× / 1.60× for Lv II / Lv III. (task-063 phase 2d)
+            // Ruin "Profane Hands": Ruin-adopted attackers deal +25/40/60%
+            // damage to enemy buildings. Refund-on-destroy half lives in
+            // SectRuinRefundSystem. Friendly fire is excluded. (task-063
+            // phase 2d / phase 4 scaling)
             if (em.HasComponent<BuildingTag>(target)
                 && em.HasComponent<FactionTag>(attacker)
                 && em.HasComponent<FactionTag>(target))
             {
                 var atkFac = em.GetComponentData<FactionTag>(attacker).Value;
                 var tgtFac = em.GetComponentData<FactionTag>(target).Value;
-                if (atkFac != tgtFac
-                    && SectQuery.IsAdoptedAtLeast(em, atkFac,
-                        SectConfig.Ruin, SectLeverKind.Passive))
+                if (atkFac != tgtFac)
                 {
-                    final = (int)(final * 1.25f);
+                    byte ruinLevel = SectQuery.LevelOf(em, atkFac,
+                        SectConfig.Ruin, SectLeverKind.Passive);
+                    if (ruinLevel > 0)
+                    {
+                        float ruinMult = ruinLevel switch
+                        {
+                            2 => 1.40f,
+                            3 => 1.60f,
+                            _ => 1.25f,
+                        };
+                        final = (int)(final * ruinMult);
+                    }
                 }
             }
 
-            // Antiquity Lv I "Tally of the Lost" passive: +1% per logged kill
-            // of the *target's* UnitClass on this attacker (capped at +10% per
-            // class — the cap lives in SectAntiquityTallySystem). Phase 4
-            // raises both the per-kill bonus and the cap. (task-063 phase 2e)
+            // Antiquity "Tally of the Lost": +N% per logged kill of the
+            // target's UnitClass; per-kill bonus scales with lever level.
+            // (task-063 phase 2e / phase 4 scaling)
             if (em.HasComponent<AntiquityKills>(attacker)
-                && em.HasComponent<UnitTag>(target))
+                && em.HasComponent<UnitTag>(target)
+                && em.HasComponent<FactionTag>(attacker))
             {
-                var kills = em.GetComponentData<AntiquityKills>(attacker);
-                var tgtClass = em.GetComponentData<UnitTag>(target).Class;
-                byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
-                if (n > 0)
-                    final = (int)(final * (1f + 0.01f * n));
+                byte antiqLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(attacker).Value,
+                    SectConfig.Antiquity, SectLeverKind.Passive);
+                if (antiqLevel > 0)
+                {
+                    var kills = em.GetComponentData<AntiquityKills>(attacker);
+                    var tgtClass = em.GetComponentData<UnitTag>(target).Class;
+                    byte n = SectAntiquityTallySystem.KillsAgainst(in kills, tgtClass);
+                    if (n > 0)
+                    {
+                        float perKill = antiqLevel switch
+                        {
+                            2 => 0.015f,
+                            3 => 0.020f,
+                            _ => 0.010f,
+                        };
+                        final = (int)(final * (1f + perKill * n));
+                    }
+                }
             }
 
-            // Wrath Lv I "Spite of the Forsaken" passive: attacker deals
-            // +0.5% damage per 5% HP missing (max +9.5% at 1 HP). The blood-
-            // pool half (+10% in pools at Lv I) lives behind Phase 3 and is
-            // not applied here. Phase 4 scales the per-stack bonus to 1% / 1.5%
-            // for Lv II / Lv III. (task-063 phase 2c)
+            // Wrath "Spite of the Forsaken": +N% per 5% HP missing on the
+            // attacker. Lv I 0.5% per 5% (max +9.5%). Lv II 1% (max +19%).
+            // Lv III 1.5% (max +28.5%). Blood-pool half lives in Phase 3.
+            // (task-063 phase 2c / phase 4 scaling)
             if (em.HasComponent<FactionTag>(attacker)
-                && em.HasComponent<Health>(attacker)
-                && SectQuery.IsAdoptedAtLeast(em,
-                    em.GetComponentData<FactionTag>(attacker).Value,
-                    SectConfig.Wrath, SectLeverKind.Passive))
+                && em.HasComponent<Health>(attacker))
             {
-                var hp = em.GetComponentData<Health>(attacker);
-                if (hp.Max > 0 && hp.Value < hp.Max)
+                byte wrathLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(attacker).Value,
+                    SectConfig.Wrath, SectLeverKind.Passive);
+                if (wrathLevel > 0)
                 {
-                    float fractionMissing = 1f - (float)hp.Value / hp.Max;
-                    // 0.5% per 5% missing == 0.1× the missing fraction.
-                    float bonus = fractionMissing * 0.10f;
-                    final = (int)(final * (1f + bonus));
+                    var hp = em.GetComponentData<Health>(attacker);
+                    if (hp.Max > 0 && hp.Value < hp.Max)
+                    {
+                        float fractionMissing = 1f - (float)hp.Value / hp.Max;
+                        // Per-level scalar on the fraction-missing.
+                        float scalar = wrathLevel switch
+                        {
+                            2 => 0.20f,
+                            3 => 0.30f,
+                            _ => 0.10f,
+                        };
+                        final = (int)(final * (1f + fractionMissing * scalar));
+                    }
                 }
             }
 
@@ -203,21 +231,28 @@ namespace TheWaningBorder.Systems.Combat
                 ecb.RemoveComponent<VoidStrikeBuff>(attacker);
             }
 
-            // Reclamation Lv I "Curse-Hardened" passive (combat half): defender
-            // takes -25% damage from Crystal-faction PvE attackers. Applied last
-            // so the reduction comes off the final post-bonus number — same
-            // intent as a flat resistance. The cursed-ground DoT half is hooked
-            // separately in CursedGroundDamageSystem (it bypasses this helper).
-            // Phase 4 scales reduction to 35% / 50% for Lv II / Lv III.
-            // (task-063 phase 2d)
+            // Reclamation "Curse-Hardened" (combat half): defender takes -25/35/50%
+            // damage from Crystal-faction PvE attackers. Applied last so the
+            // reduction comes off the final post-bonus number — same intent as
+            // a flat resistance. The cursed-ground DoT half is in
+            // CursedGroundDamageSystem. (task-063 phase 2d / phase 4 scaling)
             if (em.HasComponent<CrystalTag>(attacker)
-                && em.HasComponent<FactionTag>(target)
-                && SectQuery.IsAdoptedAtLeast(em,
-                    em.GetComponentData<FactionTag>(target).Value,
-                    SectConfig.Reclamation, SectLeverKind.Passive))
+                && em.HasComponent<FactionTag>(target))
             {
-                final = (int)(final * 0.75f);
-                if (final < 1) final = 1;
+                byte reclLevel = SectQuery.LevelOf(em,
+                    em.GetComponentData<FactionTag>(target).Value,
+                    SectConfig.Reclamation, SectLeverKind.Passive);
+                if (reclLevel > 0)
+                {
+                    float reclMult = reclLevel switch
+                    {
+                        2 => 0.65f,
+                        3 => 0.50f,
+                        _ => 0.75f,
+                    };
+                    final = (int)(final * reclMult);
+                    if (final < 1) final = 1;
+                }
             }
 
             return final;

--- a/Assets/Scripts/Systems/Combat/TargetingSystem.cs
+++ b/Assets/Scripts/Systems/Combat/TargetingSystem.cs
@@ -29,6 +29,8 @@ namespace TheWaningBorder.Systems.Combat
         private const float GuardReturnThreshold = 2f;
         private const float BattalionDefaultLeash = 25f;
         private const float DefaultMeleeRange = 1.5f;
+        // Default-stance pursuit time cap (spec: pursue 5s outside leash, then return).
+        private const double DefaultPursuitDuration = 5.0;
 
         // Fix #207: spatial-hash cell size for the enemy scan.
         // Cell=20 means a unit with LOS<=20 only visits a 3x3 neighborhood
@@ -385,7 +387,11 @@ namespace TheWaningBorder.Systems.Combat
                     }
                     else if (stance == BattalionStance.Default)
                     {
-                        // Default stance battalion member: check distance from leader's guard point
+                        // Default stance: time-bounded pursuit. Once the unit
+                        // strays beyond the guard leash, give it 5 seconds to
+                        // chase before forcing a return to the guard point.
+                        // Inside the leash, no constraint applies and any
+                        // existing pursuit timer is cleared.
                         var memberData = em.GetComponentData<BattalionMemberData>(entity);
                         if (em.Exists(memberData.Leader) && em.HasComponent<GuardPoint>(memberData.Leader))
                         {
@@ -395,8 +401,33 @@ namespace TheWaningBorder.Systems.Combat
                                 var distFromLeaderGuard = DistXZ(myPos, leaderGuard.Position);
                                 if (distFromLeaderGuard > BattalionDefaultLeash)
                                 {
-                                    // Too far from leader's guard point — do not acquire target
-                                    continue;
+                                    double now = state.WorldUnmanaged.Time.ElapsedTime;
+                                    if (em.HasComponent<DefaultStancePursuit>(entity))
+                                    {
+                                        var pursuit = em.GetComponentData<DefaultStancePursuit>(entity);
+                                        if (now - pursuit.StartedAt > DefaultPursuitDuration)
+                                        {
+                                            // Chase ran out — return to guard, drop target.
+                                            ecb.SetComponent(entity, new Target { Value = Entity.Null });
+                                            if (em.HasComponent<DesiredDestination>(entity))
+                                                ecb.SetComponent(entity, new DesiredDestination
+                                                    { Position = leaderGuard.Position, Has = 1 });
+                                            else
+                                                ecb.AddComponent(entity, new DesiredDestination
+                                                    { Position = leaderGuard.Position, Has = 1 });
+                                            ecb.RemoveComponent<DefaultStancePursuit>(entity);
+                                            continue;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        ecb.AddComponent(entity, new DefaultStancePursuit { StartedAt = now });
+                                    }
+                                }
+                                else if (em.HasComponent<DefaultStancePursuit>(entity))
+                                {
+                                    // Back in leash — fresh 5s on the next chase.
+                                    ecb.RemoveComponent<DefaultStancePursuit>(entity);
                                 }
                             }
                         }

--- a/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
@@ -1,0 +1,103 @@
+// UnitRankDeathEffectsSystem.cs
+// On-death AOE for Lv 4+ veteran units. Mirrors PillageSystem's death-event
+// hook (runs before DeathSystem with WithNone<DeathAnimationState>).
+//
+// Lv 4: small magical explosion, AOE damage to nearby enemies.
+// Lv 5: medium explosion, more damage + push-back (sets DesiredDestination
+//       on nearby enemies away from the death position).
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Combat
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct UnitRankDeathEffectsSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitRank>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Snapshot dead Lv 4+ units before applying AOE so the iteration
+            // doesn't see effects we cause.
+            var explosions = new NativeList<float3>(Allocator.Temp);
+            var explosionFactions = new NativeList<Faction>(Allocator.Temp);
+            var explosionRanks = new NativeList<byte>(Allocator.Temp);
+
+            foreach (var (health, transform, faction, rank) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<FactionTag>, RefRO<UnitRank>>()
+                .WithAll<UnitTag>()
+                .WithNone<DeathAnimationState>())
+            {
+                if (health.ValueRO.Value > 0) continue;
+                if (rank.ValueRO.Value < 4) continue;
+
+                explosions.Add(transform.ValueRO.Position);
+                explosionFactions.Add(faction.ValueRO.Value);
+                explosionRanks.Add(rank.ValueRO.Value);
+            }
+
+            for (int i = 0; i < explosions.Length; i++)
+            {
+                ApplyExplosion(em, explosions[i], explosionFactions[i], explosionRanks[i]);
+            }
+
+            explosions.Dispose();
+            explosionFactions.Dispose();
+            explosionRanks.Dispose();
+        }
+
+        private static void ApplyExplosion(EntityManager em, float3 center, Faction owner, byte rank)
+        {
+            int dmg    = rank >= 5 ? UnitRankConfig.Lv5DeathAoeDamage : UnitRankConfig.Lv4DeathAoeDamage;
+            float r    = rank >= 5 ? UnitRankConfig.Lv5DeathAoeRadius : UnitRankConfig.Lv4DeathAoeRadius;
+            bool push  = rank >= 5;
+            float r2   = r * r;
+
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value == owner) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                float distSqr = dx * dx + dz * dz;
+                if (distSqr > r2) continue;
+
+                var hp = em.GetComponentData<Health>(e);
+                hp.Value = math.max(0, hp.Value - dmg);
+                em.SetComponentData(e, hp);
+
+                if (push && distSqr > 0.001f)
+                {
+                    float dist = math.sqrt(distSqr);
+                    float3 awayDir = new float3(dx / dist, 0f, dz / dist);
+                    float3 pushTarget = p + awayDir * UnitRankConfig.Lv5PushDistance;
+                    if (em.HasComponent<DesiredDestination>(e))
+                        em.SetComponentData(e, new DesiredDestination { Position = pushTarget, Has = 1 });
+                    // Don't add DesiredDestination to entities that don't have it
+                    // (mostly buildings filtered out by UnitTag query already).
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs.meta
+++ b/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c7e4a8b1d3f5926e8c5b4d2a7f1e463

--- a/Assets/Scripts/Systems/Combat/UnitRankSystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitRankSystem.cs
@@ -1,0 +1,131 @@
+// UnitRankSystem.cs
+// Applies the per-rank stat diff to military units (Damage, Defense, LineOfSight)
+// and ticks Lv4+ HP regen. Pairs with UnitRankCommandHelper for the upgrade
+// transaction and UnitRankDeathEffectsSystem for the on-death AOE.
+//
+// Stamp pattern (mirrors SectFortitudeHpSystem): UnitRankApplied tracks the
+// last-applied rank. Each tick, units whose UnitRank.Value > UnitRankApplied.Value
+// get the (newFactor / oldFactor) diff applied and the stamp bumped.
+//
+// Audit fix #1.
+//
+// Location: Assets/Scripts/Systems/Combat/UnitRankSystem.cs
+
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Combat
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct UnitRankSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // ── Rank stamping + stat diffs ─────────────────────────────────
+            foreach (var (rank, entity) in SystemAPI
+                .Query<RefRO<UnitRank>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                byte newRank = rank.ValueRO.Value;
+                if (newRank < 1) newRank = 1;
+
+                byte oldRank = 0;
+                if (em.HasComponent<UnitRankApplied>(entity))
+                    oldRank = em.GetComponentData<UnitRankApplied>(entity).Value;
+
+                if (newRank == oldRank) continue;
+
+                ApplyRankDiff(em, entity, oldRank, newRank);
+                if (em.HasComponent<UnitRankApplied>(entity))
+                    em.SetComponentData(entity, new UnitRankApplied { Value = newRank });
+                else
+                    em.AddComponentData(entity, new UnitRankApplied { Value = newRank });
+            }
+
+            // ── Lv 4+ HP regen ────────────────────────────────────────────
+            foreach (var (rank, health) in SystemAPI
+                .Query<RefRO<UnitRank>, RefRW<Health>>()
+                .WithAll<UnitTag>())
+            {
+                if (rank.ValueRO.Value < 4) continue;
+                if (health.ValueRO.Value <= 0) continue;
+                if (health.ValueRO.Value >= health.ValueRO.Max) continue;
+
+                float regen = UnitRankConfig.Lv4HpRegenPerSecond * dt;
+                int delta = (int)math.ceil(regen);
+                if (delta < 1) delta = 0; // sub-1 rounds to nothing — accumulates over multiple ticks
+                if (delta > 0)
+                    health.ValueRW.Value = math.min(health.ValueRO.Max, health.ValueRO.Value + delta);
+            }
+
+            // ── Glow Ability tick ─────────────────────────────────────────
+            foreach (var (glow, health, entity) in SystemAPI
+                .Query<RefRW<GlowAbilityState>, RefRW<Health>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                if (glow.ValueRO.ActiveRemaining > 0f)
+                {
+                    glow.ValueRW.ActiveRemaining = math.max(0f, glow.ValueRO.ActiveRemaining - dt);
+                    // Burst HP regen while active.
+                    if (health.ValueRO.Value > 0 && health.ValueRO.Value < health.ValueRO.Max)
+                    {
+                        int bonus = (int)math.ceil(UnitRankConfig.GlowAbilityRegenPerSec * dt);
+                        if (bonus > 0)
+                            health.ValueRW.Value = math.min(health.ValueRO.Max, health.ValueRO.Value + bonus);
+                    }
+                }
+                if (glow.ValueRO.CooldownRemaining > 0f)
+                {
+                    glow.ValueRW.CooldownRemaining = math.max(0f, glow.ValueRO.CooldownRemaining - dt);
+                }
+            }
+        }
+
+        private static void ApplyRankDiff(EntityManager em, Entity entity,
+            byte oldRank, byte newRank)
+        {
+            float atkDiff = UnitRankConfig.AttackMultiplierFor(newRank)
+                          / UnitRankConfig.AttackMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+            float defDiff = UnitRankConfig.DefenseMultiplierFor(newRank)
+                          / UnitRankConfig.DefenseMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+            float losDiff = UnitRankConfig.LineOfSightMultiplierFor(newRank)
+                          / UnitRankConfig.LineOfSightMultiplierFor(oldRank == 0 ? (byte)1 : oldRank);
+
+            if (math.abs(atkDiff - 1f) > 0.001f && em.HasComponent<Damage>(entity))
+            {
+                var d = em.GetComponentData<Damage>(entity);
+                d.Value = (int)(d.Value * atkDiff);
+                em.SetComponentData(entity, d);
+            }
+
+            if (math.abs(defDiff - 1f) > 0.001f && em.HasComponent<Defense>(entity))
+            {
+                var def = em.GetComponentData<Defense>(entity);
+                def.Melee  = (int)(def.Melee  * defDiff);
+                def.Ranged = (int)(def.Ranged * defDiff);
+                def.Siege  = (int)(def.Siege  * defDiff);
+                def.Magic  = (int)(def.Magic  * defDiff);
+                em.SetComponentData(entity, def);
+            }
+
+            if (math.abs(losDiff - 1f) > 0.001f && em.HasComponent<LineOfSight>(entity))
+            {
+                var los = em.GetComponentData<LineOfSight>(entity);
+                los.Radius *= losDiff;
+                em.SetComponentData(entity, los);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Combat/UnitRankSystem.cs.meta
+++ b/Assets/Scripts/Systems/Combat/UnitRankSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b8d2a6e3c9f7148e4b1c5d9a2f6b384

--- a/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
@@ -3,6 +3,7 @@ using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
+using TheWaningBorder.Economy;
 
 namespace TheWaningBorder.Systems.Creatures
 {
@@ -52,6 +53,7 @@ namespace TheWaningBorder.Systems.Creatures
             }
 
             // Apply damage to non-crystal units standing on cursed ground
+            var em = state.EntityManager;
             foreach (var (health, unitTransform, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<LocalTransform>>()
                 .WithAll<UnitTag>()
@@ -71,6 +73,19 @@ namespace TheWaningBorder.Systems.Creatures
                     {
                         // Apply one tick of damage (DPS * tick interval)
                         int damage = math.max(1, (int)(groundDPS[i].DamagePerSecond * DamageTickInterval));
+
+                        // Reclamation Lv I "Curse-Hardened" passive: Reclamation-
+                        // adopted factions take -25% from Crystal-Curse PvE.
+                        // Mirrors the combat-path reduction in CombatDamageHelper.
+                        // (task-063 phase 2d)
+                        if (em.HasComponent<FactionTag>(entity)
+                            && SectQuery.IsAdoptedAtLeast(em,
+                                em.GetComponentData<FactionTag>(entity).Value,
+                                SectConfig.Reclamation, SectLeverKind.Passive))
+                        {
+                            damage = math.max(1, (int)(damage * 0.75f));
+                        }
+
                         ref var hp = ref health.ValueRW;
                         hp.Value = math.max(0, hp.Value - damage);
                         break; // Only take damage from one tile per tick

--- a/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CursedGroundDamageSystem.cs
@@ -74,16 +74,25 @@ namespace TheWaningBorder.Systems.Creatures
                         // Apply one tick of damage (DPS * tick interval)
                         int damage = math.max(1, (int)(groundDPS[i].DamagePerSecond * DamageTickInterval));
 
-                        // Reclamation Lv I "Curse-Hardened" passive: Reclamation-
-                        // adopted factions take -25% from Crystal-Curse PvE.
+                        // Reclamation "Curse-Hardened" passive: Reclamation-
+                        // adopted factions take -25/35/50% from Crystal-Curse PvE.
                         // Mirrors the combat-path reduction in CombatDamageHelper.
-                        // (task-063 phase 2d)
-                        if (em.HasComponent<FactionTag>(entity)
-                            && SectQuery.IsAdoptedAtLeast(em,
-                                em.GetComponentData<FactionTag>(entity).Value,
-                                SectConfig.Reclamation, SectLeverKind.Passive))
+                        // (task-063 phase 2d / phase 4 scaling)
+                        if (em.HasComponent<FactionTag>(entity))
                         {
-                            damage = math.max(1, (int)(damage * 0.75f));
+                            byte reclLevel = SectQuery.LevelOf(em,
+                                em.GetComponentData<FactionTag>(entity).Value,
+                                SectConfig.Reclamation, SectLeverKind.Passive);
+                            if (reclLevel > 0)
+                            {
+                                float reclMult = reclLevel switch
+                                {
+                                    2 => 0.65f,
+                                    3 => 0.50f,
+                                    _ => 0.75f,
+                                };
+                                damage = math.max(1, (int)(damage * reclMult));
+                            }
                         }
 
                         ref var hp = ref health.ValueRW;

--- a/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
+++ b/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
@@ -1,0 +1,63 @@
+// GlowIncomeSystem.cs
+// Credits Glow to the killer faction when an Elite crystal unit dies
+// (Veilstinger / Godsplinter). Mirrors PillageSystem's death-event hook
+// — runs before DeathSystem with WithNone<DeathAnimationState> so each
+// kill pays exactly once.
+//
+// "Elite" identification: any CrystalUnitTag entity that also carries
+// VeilstingerState or GodsplinterState. Cadaver-spawned crystal mobs
+// don't count — they have CrystalUnitTag but neither named state.
+//
+// Salvage + craft Glow paths are out of scope here; this covers the
+// kill-reward lane only.
+//
+// Audit fix #2.
+//
+// Location: Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct GlowIncomeSystem : ISystem
+    {
+        // Reward per kill.  Phase-5 polish may differentiate Veilstinger vs
+        // Godsplinter, but for now both pay the same modest amount.
+        private const int VeilstingerGlow = 2;
+        private const int GodsplinterGlow = 5;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastDamager, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastDamagedByFaction>, RefRO<FactionTag>>()
+                .WithAll<CrystalUnitTag>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction killer = lastDamager.ValueRO.Value;
+                if (faction.ValueRO.Value == killer) continue; // shouldn't happen
+
+                int glow;
+                if (em.HasComponent<GodsplinterState>(entity)) glow = GodsplinterGlow;
+                else if (em.HasComponent<VeilstingerState>(entity)) glow = VeilstingerGlow;
+                else continue; // not Elite
+
+                FactionEconomy.Add(em, killer, Cost.Of(glow: glow));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs.meta
+++ b/Assets/Scripts/Systems/Economy/GlowIncomeSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a4e2c6f1d3b5917e3b7a8c4d6f2e951

--- a/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
@@ -1,0 +1,265 @@
+// SectActivePowerSystem.cs
+// Active-Power lever dispatch (task-063 phase 5). Each adopted sect
+// exposes one triggered ability per the SectLeverEffects.ActiveOf table;
+// players (and AI) request a cast via SectActivePowerHelper.Fire which
+// validates cooldown + lever level, deducts the cooldown, and then
+// dispatches to the per-kind handler in SwitchOnKind.
+//
+// The cooldown lives in a DynamicBuffer<SectActivePowerCooldown> on the
+// faction bank entity so all 12 sects' timers per faction live in one
+// place. SectActivePowerSystem ticks all cooldowns and prunes entries
+// at zero.
+//
+// Magnitudes scale with the Active-Power lever level via
+// SectLeverEffects.LevelScalar; cooldowns scale inversely.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectActivePowerSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            // No specific RequireForUpdate — runs every tick to bleed cooldowns.
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            foreach (var (cooldowns, entity) in SystemAPI
+                .Query<DynamicBuffer<SectActivePowerCooldown>>()
+                .WithEntityAccess())
+            {
+                for (int i = cooldowns.Length - 1; i >= 0; i--)
+                {
+                    var cd = cooldowns[i];
+                    cd.Remaining -= dt;
+                    if (cd.Remaining <= 0f)
+                        cooldowns.RemoveAtSwapBack(i);
+                    else
+                        cooldowns[i] = cd;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Static helper for firing a sect's Active Power. UI buttons /
+    /// hotkeys / AI all funnel through Fire so the cooldown + spec
+    /// lookup live in one place.
+    /// </summary>
+    public static class SectActivePowerHelper
+    {
+        /// <summary>
+        /// Returns the remaining cooldown for the faction's sect Active
+        /// Power, or 0 if ready (or if the lever isn't bought).
+        /// </summary>
+        public static float CooldownRemaining(EntityManager em, Faction faction, string sectId)
+        {
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (sectIdx < 0) return float.MaxValue;
+            if (!FactionEconomy.TryGetBank(em, faction, out var bank)) return float.MaxValue;
+            if (!em.HasBuffer<SectActivePowerCooldown>(bank)) return 0f;
+            var buf = em.GetBuffer<SectActivePowerCooldown>(bank);
+            for (int i = 0; i < buf.Length; i++)
+                if (buf[i].SectIndex == sectIdx) return buf[i].Remaining;
+            return 0f;
+        }
+
+        public static bool CanFire(EntityManager em, Faction faction, string sectId)
+        {
+            byte level = SectQuery.LevelOf(em, faction, sectId, SectLeverKind.ActivePower);
+            if (level == 0) return false;
+            return CooldownRemaining(em, faction, sectId) <= 0f;
+        }
+
+        /// <summary>
+        /// Attempt to fire <paramref name="sectId"/>'s Active Power for
+        /// <paramref name="faction"/> at <paramref name="targetPos"/>.
+        /// Returns true if the cast succeeded (cooldown is set and the
+        /// effect was dispatched), false otherwise.
+        /// </summary>
+        public static bool Fire(EntityManager em, Faction faction, string sectId, float3 targetPos)
+        {
+            byte level = SectQuery.LevelOf(em, faction, sectId, SectLeverKind.ActivePower);
+            if (level == 0) return false;
+            if (CooldownRemaining(em, faction, sectId) > 0f) return false;
+
+            var spec = SectLeverEffects.ActiveOf(sectId);
+            if (spec.Kind == SectActivePowerKind.None) return false;
+
+            // Magnitude scales with level; cooldown scales inversely.
+            float scalar = SectLeverEffects.LevelScalar(level);
+            float radius = spec.Radius;
+            float magnitude = spec.Magnitude * scalar;
+            float duration = spec.Duration;
+            float cooldown = spec.Cooldown / scalar;
+
+            DispatchEffect(em, faction, spec.Kind, targetPos, radius, magnitude, duration);
+
+            // Stamp cooldown.
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (FactionEconomy.TryGetBank(em, faction, out var bank))
+            {
+                DynamicBuffer<SectActivePowerCooldown> buf;
+                if (!em.HasBuffer<SectActivePowerCooldown>(bank))
+                    buf = em.AddBuffer<SectActivePowerCooldown>(bank);
+                else
+                    buf = em.GetBuffer<SectActivePowerCooldown>(bank);
+
+                bool found = false;
+                for (int i = 0; i < buf.Length; i++)
+                {
+                    if (buf[i].SectIndex == sectIdx)
+                    {
+                        buf[i] = new SectActivePowerCooldown { SectIndex = (byte)sectIdx, Remaining = cooldown };
+                        found = true; break;
+                    }
+                }
+                if (!found)
+                    buf.Add(new SectActivePowerCooldown { SectIndex = (byte)sectIdx, Remaining = cooldown });
+            }
+            return true;
+        }
+
+        private static void DispatchEffect(EntityManager em, Faction faction,
+            SectActivePowerKind kind, float3 pos, float radius, float magnitude, float duration)
+        {
+            switch (kind)
+            {
+                case SectActivePowerKind.SmiteCircle:
+                    ApplyCircleDamage(em, faction, pos, radius, (int)magnitude);
+                    break;
+                case SectActivePowerKind.HealCircle:
+                    ApplyCircleHeal(em, faction, pos, radius, (int)magnitude);
+                    break;
+                case SectActivePowerKind.ArmorCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { ArmorBonus = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.DamageCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { DamageMultiplier = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.SpeedCircle:
+                    ApplyCircleBuff(em, faction, pos, radius,
+                        new SpellBuff { SpeedMultiplier = magnitude, TimeRemaining = duration });
+                    break;
+                case SectActivePowerKind.BurningCircle:
+                case SectActivePowerKind.SpawnPyre:
+                    SpawnBurning(em, faction, pos, radius, magnitude, duration);
+                    break;
+                case SectActivePowerKind.RevealCircle:
+                    SpawnReveal(em, faction, pos, radius, duration);
+                    break;
+            }
+        }
+
+        private static void ApplyCircleDamage(EntityManager em, Faction faction,
+            float3 center, float radius, int dmg)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value == faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                var hp = em.GetComponentData<Health>(e);
+                hp.Value = math.max(0, hp.Value - dmg);
+                em.SetComponentData(e, hp);
+            }
+        }
+
+        private static void ApplyCircleHeal(EntityManager em, Faction faction,
+            float3 center, float radius, int amount)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadWrite<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value != faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                var hp = em.GetComponentData<Health>(e);
+                if (hp.Value <= 0) continue;
+                hp.Value = math.min(hp.Max, hp.Value + amount);
+                em.SetComponentData(e, hp);
+            }
+        }
+
+        private static void ApplyCircleBuff(EntityManager em, Faction faction,
+            float3 center, float radius, SpellBuff buff)
+        {
+            float r2 = radius * radius;
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<FactionTag>(e).Value != faction) continue;
+                float3 p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - center.x, dz = p.z - center.z;
+                if (dx * dx + dz * dz > r2) continue;
+                TheWaningBorder.Systems.Combat.CombatDamageHelper.MergeSpellBuff(em, ecb, e, buff);
+            }
+            ecb.Playback(em);
+            ecb.Dispose();
+        }
+
+        private static void SpawnBurning(EntityManager em, Faction faction,
+            float3 center, float radius, float dps, float duration)
+        {
+            var pyre = em.CreateEntity(
+                typeof(BurningGround), typeof(LocalTransform), typeof(FactionTag));
+            em.SetComponentData(pyre, new BurningGround
+            {
+                DPS = dps,
+                TimeRemaining = duration,
+                Radius = radius,
+            });
+            em.SetComponentData(pyre, LocalTransform.FromPositionRotationScale(
+                center, quaternion.identity, 1f));
+            em.SetComponentData(pyre, new FactionTag { Value = faction });
+        }
+
+        private static void SpawnReveal(EntityManager em, Faction faction,
+            float3 center, float radius, float duration)
+        {
+            // Stub: a fog-of-war reveal needs FogOfWarSystem support that's
+            // out of scope here. Future Phase 5 polish will add a SectReveal
+            // entity that FogOfWarSystem honors. For now, scout-LOS bumps
+            // implemented elsewhere cover the core intent.
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectActivePowerSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d8a3c2f1b6e5921e7a4b8c2d1f3e895

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
@@ -1,0 +1,107 @@
+// SectAntiquityTallySystem.cs
+// Implements Antiquity's Lv I "Tally of the Lost" passive: each kill the
+// attacker makes is logged into a per-UnitClass counter on the attacker
+// (the AntiquityKills component). CombatDamageHelper reads those counters
+// on every hit and grants +1% per logged kill of the *target's* class,
+// capped at +10% (Lv I). Phase 4 raises both the per-kill bonus and the
+// cap.
+//
+// Hook: same death-event pattern as SectVenerationFervorSystem. Runs
+// before DeathSystem, scans entities at Health <= 0 with no death-marker,
+// reads LastAttackerEntity, increments the killer's class counter for
+// the dead unit's UnitClass.
+//
+// task-063 phase 2e.
+//
+// Location: Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectAntiquityTallySystem : ISystem
+    {
+        // Lv I cap. Phase 4: 16 / 25 for Lv II / Lv III.
+        private const byte KillCap = 10;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastAttacker, victimUnit, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastAttackerEntity>, RefRO<UnitTag>>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Entity killer = lastAttacker.ValueRO.Value;
+                if (killer == Entity.Null || !em.Exists(killer)) continue;
+                if (!em.HasComponent<FactionTag>(killer)) continue;
+                if (!em.HasComponent<UnitTag>(killer)) continue;
+
+                Faction killerFaction = em.GetComponentData<FactionTag>(killer).Value;
+                if (em.HasComponent<FactionTag>(entity)
+                    && em.GetComponentData<FactionTag>(entity).Value == killerFaction) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
+                        SectConfig.Antiquity, SectLeverKind.Passive)) continue;
+
+                var victimClass = victimUnit.ValueRO.Class;
+
+                // Stamp lazily on first relevant kill.
+                if (!em.HasComponent<AntiquityKills>(killer))
+                    em.AddComponentData(killer, new AntiquityKills());
+
+                var kills = em.GetComponentData<AntiquityKills>(killer);
+                Increment(ref kills, victimClass);
+                em.SetComponentData(killer, kills);
+            }
+        }
+
+        private static void Increment(ref AntiquityKills k, UnitClass cls)
+        {
+            switch (cls)
+            {
+                case UnitClass.Melee:   if (k.Melee   < KillCap) k.Melee++;   break;
+                case UnitClass.Ranged:  if (k.Ranged  < KillCap) k.Ranged++;  break;
+                case UnitClass.Siege:   if (k.Siege   < KillCap) k.Siege++;   break;
+                case UnitClass.Support: if (k.Support < KillCap) k.Support++; break;
+                case UnitClass.Magic:   if (k.Magic   < KillCap) k.Magic++;   break;
+                case UnitClass.Economy: if (k.Economy < KillCap) k.Economy++; break;
+                case UnitClass.Miner:   if (k.Miner   < KillCap) k.Miner++;   break;
+                case UnitClass.Scout:   if (k.Scout   < KillCap) k.Scout++;   break;
+            }
+        }
+
+        /// <summary>
+        /// Read the per-class kill count for a unit. Returns 0 if the attacker
+        /// has no AntiquityKills component yet. Public so CombatDamageHelper
+        /// can fold the bonus in without duplicating the switch.
+        /// </summary>
+        public static byte KillsAgainst(in AntiquityKills k, UnitClass cls)
+        {
+            switch (cls)
+            {
+                case UnitClass.Melee:   return k.Melee;
+                case UnitClass.Ranged:  return k.Ranged;
+                case UnitClass.Siege:   return k.Siege;
+                case UnitClass.Support: return k.Support;
+                case UnitClass.Magic:   return k.Magic;
+                case UnitClass.Economy: return k.Economy;
+                case UnitClass.Miner:   return k.Miner;
+                case UnitClass.Scout:   return k.Scout;
+                default: return 0;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs
@@ -25,8 +25,12 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectAntiquityTallySystem : ISystem
     {
-        // Lv I cap. Phase 4: 16 / 25 for Lv II / Lv III.
-        private const byte KillCap = 10;
+        private static byte KillCapFor(byte level) => level switch
+        {
+            2 => 16,
+            3 => 25,
+            _ => 10,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -53,8 +57,9 @@ namespace TheWaningBorder.Systems.Sect
                 if (em.HasComponent<FactionTag>(entity)
                     && em.GetComponentData<FactionTag>(entity).Value == killerFaction) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Antiquity, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Antiquity, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 var victimClass = victimUnit.ValueRO.Class;
 
@@ -63,23 +68,23 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new AntiquityKills());
 
                 var kills = em.GetComponentData<AntiquityKills>(killer);
-                Increment(ref kills, victimClass);
+                Increment(ref kills, victimClass, KillCapFor(level));
                 em.SetComponentData(killer, kills);
             }
         }
 
-        private static void Increment(ref AntiquityKills k, UnitClass cls)
+        private static void Increment(ref AntiquityKills k, UnitClass cls, byte cap)
         {
             switch (cls)
             {
-                case UnitClass.Melee:   if (k.Melee   < KillCap) k.Melee++;   break;
-                case UnitClass.Ranged:  if (k.Ranged  < KillCap) k.Ranged++;  break;
-                case UnitClass.Siege:   if (k.Siege   < KillCap) k.Siege++;   break;
-                case UnitClass.Support: if (k.Support < KillCap) k.Support++; break;
-                case UnitClass.Magic:   if (k.Magic   < KillCap) k.Magic++;   break;
-                case UnitClass.Economy: if (k.Economy < KillCap) k.Economy++; break;
-                case UnitClass.Miner:   if (k.Miner   < KillCap) k.Miner++;   break;
-                case UnitClass.Scout:   if (k.Scout   < KillCap) k.Scout++;   break;
+                case UnitClass.Melee:   if (k.Melee   < cap) k.Melee++;   break;
+                case UnitClass.Ranged:  if (k.Ranged  < cap) k.Ranged++;  break;
+                case UnitClass.Siege:   if (k.Siege   < cap) k.Siege++;   break;
+                case UnitClass.Support: if (k.Support < cap) k.Support++; break;
+                case UnitClass.Magic:   if (k.Magic   < cap) k.Magic++;   break;
+                case UnitClass.Economy: if (k.Economy < cap) k.Economy++; break;
+                case UnitClass.Miner:   if (k.Miner   < cap) k.Miner++;   break;
+                case UnitClass.Scout:   if (k.Scout   < cap) k.Scout++;   break;
             }
         }
 

--- a/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectAntiquityTallySystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d3f1c4a7b2e9163528a4d6c9f1b3e57

--- a/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
@@ -1,0 +1,106 @@
+// SectAshPyreSystem.cs
+// Implements Ash's Lv I "Pyre's Promise" passive: when a unit of an Ash-
+// adopted faction dies, it leaves a small burning-ground patch at its
+// death position — a low-DPS, short-lived AoE that damages enemies who
+// walk through it. Mirrors PillageSystem's death-event hook (runs before
+// DeathSystem with the WithNone marker so each death fires exactly once).
+//
+// Lv I tuning (overridden per-level by SectAshPyreSystem.GetTuning when
+// task-063 phase 4 lands):
+//   - DPS:      4
+//   - Duration: 3s
+//   - Radius:   2m
+//
+// task-063 phase 2f.
+//
+// Location: Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectAshPyreSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            var pyreSpawns = new NativeList<float3>(Allocator.Temp);
+            var pyreFactions = new NativeList<Faction>(Allocator.Temp);
+            var pyreDps = new NativeList<float>(Allocator.Temp);
+            var pyreRadius = new NativeList<float>(Allocator.Temp);
+            var pyreDuration = new NativeList<float>(Allocator.Temp);
+
+            foreach (var (health, transform, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<UnitTag>()
+                .WithNone<DeathAnimationState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction victimFaction = faction.ValueRO.Value;
+                byte level = SectQuery.LevelOf(em, victimFaction,
+                    SectConfig.Ash, SectLeverKind.Passive);
+                if (level == 0) continue;
+
+                GetTuning(level, out float dps, out float duration, out float radius);
+
+                pyreSpawns.Add(transform.ValueRO.Position);
+                pyreFactions.Add(victimFaction);
+                pyreDps.Add(dps);
+                pyreRadius.Add(radius);
+                pyreDuration.Add(duration);
+            }
+
+            for (int i = 0; i < pyreSpawns.Length; i++)
+            {
+                var pyre = em.CreateEntity(
+                    typeof(BurningGround),
+                    typeof(LocalTransform),
+                    typeof(FactionTag));
+                em.SetComponentData(pyre, new BurningGround
+                {
+                    DPS = pyreDps[i],
+                    TimeRemaining = pyreDuration[i],
+                    Radius = pyreRadius[i],
+                });
+                em.SetComponentData(pyre, LocalTransform.FromPositionRotationScale(
+                    pyreSpawns[i], quaternion.identity, 1f));
+                em.SetComponentData(pyre, new FactionTag { Value = pyreFactions[i] });
+            }
+
+            pyreSpawns.Dispose();
+            pyreFactions.Dispose();
+            pyreDps.Dispose();
+            pyreRadius.Dispose();
+            pyreDuration.Dispose();
+        }
+
+        /// <summary>
+        /// Per-level tuning. Lv I/II/III scale both potency and area.
+        /// (task-063 phase 4)
+        /// </summary>
+        public static void GetTuning(byte level, out float dps, out float duration, out float radius)
+        {
+            switch (level)
+            {
+                case 2:  dps = 7f; duration = 4f; radius = 2.5f; return;
+                case 3:  dps = 11f; duration = 5f; radius = 3f;  return;
+                default: dps = 4f; duration = 3f; radius = 2f;   return;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectAshPyreSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a4e2b9c5d1f6358247d3b8e1c6a4f95

--- a/Assets/Scripts/Systems/Sect/SectBloodPoolSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectBloodPoolSystem.cs
@@ -1,0 +1,172 @@
+// SectBloodPoolSystem.cs
+// Phase 3 of task-063: Feraldis blood-pool layer. Splits into three
+// concerns inside a single ISystem to keep ordering trivial:
+//
+//   1. Spawn   — every dead unit position becomes a small BloodPool entity,
+//                gated on at least one Feraldis Age II+ faction being live
+//                in the world. Runs BEFORE DeathSystem so the WithNone
+//                marker pattern lets each death fire exactly once.
+//   2. Decay   — tick TimeRemaining on each pool; destroy at zero.
+//   3. Sweep   — for each Feraldis Age II+ unit, stamp/clear InBloodPool
+//                each frame based on radius proximity to any active pool.
+//
+// CombatDamageHelper reads InBloodPool and layers the in-pool damage
+// bonus on top of Wrath's Lv I HP-missing bonus (+10% Lv I, +15% Lv II,
+// +20% Lv III). The age-gate is enforced at sweep time (units of non-
+// Feraldis or Age I factions never get the marker), and the global "is
+// Phase 3 active at all" gate is computed once per OnUpdate to skip the
+// per-unit work when no Feraldis Age II+ faction exists.
+//
+// Lv I tuning (per-pool):
+//   - Radius:    2.5m
+//   - Duration:  10s
+//
+// task-063 phase 3.
+//
+// Location: Assets/Scripts/Systems/Sect/SectBloodPoolSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Combat;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectBloodPoolSystem : ISystem
+    {
+        private const float PoolRadius   = 2.5f;
+        private const float PoolDuration = 10f;
+        // Faction enum is byte (0..7). We size cache arrays accordingly.
+        private const int   FactionCount = 8;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // Per-faction "is Feraldis Age II+" cache — built once per tick.
+            var feraldisAge2Plus = new NativeArray<bool>(FactionCount, Allocator.Temp);
+            bool anyFeraldisAge2Plus = false;
+            for (byte f = 0; f < FactionCount; f++)
+            {
+                var faction = (Faction)f;
+                if (FactionColors.GetFactionCulture(faction) != Cultures.Feraldis) continue;
+                if (!FactionEconomy.TryGetBank(em, faction, out var bank)) continue;
+                if (!em.HasComponent<FactionEra>(bank)) continue;
+                if (em.GetComponentData<FactionEra>(bank).Value < 2) continue;
+                feraldisAge2Plus[f] = true;
+                anyFeraldisAge2Plus = true;
+            }
+
+            // ───── 1. SPAWN ─────────────────────────────────────────────────
+            // Skip the death scan entirely if no Feraldis faction is Age 2+ —
+            // pools are useless and would just leak entities for 10s each.
+            if (anyFeraldisAge2Plus)
+            {
+                var spawnPositions = new NativeList<float3>(Allocator.Temp);
+                foreach (var (health, transform) in SystemAPI
+                    .Query<RefRO<Health>, RefRO<LocalTransform>>()
+                    .WithAll<UnitTag>()
+                    .WithNone<DeathAnimationState>())
+                {
+                    if (health.ValueRO.Value > 0) continue;
+                    spawnPositions.Add(transform.ValueRO.Position);
+                }
+                for (int i = 0; i < spawnPositions.Length; i++)
+                {
+                    var pool = em.CreateEntity(
+                        typeof(BloodPool), typeof(LocalTransform));
+                    em.SetComponentData(pool, new BloodPool
+                    {
+                        Radius = PoolRadius,
+                        TimeRemaining = PoolDuration,
+                    });
+                    em.SetComponentData(pool, LocalTransform.FromPositionRotationScale(
+                        spawnPositions[i], quaternion.identity, 1f));
+                }
+                spawnPositions.Dispose();
+            }
+
+            // ───── 2. DECAY ─────────────────────────────────────────────────
+            var expiredPools = new NativeList<Entity>(Allocator.Temp);
+            foreach (var (pool, entity) in SystemAPI
+                .Query<RefRW<BloodPool>>()
+                .WithEntityAccess())
+            {
+                pool.ValueRW.TimeRemaining -= dt;
+                if (pool.ValueRO.TimeRemaining <= 0f)
+                    expiredPools.Add(entity);
+            }
+            for (int i = 0; i < expiredPools.Length; i++)
+            {
+                if (em.Exists(expiredPools[i]))
+                    em.DestroyEntity(expiredPools[i]);
+            }
+            expiredPools.Dispose();
+
+            // ───── 3. SWEEP ─────────────────────────────────────────────────
+            // Collect surviving pool positions/radii for the proximity test.
+            var poolPositions = new NativeList<float3>(Allocator.Temp);
+            var poolRadii = new NativeList<float>(Allocator.Temp);
+            foreach (var (pool, transform) in SystemAPI
+                .Query<RefRO<BloodPool>, RefRO<LocalTransform>>())
+            {
+                if (pool.ValueRO.TimeRemaining <= 0f) continue;
+                poolPositions.Add(transform.ValueRO.Position);
+                poolRadii.Add(pool.ValueRO.Radius);
+            }
+
+            // Stamp / clear InBloodPool on Feraldis Age II+ units.
+            var toStamp = new NativeList<Entity>(Allocator.Temp);
+            var toClear = new NativeList<Entity>(Allocator.Temp);
+
+            foreach (var (faction, transform, entity) in SystemAPI
+                .Query<RefRO<FactionTag>, RefRO<LocalTransform>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                bool gated = (byte)faction.ValueRO.Value < FactionCount
+                          && feraldisAge2Plus[(byte)faction.ValueRO.Value];
+                bool inAnyPool = false;
+                if (gated && poolPositions.Length > 0)
+                {
+                    var p = transform.ValueRO.Position;
+                    for (int i = 0; i < poolPositions.Length; i++)
+                    {
+                        float dx = p.x - poolPositions[i].x;
+                        float dz = p.z - poolPositions[i].z;
+                        if (dx * dx + dz * dz <= poolRadii[i] * poolRadii[i])
+                        {
+                            inAnyPool = true;
+                            break;
+                        }
+                    }
+                }
+
+                bool stamped = em.HasComponent<InBloodPool>(entity);
+                if (inAnyPool && !stamped) toStamp.Add(entity);
+                else if (!inAnyPool && stamped) toClear.Add(entity);
+            }
+
+            for (int i = 0; i < toStamp.Length; i++)
+                if (em.Exists(toStamp[i])) em.AddComponent<InBloodPool>(toStamp[i]);
+            for (int i = 0; i < toClear.Length; i++)
+                if (em.Exists(toClear[i])) em.RemoveComponent<InBloodPool>(toClear[i]);
+
+            toStamp.Dispose();
+            toClear.Dispose();
+            poolPositions.Dispose();
+            poolRadii.Dispose();
+            feraldisAge2Plus.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectBloodPoolSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectBloodPoolSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9c7a3d5e1b6f4825a7e1d9b3c8f4a162

--- a/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
@@ -1,0 +1,146 @@
+// SectBuildingLeverSystem.cs
+// Generic chapel-aura system for the Building lever (task-063 phase 5).
+//
+// Each chapel scans for nearby allied units once per frame and refreshes
+// a SpellBuff (or HP regen) on each, with the aura parameters drawn from
+// SectLeverEffects.AuraOf(sectId). The aura magnitudes scale with the
+// faction's Building lever level via SectLeverEffects.LevelScalar.
+//
+// SpellBuff is refreshed every frame with TimeRemaining = 0.5s, so units
+// stepping out of the aura lose the buff within half a second
+// (SpellBuffSystem ticks the field down). The HP regen is applied
+// directly inline, capped at MaxHP.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectBuildingLeverSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ChapelTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // Snapshot all chapels and their auras once per tick.
+            var chapelPositions = new NativeList<float3>(Allocator.Temp);
+            var chapelFactions  = new NativeList<Faction>(Allocator.Temp);
+            var chapelAuras     = new NativeList<SectAuraSpec>(Allocator.Temp);
+
+            foreach (var (chapel, transform, faction, entity) in SystemAPI
+                .Query<RefRO<ChapelTag>, RefRO<LocalTransform>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<UnderConstruction>()
+                .WithEntityAccess())
+            {
+                string sectId = chapel.ValueRO.SectId.ToString();
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    sectId, SectLeverKind.Building);
+                if (level == 0) continue;
+
+                var aura = SectLeverEffects.AuraOf(sectId);
+                if (aura.Radius <= 0f) continue;
+
+                float scalar = SectLeverEffects.LevelScalar(level);
+                aura.DamageMultiplier = aura.DamageMultiplier > 1f
+                    ? 1f + (aura.DamageMultiplier - 1f) * scalar : aura.DamageMultiplier;
+                aura.SpeedMultiplier = aura.SpeedMultiplier > 1f
+                    ? 1f + (aura.SpeedMultiplier - 1f) * scalar : aura.SpeedMultiplier;
+                aura.ArmorBonus = (int)(aura.ArmorBonus * scalar);
+                aura.DamageReflect = aura.DamageReflect * scalar;
+                aura.HpRegenPerSecond = (int)(aura.HpRegenPerSecond * scalar);
+
+                chapelPositions.Add(transform.ValueRO.Position);
+                chapelFactions.Add(faction.ValueRO.Value);
+                chapelAuras.Add(aura);
+            }
+
+            if (chapelPositions.Length == 0)
+            {
+                chapelPositions.Dispose();
+                chapelFactions.Dispose();
+                chapelAuras.Dispose();
+                return;
+            }
+
+            // For each ally unit in range of any of its faction's chapels,
+            // refresh SpellBuff with the merged max-of-fields semantics.
+            var ecb = new EntityCommandBuffer(Allocator.Temp);
+
+            foreach (var (faction, transform, health, entity) in SystemAPI
+                .Query<RefRO<FactionTag>, RefRO<LocalTransform>, RefRW<Health>>()
+                .WithAll<UnitTag>()
+                .WithEntityAccess())
+            {
+                Faction unitFaction = faction.ValueRO.Value;
+                float3 unitPos = transform.ValueRO.Position;
+
+                // Combine all in-range chapel auras into a single best-of buff.
+                SectAuraSpec best = default;
+                bool any = false;
+                for (int i = 0; i < chapelPositions.Length; i++)
+                {
+                    if (chapelFactions[i] != unitFaction) continue;
+                    var ca = chapelAuras[i];
+                    if (math.distance(unitPos, chapelPositions[i]) > ca.Radius) continue;
+                    any = true;
+                    if (ca.DamageMultiplier > best.DamageMultiplier) best.DamageMultiplier = ca.DamageMultiplier;
+                    if (ca.ArmorBonus > best.ArmorBonus)             best.ArmorBonus       = ca.ArmorBonus;
+                    if (ca.SpeedMultiplier > best.SpeedMultiplier)   best.SpeedMultiplier  = ca.SpeedMultiplier;
+                    if (ca.DamageReflect > best.DamageReflect)       best.DamageReflect    = ca.DamageReflect;
+                    if (ca.HpRegenPerSecond > best.HpRegenPerSecond) best.HpRegenPerSecond = ca.HpRegenPerSecond;
+                }
+                if (!any) continue;
+
+                // Refresh SpellBuff (MergeSpellBuff takes max of every field).
+                if (best.DamageMultiplier > 0f
+                    || best.ArmorBonus > 0
+                    || best.SpeedMultiplier > 0f
+                    || best.DamageReflect > 0f)
+                {
+                    var incoming = new SpellBuff
+                    {
+                        DamageMultiplier = best.DamageMultiplier,
+                        ArmorBonus       = best.ArmorBonus,
+                        SpeedMultiplier  = best.SpeedMultiplier,
+                        DamageReflect    = best.DamageReflect,
+                        TimeRemaining    = 0.5f, // refreshed every frame
+                    };
+                    TheWaningBorder.Systems.Combat.CombatDamageHelper
+                        .MergeSpellBuff(em, ecb, entity, incoming);
+                }
+
+                // Inline HP regen — bounded by MaxHP, applied per dt.
+                if (best.HpRegenPerSecond > 0
+                    && health.ValueRO.Value > 0
+                    && health.ValueRO.Value < health.ValueRO.Max)
+                {
+                    int delta = (int)math.ceil(best.HpRegenPerSecond * dt);
+                    if (delta < 1) delta = 1;
+                    int newHp = math.min(health.ValueRO.Max, health.ValueRO.Value + delta);
+                    health.ValueRW.Value = newHp;
+                }
+            }
+
+            ecb.Playback(em);
+            ecb.Dispose();
+            chapelPositions.Dispose();
+            chapelFactions.Dispose();
+            chapelAuras.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectBuildingLeverSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d8c4f5e3a2b694712f8c5d9b3a7e426

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
@@ -1,0 +1,73 @@
+// SectFortitudeHpSystem.cs
+// Implements Fortitude's Lv I "Veiled Stone" passive (walls/towers +12% HP).
+// Mirrors SectWitnessVisionSystem's stamp-and-apply pattern: scans walls
+// (WallTag) and towers (WatchTowerTag, TotemTowerTag, WallTowerTag) of
+// Fortitude-adopted factions that don't yet carry FortitudeHpApplied, and
+// multiplies both Health.Max and Health.Value by the Lv I factor (×1.12).
+//
+// Tower range +0.5 (the second half of the Lv I lever) is deferred — tower
+// fire range is read in BuildingCombatSystem and will need a per-faction
+// scalar. Phase 4 / Phase 5.
+//
+// task-063 phase 2d.
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectFortitudeHpSystem : ISystem
+    {
+        // Lv I factor. Phase 4: 1.25× / 1.40× for Lv II / Lv III.
+        private const float HpMultiplierLv1 = 1.12f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BuildingTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+
+            foreach (var (health, faction, entity) in SystemAPI
+                .Query<RefRW<Health>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<FortitudeHpApplied>()
+                .WithEntityAccess())
+            {
+                // Only apply to walls + towers — the Lv I lever specifies them.
+                bool isWallOrTower =
+                    em.HasComponent<WallTag>(entity)
+                 || em.HasComponent<WallHubTag>(entity)
+                 || em.HasComponent<WallInstanceTag>(entity)
+                 || em.HasComponent<WallTowerTag>(entity)
+                 || em.HasComponent<WatchTowerTag>(entity)
+                 || em.HasComponent<TotemTowerTag>(entity);
+                if (!isWallOrTower) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Fortitude, SectLeverKind.Passive)) continue;
+
+                var hp = health.ValueRO;
+                int newMax = (int)(hp.Max * HpMultiplierLv1);
+                int newVal = (int)(hp.Value * HpMultiplierLv1);
+                health.ValueRW.Max = newMax;
+                health.ValueRW.Value = newVal;
+
+                pendingStamps.Add(entity);
+            }
+
+            for (int i = 0; i < pendingStamps.Length; i++)
+            {
+                if (em.Exists(pendingStamps[i]))
+                    em.AddComponentData(pendingStamps[i], new FortitudeHpApplied { AppliedLevel = 1 });
+            }
+            pendingStamps.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs
@@ -20,8 +20,14 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectFortitudeHpSystem : ISystem
     {
-        // Lv I factor. Phase 4: 1.25× / 1.40× for Lv II / Lv III.
-        private const float HpMultiplierLv1 = 1.12f;
+        // Per-level HP multiplier. Phase 4 lever upgrades read AppliedLevel
+        // and apply the diff (factorAt(new) / factorAt(old)) — see below.
+        public static float MultiplierFor(byte level) => level switch
+        {
+            2 => 1.25f,
+            3 => 1.40f,
+            _ => 1.12f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -32,7 +38,9 @@ namespace TheWaningBorder.Systems.Sect
         {
             var em = state.EntityManager;
 
-            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+            // Pass 1: brand-new walls/towers that haven't received any HP bonus yet.
+            var pendingNewStamps = new NativeList<Entity>(8, Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(8, Allocator.Temp);
 
             foreach (var (health, faction, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<FactionTag>>()
@@ -50,24 +58,47 @@ namespace TheWaningBorder.Systems.Sect
                  || em.HasComponent<TotemTowerTag>(entity);
                 if (!isWallOrTower) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Fortitude, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Fortitude, SectLeverKind.Passive);
+                if (level == 0) continue;
 
+                float mult = MultiplierFor(level);
                 var hp = health.ValueRO;
-                int newMax = (int)(hp.Max * HpMultiplierLv1);
-                int newVal = (int)(hp.Value * HpMultiplierLv1);
-                health.ValueRW.Max = newMax;
-                health.ValueRW.Value = newVal;
+                health.ValueRW.Max   = (int)(hp.Max   * mult);
+                health.ValueRW.Value = (int)(hp.Value * mult);
 
-                pendingStamps.Add(entity);
+                pendingNewStamps.Add(entity);
+                pendingNewLevels.Add(level);
             }
 
-            for (int i = 0; i < pendingStamps.Length; i++)
+            for (int i = 0; i < pendingNewStamps.Length; i++)
             {
-                if (em.Exists(pendingStamps[i]))
-                    em.AddComponentData(pendingStamps[i], new FortitudeHpApplied { AppliedLevel = 1 });
+                if (em.Exists(pendingNewStamps[i]))
+                    em.AddComponentData(pendingNewStamps[i],
+                        new FortitudeHpApplied { AppliedLevel = pendingNewLevels[i] });
             }
-            pendingStamps.Dispose();
+            pendingNewStamps.Dispose();
+            pendingNewLevels.Dispose();
+
+            // Pass 2: already-stamped buildings whose faction's lever level
+            // has since increased. Apply the diff factor to bring them up
+            // to date and bump AppliedLevel. (task-063 phase 4)
+            foreach (var (health, faction, applied, entity) in SystemAPI
+                .Query<RefRW<Health>, RefRO<FactionTag>, RefRW<FortitudeHpApplied>>()
+                .WithAll<BuildingTag>()
+                .WithEntityAccess())
+            {
+                byte currentLevel = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Fortitude, SectLeverKind.Passive);
+                byte appliedLevel = applied.ValueRO.AppliedLevel;
+                if (currentLevel <= appliedLevel) continue;
+
+                float diffMult = MultiplierFor(currentLevel) / MultiplierFor(appliedLevel);
+                var hp = health.ValueRO;
+                health.ValueRW.Max   = (int)(hp.Max   * diffMult);
+                health.ValueRW.Value = (int)(hp.Value * diffMult);
+                applied.ValueRW.AppliedLevel = currentLevel;
+            }
         }
     }
 }

--- a/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectFortitudeHpSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c8e5b3a4d9f7261e3a4b2c5d8e9f1a4

--- a/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectJusticeMarkSystem.cs
@@ -30,9 +30,16 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectJusticeMarkSystem : ISystem
     {
-        // Lv I tuning. Phase 4 will scale these via SectQuery.LevelOf.
+        // Mark duration is shared across levels — Phase 4 only scales the
+        // damage bonus per the Lv I/II/III spec (+10% / +20% / +30%).
         private const float MarkDuration = 30f;
-        private const float MarkDamageBonus = 0.10f; // +10% damage taken at Lv I
+
+        private static float DamageBonusFor(byte level) => level switch
+        {
+            2 => 0.20f,
+            3 => 0.30f,
+            _ => 0.10f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -79,13 +86,14 @@ namespace TheWaningBorder.Systems.Sect
                 if (avengerFaction == killerFaction) continue; // friendly fire — no mark
 
                 // Gate on the VICTIM's faction having Justice adopted.
-                if (!SectQuery.IsAdoptedAtLeast(em, avengerFaction,
-                        SectConfig.Justice, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, avengerFaction,
+                    SectConfig.Justice, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 var mark = new MarkedForSentence
                 {
                     MarkerFaction = avengerFaction,
-                    DamageBonus   = MarkDamageBonus,
+                    DamageBonus   = DamageBonusFor(level),
                     TimeRemaining = MarkDuration,
                 };
 

--- a/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRenewalAutoRepairSystem.cs
@@ -25,10 +25,17 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectRenewalAutoRepairSystem : ISystem
     {
-        // Lv I tuning. Phase 4: 25% / 40% per minute for Lv II / Lv III.
-        private const float RepairRatePerMinute = 0.12f;            // 12% of MaxHP per minute
+        // Out-of-combat threshold + tick interval are constant across levels.
+        // Repair-rate is per-level — Phase 4 scales per spec (12/25/40 %/min).
         private const float OutOfCombatThreshold = 5.0f;             // seconds without taking damage
         private const float TickInterval = 0.5f;                     // half-second tick (240 buildings @ 60fps would be wasteful)
+
+        private static float RepairRatePerMinuteFor(byte level) => level switch
+        {
+            2 => 0.25f,
+            3 => 0.40f,
+            _ => 0.12f,
+        };
 
         // Per-system tick accumulator.
         private float _tickTimer;
@@ -49,10 +56,6 @@ namespace TheWaningBorder.Systems.Sect
             var em = state.EntityManager;
             double now = SystemAPI.Time.ElapsedTime;
 
-            // Convert per-minute rate to per-tick HP delta.
-            // tickHp = MaxHP * 0.12 * (effectiveDt / 60).
-            float perTickFraction = RepairRatePerMinute * (effectiveDt / 60f);
-
             foreach (var (health, faction, entity) in SystemAPI
                 .Query<RefRW<Health>, RefRO<FactionTag>>()
                 .WithAll<BuildingTag>()
@@ -62,8 +65,9 @@ namespace TheWaningBorder.Systems.Sect
                 if (health.ValueRO.Value <= 0) continue;
                 if (health.ValueRO.Value >= health.ValueRO.Max) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Renewal, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Renewal, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 // Out-of-combat gate: skip if damaged within the last threshold.
                 if (em.HasComponent<BuildingDamageState>(entity))
@@ -72,7 +76,8 @@ namespace TheWaningBorder.Systems.Sect
                     if (now - dmg.LastDamagedAt < OutOfCombatThreshold) continue;
                 }
 
-                // Tick repair. Round up so a low-Max building still gets at least 1 HP per tick.
+                // Per-level rate, then convert per-minute → per-tick HP delta.
+                float perTickFraction = RepairRatePerMinuteFor(level) * (effectiveDt / 60f);
                 int delta = (int)math.ceil(health.ValueRO.Max * perTickFraction);
                 if (delta < 1) delta = 1;
 

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
@@ -31,8 +31,13 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectRuinRefundSystem : ISystem
     {
-        // Lv I refund factor. Phase 4: 0.18 / 0.25 for Lv II / Lv III.
-        private const float RefundFraction = 0.12f;
+        // Per-level refund fraction.
+        private static float RefundFractionFor(byte level) => level switch
+        {
+            2 => 0.18f,
+            3 => 0.25f,
+            _ => 0.12f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -57,19 +62,21 @@ namespace TheWaningBorder.Systems.Sect
                 // Skip own-faction kills (denies refund-farming demolitions).
                 if (killerFaction == victimFaction) continue;
 
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Ruin, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Ruin, SectLeverKind.Passive);
+                if (level == 0) continue;
 
                 string buildingId = BuildCosts.IdFromEntity(em, entity);
                 if (buildingId == null) continue;
                 if (!BuildCosts.TryGet(buildingId, out var cost)) continue;
 
+                float frac = RefundFractionFor(level);
                 var refund = Cost.Of(
-                    supplies:  (int)(cost.Supplies  * RefundFraction),
-                    iron:      (int)(cost.Iron      * RefundFraction),
-                    crystal:   (int)(cost.Crystal   * RefundFraction),
-                    veilsteel: (int)(cost.Veilsteel * RefundFraction),
-                    glow:      (int)(cost.Glow      * RefundFraction)
+                    supplies:  (int)(cost.Supplies  * frac),
+                    iron:      (int)(cost.Iron      * frac),
+                    crystal:   (int)(cost.Crystal   * frac),
+                    veilsteel: (int)(cost.Veilsteel * frac),
+                    glow:      (int)(cost.Glow      * frac)
                 );
 
                 FactionEconomy.Add(em, killerFaction, refund);

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
@@ -1,0 +1,79 @@
+// SectRuinRefundSystem.cs
+// Implements Ruin's Lv I "Profane Hands" passive (the 12%-refund-on-destruction
+// half). Mirrors PillageSystem: ticks before DeathSystem, scans entities at
+// Health <= 0 that haven't entered the death-animation pipeline yet, and if
+// the killer faction has Ruin adopted AND the dead entity is an enemy
+// building, credits the killer with 12% of the building's build cost.
+//
+// The +25% damage-vs-buildings half lives in CombatDamageHelper.ApplyBonusDamageOnHit.
+//
+// No-stack note: design rule #3 says Renewal/Ruin/Reclamation refunds don't
+// stack. Renewal Lv I refunds 12% of cost on UNIT death (deferred to a later
+// phase — see SectRenewalAutoRepairSystem.cs); Ruin Lv I refunds 12% on
+// BUILDING death. They never compete on the same entity, so no per-event
+// guard component is needed at Lv I. If Phase 4 introduces a sect that also
+// pays out on building destruction, a RefundConsumed marker should be added
+// here BEFORE the second sect is wired up.
+//
+// task-063 phase 2d.
+//
+// Location: Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs
+
+using Unity.Entities;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Data;
+using TheWaningBorder.Systems.Combat;
+using Cost = TheWaningBorder.Core.Cost;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(DeathSystem))]
+    public partial struct SectRuinRefundSystem : ISystem
+    {
+        // Lv I refund factor. Phase 4: 0.18 / 0.25 for Lv II / Lv III.
+        private const float RefundFraction = 0.12f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<Health>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            foreach (var (health, lastDamager, faction, entity) in SystemAPI
+                .Query<RefRO<Health>, RefRO<LastDamagedByFaction>, RefRO<FactionTag>>()
+                .WithAll<BuildingTag>()
+                .WithNone<DeathAnimationState, BuildingCollapseState>()
+                .WithEntityAccess())
+            {
+                if (health.ValueRO.Value > 0) continue;
+
+                Faction killerFaction = lastDamager.ValueRO.Value;
+                Faction victimFaction = faction.ValueRO.Value;
+
+                // Skip own-faction kills (denies refund-farming demolitions).
+                if (killerFaction == victimFaction) continue;
+
+                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
+                        SectConfig.Ruin, SectLeverKind.Passive)) continue;
+
+                string buildingId = BuildCosts.IdFromEntity(em, entity);
+                if (buildingId == null) continue;
+                if (!BuildCosts.TryGet(buildingId, out var cost)) continue;
+
+                var refund = Cost.Of(
+                    supplies:  (int)(cost.Supplies  * RefundFraction),
+                    iron:      (int)(cost.Iron      * RefundFraction),
+                    crystal:   (int)(cost.Crystal   * RefundFraction),
+                    veilsteel: (int)(cost.Veilsteel * RefundFraction),
+                    glow:      (int)(cost.Glow      * RefundFraction)
+                );
+
+                FactionEconomy.Add(em, killerFaction, refund);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectRuinRefundSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c2e8b7d9a3f615284a7c3d1b6e8f4a9

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
@@ -1,0 +1,105 @@
+// SectSilenceVigilSystem.cs
+// Implements Silence's Lv I "Steadfast Vigil" passive: a unit holding
+// position (HoldPositionTag) belonging to a Silence-adopted faction
+// accumulates a defense bonus that ramps over time. The bonus is exposed
+// via the SilenceVigilArmor component, which CombatDamageHelper.GetSpellBuffArmorBonus
+// folds into the matrix damage formula on the defender side.
+//
+// Ramp (Lv I): 0..2s held = 0 armor, 2..6s = linear 0 -> +6, 6s+ = +6.
+// Phase 4 raises the cap and shortens the warm-up window.
+//
+// On HoldPosition release the system removes both SilenceVigilState and
+// SilenceVigilArmor on the same frame so the bonus drops the instant
+// the unit moves — preventing a "carry the buff out of the stance" leak
+// that would happen if we mirrored the bonus into a SpellBuff with a
+// non-zero TimeRemaining.
+//
+// task-063 phase 2e.
+//
+// Location: Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectSilenceVigilSystem : ISystem
+    {
+        // Lv I tuning. Phase 4: faster warm-up + higher cap for Lv II / Lv III.
+        private const float WarmupSeconds = 2f;
+        private const float RampSeconds   = 4f;   // ramp window AFTER warm-up
+        private const int   ArmorCap      = 6;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<HoldPositionTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            var em = state.EntityManager;
+
+            // Ramp: tick TimeInStance, then write the matching armor bump.
+            // Skip units whose faction doesn't have Silence adopted — for
+            // them the state simply never gets stamped.
+            foreach (var (faction, entity) in SystemAPI
+                .Query<RefRO<FactionTag>>()
+                .WithAll<HoldPositionTag, UnitTag>()
+                .WithEntityAccess())
+            {
+                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
+                        SectConfig.Silence, SectLeverKind.Passive)) continue;
+
+                float t;
+                if (em.HasComponent<SilenceVigilState>(entity))
+                {
+                    var st = em.GetComponentData<SilenceVigilState>(entity);
+                    st.TimeInStance += dt;
+                    em.SetComponentData(entity, st);
+                    t = st.TimeInStance;
+                }
+                else
+                {
+                    em.AddComponentData(entity, new SilenceVigilState { TimeInStance = dt });
+                    t = dt;
+                }
+
+                int bonus;
+                if (t < WarmupSeconds) bonus = 0;
+                else if (t >= WarmupSeconds + RampSeconds) bonus = ArmorCap;
+                else
+                {
+                    float fraction = (t - WarmupSeconds) / RampSeconds;
+                    bonus = (int)(fraction * ArmorCap);
+                }
+
+                if (em.HasComponent<SilenceVigilArmor>(entity))
+                    em.SetComponentData(entity, new SilenceVigilArmor { Bonus = bonus });
+                else if (bonus > 0)
+                    em.AddComponentData(entity, new SilenceVigilArmor { Bonus = bonus });
+            }
+
+            // Sweep: any unit that has SilenceVigilState/Armor but is no
+            // longer holding position must lose both immediately.
+            var toClear = new NativeList<Entity>(8, Allocator.Temp);
+            foreach (var (st, entity) in SystemAPI
+                .Query<RefRO<SilenceVigilState>>()
+                .WithNone<HoldPositionTag>()
+                .WithEntityAccess())
+            {
+                toClear.Add(entity);
+            }
+            for (int i = 0; i < toClear.Length; i++)
+            {
+                var e = toClear[i];
+                if (!em.Exists(e)) continue;
+                if (em.HasComponent<SilenceVigilState>(e)) em.RemoveComponent<SilenceVigilState>(e);
+                if (em.HasComponent<SilenceVigilArmor>(e)) em.RemoveComponent<SilenceVigilArmor>(e);
+            }
+            toClear.Dispose();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs
@@ -27,10 +27,16 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectSilenceVigilSystem : ISystem
     {
-        // Lv I tuning. Phase 4: faster warm-up + higher cap for Lv II / Lv III.
-        private const float WarmupSeconds = 2f;
-        private const float RampSeconds   = 4f;   // ramp window AFTER warm-up
-        private const int   ArmorCap      = 6;
+        // Per-level tuning: warm-up shrinks and the cap grows with the lever.
+        private static void GetTuning(byte level, out float warmup, out float ramp, out int cap)
+        {
+            switch (level)
+            {
+                case 2:  warmup = 1.0f; ramp = 3.0f; cap = 10; return;
+                case 3:  warmup = 0.5f; ramp = 2.5f; cap = 15; return;
+                default: warmup = 2.0f; ramp = 4.0f; cap = 6;  return;
+            }
+        }
 
         public void OnCreate(ref SystemState state)
         {
@@ -50,8 +56,10 @@ namespace TheWaningBorder.Systems.Sect
                 .WithAll<HoldPositionTag, UnitTag>()
                 .WithEntityAccess())
             {
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Silence, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Silence, SectLeverKind.Passive);
+                if (level == 0) continue;
+                GetTuning(level, out float warmup, out float ramp, out int cap);
 
                 float t;
                 if (em.HasComponent<SilenceVigilState>(entity))
@@ -68,12 +76,12 @@ namespace TheWaningBorder.Systems.Sect
                 }
 
                 int bonus;
-                if (t < WarmupSeconds) bonus = 0;
-                else if (t >= WarmupSeconds + RampSeconds) bonus = ArmorCap;
+                if (t < warmup) bonus = 0;
+                else if (t >= warmup + ramp) bonus = cap;
                 else
                 {
-                    float fraction = (t - WarmupSeconds) / RampSeconds;
-                    bonus = (int)(fraction * ArmorCap);
+                    float fraction = (t - warmup) / ramp;
+                    bonus = (int)(fraction * cap);
                 }
 
                 if (em.HasComponent<SilenceVigilArmor>(entity))

--- a/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectSilenceVigilSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e1a8b6f3d2c4915e8b3a7c2f4d6e198

--- a/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
@@ -1,0 +1,166 @@
+// SectUnitLeverSystem.cs
+// Generic stat-bump applier for the Unit lever (task-063 phase 5).
+//
+// For each faction × sect with the Unit lever at Lv 1+, scans units of
+// that faction matching the spec's UnitClass and applies the per-sect
+// bump (HP / armor / damage). Stamped via SectUnitLeverApplied so each
+// unit is processed exactly once per (sect-id, level) pair. Phase 4
+// scaling diff is applied when the lever level on the faction rises.
+//
+// task-063 phase 5.
+//
+// Location: Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Sect
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct SectUnitLeverSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UnitTag>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+
+            // Per-faction × per-sect, walk the matching units once.
+            // Inner loop is small (at most 8 sects × number-of-factions),
+            // so the cost per tick is dominated by the unit query.
+            for (int sectIdx = 0; sectIdx < SectConfig.SectCount; sectIdx++)
+            {
+                string sectId = SectConfig.IdAt(sectIdx);
+                var spec = SectLeverEffects.UnitOf(sectId);
+                // Skip sects whose Unit-lever spec is empty / default.
+                if (spec.DamageMultiplier == 0f && spec.ArmorBonus == 0 && spec.HpMultiplier == 0f) continue;
+
+                ApplyForSect(ref state, em, sectId, spec);
+            }
+        }
+
+        private static void ApplyForSect(ref SystemState state, EntityManager em,
+            string sectId, in SectUnitLeverSpec spec)
+        {
+            // Stamp encodes (sectIndex << 4) | level so re-application on
+            // upgrade is a simple inequality check.
+            int sectIdx = SectConfig.IndexOf(sectId);
+            if (sectIdx < 0) return;
+
+            // Pass 1: never-stamped units of this sect.
+            var pendingNew = new NativeList<Entity>(Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(Allocator.Temp);
+
+            foreach (var (unit, faction, entity) in SystemAPI
+                .Query<RefRO<UnitTag>, RefRO<FactionTag>>()
+                .WithEntityAccess())
+            {
+                if (spec.AppliesToClass >= 0 && (int)unit.ValueRO.Class != spec.AppliesToClass)
+                    continue;
+
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    sectId, SectLeverKind.Unit);
+                if (level == 0) continue;
+
+                // Existing stamp: skip if this sect already at the same or higher level.
+                if (HasStampForSect(em, entity, sectIdx, out byte appliedLevel)
+                    && appliedLevel >= level) continue;
+
+                pendingNew.Add(entity);
+                pendingNewLevels.Add(level);
+            }
+
+            for (int i = 0; i < pendingNew.Length; i++)
+            {
+                var e = pendingNew[i];
+                if (!em.Exists(e)) continue;
+
+                byte applied = HasStampForSect(em, e, sectIdx, out byte prev) ? prev : (byte)0;
+                byte newLevel = pendingNewLevels[i];
+
+                float scalar = SectLeverEffects.LevelScalar(newLevel)
+                              / (applied > 0 ? SectLeverEffects.LevelScalar(applied) : 1f);
+
+                ApplyDelta(em, e, spec, scalar);
+                SetStampForSect(em, e, sectIdx, newLevel);
+            }
+
+            pendingNew.Dispose();
+            pendingNewLevels.Dispose();
+        }
+
+        // Stamp uses a DynamicBuffer<SectUnitLeverApplied> per unit so each
+        // sect's level can be tracked independently (a unit's faction may
+        // have multiple sects with the same UnitClass target).
+        private static bool HasStampForSect(EntityManager em, Entity entity, int sectIdx, out byte level)
+        {
+            level = 0;
+            if (!em.HasBuffer<SectUnitLeverApplied>(entity)) return false;
+            var buf = em.GetBuffer<SectUnitLeverApplied>(entity);
+            for (int i = 0; i < buf.Length; i++)
+            {
+                if (buf[i].SectIndex == sectIdx) { level = buf[i].Level; return true; }
+            }
+            return false;
+        }
+
+        private static void SetStampForSect(EntityManager em, Entity entity, int sectIdx, byte level)
+        {
+            DynamicBuffer<SectUnitLeverApplied> buf;
+            if (!em.HasBuffer<SectUnitLeverApplied>(entity))
+                buf = em.AddBuffer<SectUnitLeverApplied>(entity);
+            else
+                buf = em.GetBuffer<SectUnitLeverApplied>(entity);
+            for (int i = 0; i < buf.Length; i++)
+            {
+                if (buf[i].SectIndex == sectIdx)
+                {
+                    buf[i] = new SectUnitLeverApplied { SectIndex = (byte)sectIdx, Level = level };
+                    return;
+                }
+            }
+            buf.Add(new SectUnitLeverApplied { SectIndex = (byte)sectIdx, Level = level });
+        }
+
+        private static void ApplyDelta(EntityManager em, Entity entity,
+            in SectUnitLeverSpec spec, float scalar)
+        {
+            // HP — multiplicative on Max + Value.
+            if (math.abs(spec.HpMultiplier - 1f) > 0.001f && em.HasComponent<Health>(entity))
+            {
+                var hp = em.GetComponentData<Health>(entity);
+                float diff = 1f + (spec.HpMultiplier - 1f) * scalar;
+                hp.Max   = (int)(hp.Max   * diff);
+                hp.Value = (int)(hp.Value * diff);
+                em.SetComponentData(entity, hp);
+            }
+
+            // Armor — flat add to all defense channels.
+            if (spec.ArmorBonus > 0 && em.HasComponent<Defense>(entity))
+            {
+                var def = em.GetComponentData<Defense>(entity);
+                int bump = (int)(spec.ArmorBonus * scalar);
+                def.Melee  += bump;
+                def.Ranged += bump;
+                def.Siege  += bump;
+                def.Magic  += bump;
+                em.SetComponentData(entity, def);
+            }
+
+            // Damage — multiplicative on Damage component.
+            if (math.abs(spec.DamageMultiplier - 1f) > 0.001f && em.HasComponent<Damage>(entity))
+            {
+                var dmg = em.GetComponentData<Damage>(entity);
+                float diff = 1f + (spec.DamageMultiplier - 1f) * scalar;
+                dmg.Value = (int)(dmg.Value * diff);
+                em.SetComponentData(entity, dmg);
+            }
+        }
+    }
+
+}

--- a/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs.meta
+++ b/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b6e8f1a4c5d3712f9a8c2b6e1d4f573

--- a/Assets/Scripts/Systems/Sect/SectVenerationFervorSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectVenerationFervorSystem.cs
@@ -24,11 +24,20 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateBefore(typeof(DeathSystem))]
     public partial struct SectVenerationFervorSystem : ISystem
     {
-        // Lv I tuning. Kept inline; Phase 4 will pull from SectDefinition.
-        private const byte  MaxStacks    = 8;        // caps the multiplier at +24% / +24%
-        private const float StackDuration = 3f;
-        private const float DamageBonusPerStack = 0.03f;
-        private const float AttackSpeedBonusPerStack = 0.03f;
+        // Stack count + duration are shared across levels; Phase 4 scales
+        // only the per-stack bonus values. Lv III adds a movement-speed
+        // stack — that lever is deferred to Phase 5 since the move-speed
+        // read points aren't yet wired through SpellBuff.SpeedMultiplier.
+        private const byte  MaxStacks     = 8;        // caps the multiplier at +(stack% × 8)
+        private const float StackDuration = 3f;       // Lv III bumps to 4s — applied below.
+
+        private static float DamageBonusPerStackFor(byte level) => level switch
+        {
+            2 => 0.05f,
+            3 => 0.07f,
+            _ => 0.03f,
+        };
+        private static float StackDurationFor(byte level) => level == 3 ? 4f : StackDuration;
 
         public void OnCreate(ref SystemState state)
         {
@@ -53,17 +62,18 @@ namespace TheWaningBorder.Systems.Sect
 
                 Faction killerFaction = em.GetComponentData<FactionTag>(killer).Value;
 
-                // Gate on Veneration adoption (any lever level on the Passive
-                // counts; Phase 4 reads the level to scale per-stack values).
-                if (!SectQuery.IsAdoptedAtLeast(em, killerFaction,
-                        SectConfig.Veneration, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, killerFaction,
+                    SectConfig.Veneration, SectLeverKind.Passive);
+                if (level == 0) continue;
+                float perStack = DamageBonusPerStackFor(level);
+                float duration = StackDurationFor(level);
 
                 // Add or refresh the stack.
                 if (em.HasComponent<VenerationFervor>(killer))
                 {
                     var fervor = em.GetComponentData<VenerationFervor>(killer);
                     if (fervor.Stacks < MaxStacks) fervor.Stacks++;
-                    fervor.TimeRemaining = StackDuration;
+                    fervor.TimeRemaining = duration;
                     em.SetComponentData(killer, fervor);
                 }
                 else
@@ -71,26 +81,23 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new VenerationFervor
                     {
                         Stacks = 1,
-                        TimeRemaining = StackDuration,
+                        TimeRemaining = duration,
                     });
                 }
 
                 // Mirror the bonus into SpellBuff so existing combat-pipeline
                 // readers (CombatDamageHelper.ApplyBonusDamageOnHit reads
                 // SpellBuff.DamageMultiplier) see the boost. SpellBuff is the
-                // unified "outgoing damage modifier" channel; SpeedMultiplier
-                // doesn't directly affect attack speed in the current code,
-                // so the +attack-speed half of Fervor is handled separately
-                // in Phase 4 when the attack-cooldown read points get touched.
+                // unified "outgoing damage modifier" channel; the +attack-
+                // speed and Lv III +move halves remain Phase 5 work since
+                // those read points aren't wired through SpellBuff.
                 int newStacks = em.GetComponentData<VenerationFervor>(killer).Stacks;
-                float dmgMult = 1f + DamageBonusPerStack * newStacks;
+                float dmgMult = 1f + perStack * newStacks;
                 if (em.HasComponent<SpellBuff>(killer))
                 {
                     var buff = em.GetComponentData<SpellBuff>(killer);
-                    // Take the max so Fervor doesn't clobber a stronger
-                    // existing buff (e.g. an ally's Crystal Communion zone).
                     if (dmgMult > buff.DamageMultiplier) buff.DamageMultiplier = dmgMult;
-                    if (StackDuration > buff.TimeRemaining) buff.TimeRemaining = StackDuration;
+                    if (duration > buff.TimeRemaining) buff.TimeRemaining = duration;
                     em.SetComponentData(killer, buff);
                 }
                 else
@@ -98,7 +105,7 @@ namespace TheWaningBorder.Systems.Sect
                     em.AddComponentData(killer, new SpellBuff
                     {
                         DamageMultiplier = dmgMult,
-                        TimeRemaining    = StackDuration,
+                        TimeRemaining    = duration,
                     });
                 }
             }

--- a/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectWitnessVisionSystem.cs
@@ -26,8 +26,14 @@ namespace TheWaningBorder.Systems.Sect
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct SectWitnessVisionSystem : ISystem
     {
-        // Lv I factor. Phase 4: 1.50× / 1.75× for Lv II / Lv III.
-        private const float VisionMultiplierLv1 = 1.25f;
+        // Per-level vision multiplier. Phase 4 reads AppliedLevel and applies
+        // the diff (factorAt(new) / factorAt(old)) on lever upgrade.
+        public static float MultiplierFor(byte level) => level switch
+        {
+            2 => 1.50f,
+            3 => 1.75f,
+            _ => 1.25f,
+        };
 
         public void OnCreate(ref SystemState state)
         {
@@ -38,9 +44,9 @@ namespace TheWaningBorder.Systems.Sect
         {
             var em = state.EntityManager;
 
-            // Collect scouts that need the bonus stamped — defer the actual
-            // archetype mutation (AddComponent) until after the foreach.
-            var pendingStamps = new NativeList<Entity>(8, Allocator.Temp);
+            // Pass 1: brand-new scouts that haven't received the bonus yet.
+            var pendingNewStamps = new NativeList<Entity>(8, Allocator.Temp);
+            var pendingNewLevels = new NativeList<byte>(8, Allocator.Temp);
 
             foreach (var (unit, faction, los, entity) in SystemAPI
                 .Query<RefRO<UnitTag>, RefRO<FactionTag>, RefRW<LineOfSight>>()
@@ -48,19 +54,39 @@ namespace TheWaningBorder.Systems.Sect
                 .WithEntityAccess())
             {
                 if (unit.ValueRO.Class != UnitClass.Scout) continue;
-                if (!SectQuery.IsAdoptedAtLeast(em, faction.ValueRO.Value,
-                        SectConfig.Witness, SectLeverKind.Passive)) continue;
+                byte level = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Witness, SectLeverKind.Passive);
+                if (level == 0) continue;
 
-                los.ValueRW.Radius *= VisionMultiplierLv1;
-                pendingStamps.Add(entity);
+                los.ValueRW.Radius *= MultiplierFor(level);
+                pendingNewStamps.Add(entity);
+                pendingNewLevels.Add(level);
             }
 
-            for (int i = 0; i < pendingStamps.Length; i++)
+            for (int i = 0; i < pendingNewStamps.Length; i++)
             {
-                if (em.Exists(pendingStamps[i]))
-                    em.AddComponentData(pendingStamps[i], new WitnessVisionApplied { AppliedLevel = 1 });
+                if (em.Exists(pendingNewStamps[i]))
+                    em.AddComponentData(pendingNewStamps[i],
+                        new WitnessVisionApplied { AppliedLevel = pendingNewLevels[i] });
             }
-            pendingStamps.Dispose();
+            pendingNewStamps.Dispose();
+            pendingNewLevels.Dispose();
+
+            // Pass 2: already-stamped scouts whose faction's lever level rose
+            // since stamping. Apply the diff factor and bump AppliedLevel.
+            // (task-063 phase 4)
+            foreach (var (faction, los, applied) in SystemAPI
+                .Query<RefRO<FactionTag>, RefRW<LineOfSight>, RefRW<WitnessVisionApplied>>())
+            {
+                byte currentLevel = SectQuery.LevelOf(em, faction.ValueRO.Value,
+                    SectConfig.Witness, SectLeverKind.Passive);
+                byte appliedLevel = applied.ValueRO.AppliedLevel;
+                if (currentLevel <= appliedLevel) continue;
+
+                float diffMult = MultiplierFor(currentLevel) / MultiplierFor(appliedLevel);
+                los.ValueRW.Radius *= diffMult;
+                applied.ValueRW.AppliedLevel = currentLevel;
+            }
         }
     }
 }

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -89,6 +89,17 @@ namespace TheWaningBorder.Systems.Training
                     if (FactionColors.GetFactionCulture(buildingFaction) == Cultures.Feraldis)
                         trainingTime *= 1.75f;
 
+                    // Sect of War Lv I: military units train 15% faster.
+                    // (task-063 phase 2d) — Phase 4 scales to 25% / 35% for Lv II/III.
+                    bool isMilitary = UnitFactory.GetUnitClass(unitId) == UnitClass.Melee
+                                   || UnitFactory.GetUnitClass(unitId) == UnitClass.Ranged
+                                   || UnitFactory.GetUnitClass(unitId) == UnitClass.Siege;
+                    if (isMilitary && SectQuery.IsAdoptedAtLeast(state.EntityManager, buildingFaction,
+                            SectConfig.War, SectLeverKind.Passive))
+                    {
+                        trainingTime *= 0.85f; // -15% time = ×0.85
+                    }
+
                     ts.ValueRW.Busy = 1;
                     ts.ValueRW.Remaining = trainingTime;
                 }

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -89,15 +89,17 @@ namespace TheWaningBorder.Systems.Training
                     if (FactionColors.GetFactionCulture(buildingFaction) == Cultures.Feraldis)
                         trainingTime *= 1.75f;
 
-                    // Sect of War Lv I: military units train 15% faster.
-                    // (task-063 phase 2d) — Phase 4 scales to 25% / 35% for Lv II/III.
+                    // Sect of War: military units train -15/-25/-35% faster
+                    // (Lv I/II/III). (task-063 phase 2d / phase 4 scaling)
                     bool isMilitary = UnitFactory.GetUnitClass(unitId) == UnitClass.Melee
                                    || UnitFactory.GetUnitClass(unitId) == UnitClass.Ranged
                                    || UnitFactory.GetUnitClass(unitId) == UnitClass.Siege;
-                    if (isMilitary && SectQuery.IsAdoptedAtLeast(state.EntityManager, buildingFaction,
-                            SectConfig.War, SectLeverKind.Passive))
+                    if (isMilitary)
                     {
-                        trainingTime *= 0.85f; // -15% time = ×0.85
+                        byte warLevel = SectQuery.LevelOf(state.EntityManager, buildingFaction,
+                            SectConfig.War, SectLeverKind.Passive);
+                        if (warLevel > 0)
+                            trainingTime *= WarSectCostHelper.TrainTimeMultiplierFor(warLevel);
                     }
 
                     ts.ValueRW.Busy = 1;

--- a/Assets/Scripts/UI/HUD/ReligionHUD.cs
+++ b/Assets/Scripts/UI/HUD/ReligionHUD.cs
@@ -1,0 +1,190 @@
+// File: Assets/Scripts/UI/HUD/ReligionHUD.cs
+// Top-center HUD strip showing the local player's 6 sect chapel slots.
+// Hidden whenever the player has anything selected — matches the spec
+// behaviour ("when nothing is selected: top-center Religion HUD").
+//
+// Each slot shows: empty / building / adopted-with-letter (A/R/F/Re/S/J/V/W/W/A/R/W).
+// Adopted slots gain a small Fire button when the sect's Active Power
+// lever is bought; the cast originates at the temple position (a future
+// pass adds target-cursor mode).
+//
+// Audit fix #3.
+
+using System.Collections.Generic;
+using Unity.Entities;
+using Unity.Transforms;
+using UnityEngine;
+using TheWaningBorder.Economy;
+using TheWaningBorder.Input;
+using TheWaningBorder.Systems.Sect;
+using EntityWorld = Unity.Entities.World;
+
+namespace TheWaningBorder.UI.HUD
+{
+    public class ReligionHUD : MonoBehaviour
+    {
+        public const float SlotWidth = 72f;
+        public const float SlotHeight = 56f;
+        public const float SlotSpacing = 4f;
+        public const float TopMargin = 14f;
+        private const int SlotCount = 6;
+
+        private EntityWorld _world;
+        private EntityManager _em;
+
+        private GUIStyle _slotStyle;
+        private GUIStyle _slotEmptyStyle;
+        private GUIStyle _fireBtnStyle;
+        private bool _stylesBuilt;
+
+        private void Awake()
+        {
+            _world = EntityWorld.DefaultGameObjectInjectionWorld;
+            if (_world != null && _world.IsCreated)
+                _em = _world.EntityManager;
+        }
+
+        private void OnGUI()
+        {
+            if (_world == null || !_world.IsCreated) return;
+            if (_em.Equals(default(EntityManager))) _em = _world.EntityManager;
+
+            // Hide whenever the player has anything selected.
+            if (SelectionSystem.CurrentSelection != null
+                && SelectionSystem.CurrentSelection.Count > 0)
+                return;
+
+            BuildStyles();
+
+            var faction = GameSettings.LocalPlayerFaction;
+            if (!TryGetTemple(faction, out var temple))
+            {
+                DrawNoTempleHint();
+                return;
+            }
+
+            DrawSlots(faction, temple);
+        }
+
+        private void DrawNoTempleHint()
+        {
+            float total = SlotWidth * SlotCount + SlotSpacing * (SlotCount - 1);
+            float x = (Screen.width - total) * 0.5f;
+            var rect = new Rect(x, TopMargin, total, SlotHeight);
+            GUI.Label(rect, "Religion HUD: build a Temple of Ridan to enable sect adoption.", _slotStyle);
+        }
+
+        private void DrawSlots(Faction faction, Entity temple)
+        {
+            if (!_em.HasBuffer<TempleChapelSlot>(temple)) return;
+            var slots = _em.GetBuffer<TempleChapelSlot>(temple);
+
+            float total = SlotWidth * SlotCount + SlotSpacing * (SlotCount - 1);
+            float x0 = (Screen.width - total) * 0.5f;
+            float y = TopMargin;
+
+            for (int i = 0; i < SlotCount; i++)
+            {
+                var rect = new Rect(x0 + i * (SlotWidth + SlotSpacing), y, SlotWidth, SlotHeight);
+                if (i >= slots.Length) { GUI.Label(rect, $"Slot {i + 1}", _slotEmptyStyle); continue; }
+
+                var slot = slots[i];
+                if (slot.State == 0)
+                {
+                    GUI.Label(rect, $"Slot {i + 1}\n(empty)", _slotEmptyStyle);
+                    continue;
+                }
+                if (slot.State == 1)
+                {
+                    int pct = slot.BuildTime > 0 ? (int)(100f * slot.BuildProgress / slot.BuildTime) : 0;
+                    GUI.Label(rect, $"{ShortName(slot.SectId.ToString())}\n{pct}%", _slotStyle);
+                    continue;
+                }
+
+                // State 2 — chapel complete, sect adopted.
+                string sectId = slot.SectId.ToString();
+                GUI.Label(rect, ShortName(sectId), _slotStyle);
+
+                // Fire button if the Active Power lever is bought.
+                byte apLevel = SectQuery.LevelOf(_em, faction, sectId, SectLeverKind.ActivePower);
+                if (apLevel > 0)
+                {
+                    var btnRect = new Rect(rect.x + 4, rect.y + 28, rect.width - 8, 22);
+                    float remaining = SectActivePowerHelper.CooldownRemaining(_em, faction, sectId);
+                    bool ready = remaining <= 0f;
+                    GUI.enabled = ready;
+                    string label = ready ? "Fire" : $"{(int)remaining}s";
+                    if (GUI.Button(btnRect, label, _fireBtnStyle))
+                    {
+                        if (_em.HasComponent<LocalTransform>(temple))
+                        {
+                            var t = _em.GetComponentData<LocalTransform>(temple);
+                            SectActivePowerHelper.Fire(_em, faction, sectId, t.Position);
+                        }
+                    }
+                    GUI.enabled = true;
+                }
+            }
+        }
+
+        private bool TryGetTemple(Faction faction, out Entity temple)
+        {
+            temple = Entity.Null;
+            var query = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<TempleOfRidanTag>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var entities = query.ToEntityArray(Unity.Collections.Allocator.Temp);
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (_em.GetComponentData<FactionTag>(entities[i]).Value == faction)
+                {
+                    temple = entities[i];
+                    return true;
+                }
+            }
+            // Fallback to TempleTag (legacy alias).
+            var legacyQuery = _em.CreateEntityQuery(
+                ComponentType.ReadOnly<TempleTag>(),
+                ComponentType.ReadOnly<FactionTag>());
+            using var legacy = legacyQuery.ToEntityArray(Unity.Collections.Allocator.Temp);
+            for (int i = 0; i < legacy.Length; i++)
+            {
+                if (_em.GetComponentData<FactionTag>(legacy[i]).Value == faction)
+                {
+                    temple = legacy[i];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static string ShortName(string sectId)
+        {
+            // SectConfig ids look like "Sect_Antiquity" — strip the prefix.
+            if (string.IsNullOrEmpty(sectId)) return string.Empty;
+            const string p = "Sect_";
+            return sectId.StartsWith(p) ? sectId.Substring(p.Length) : sectId;
+        }
+
+        private void BuildStyles()
+        {
+            if (_stylesBuilt) return;
+            _slotStyle = new GUIStyle(GUI.skin.box)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 12,
+                wordWrap = true,
+            };
+            _slotEmptyStyle = new GUIStyle(_slotStyle)
+            {
+                fontStyle = FontStyle.Italic,
+            };
+            _fireBtnStyle = new GUIStyle(GUI.skin.button)
+            {
+                alignment = TextAnchor.MiddleCenter,
+                fontSize = 11,
+            };
+            _stylesBuilt = true;
+        }
+    }
+}

--- a/Assets/Scripts/UI/HUD/ReligionHUD.cs.meta
+++ b/Assets/Scripts/UI/HUD/ReligionHUD.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c1b8a3e9d2f4715238d6c4f2a8b1e75

--- a/Assets/Scripts/UI/Panels/EntityActionPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityActionPanel.cs
@@ -344,8 +344,10 @@ namespace TheWaningBorder.UI.Panels
                     return;
                 }
 
-                // Deduct cost when adding to queue
-                if (!FactionEconomy.Spend(em, faction, button.Cost))
+                // Deduct cost when adding to queue. War Lv I -5% discount applies
+                // to military units only (task-063 phase 2d).
+                var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                if (!FactionEconomy.Spend(em, faction, trainCost))
                 {
                     PlayerNotificationSystem.NotifyError("Not enough resources");
                     return;
@@ -441,7 +443,8 @@ namespace TheWaningBorder.UI.Panels
                         return;
                     }
 
-                    if (!FactionEconomy.Spend(em, faction, button.Cost))
+                    var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                    if (!FactionEconomy.Spend(em, faction, trainCost))
                     {
                         PlayerNotificationSystem.NotifyError("Not enough resources");
                         return;
@@ -807,7 +810,8 @@ namespace TheWaningBorder.UI.Panels
                         return;
                     }
 
-                    if (!FactionEconomy.Spend(em, faction, button.Cost))
+                    var trainCost = WarSectCostHelper.MilitaryDiscount(em, faction, button.Id.ToString(), button.Cost);
+                    if (!FactionEconomy.Spend(em, faction, trainCost))
                     {
                         PlayerNotificationSystem.NotifyError("Not enough resources");
                         return;

--- a/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
@@ -248,12 +248,89 @@ namespace TheWaningBorder.UI.Panels
             // Trade lane caravan countdown (Runai Trading Posts)
             DrawTradeLaneCountdown();
 
+            // Veteran rank promotion + Glow Ability (audit fix #1)
+            DrawUnitRankSection();
+
             GUILayout.Space(10);
 
             // Description
             GUILayout.Label(info.Description, _descStyle);
 
             GUILayout.EndArea();
+        }
+
+        /// <summary>
+        /// Veteran rank UI for the selected military unit. Shows the current
+        /// rank and a "Promote — N <resource>" button that consumes the
+        /// per-rank cost. At Lv 5 a Glow button replaces the promote.
+        /// (Audit fix #1)
+        /// </summary>
+        private void DrawUnitRankSection()
+        {
+            var entity = UnifiedUIManager.GetFirstSelectedEntity();
+            var em = UnifiedUIManager.GetEntityManager();
+            if (entity == Entity.Null || em.Equals(default(EntityManager))) return;
+            if (!em.HasComponent<UnitTag>(entity)) return;
+
+            var cls = em.GetComponentData<UnitTag>(entity).Class;
+            bool military = cls == UnitClass.Melee
+                         || cls == UnitClass.Ranged
+                         || cls == UnitClass.Siege;
+            if (!military) return;
+
+            // Player must own the unit to promote/cast.
+            if (!em.HasComponent<FactionTag>(entity)) return;
+            if (em.GetComponentData<FactionTag>(entity).Value != GameSettings.LocalPlayerFaction) return;
+
+            byte rank = 1;
+            if (em.HasComponent<UnitRank>(entity))
+                rank = em.GetComponentData<UnitRank>(entity).Value;
+            if (rank < 1) rank = 1;
+
+            GUILayout.Space(5);
+            GUILayout.Label($"Rank: {rank}", Styles.Label);
+
+            if (rank < TheWaningBorder.Economy.UnitRankConfig.MaxRank)
+            {
+                byte target = (byte)(rank + 1);
+                var cost = TheWaningBorder.Economy.UnitRankConfig.CostFor(target);
+                string costLabel = CostLabel(cost);
+                bool canAfford = TheWaningBorder.Economy.FactionEconomy.CanAfford(em, GameSettings.LocalPlayerFaction, cost);
+                GUI.enabled = canAfford;
+                if (GUILayout.Button($"Promote → Lv {target} ({costLabel})", GUILayout.Width(220)))
+                {
+                    TheWaningBorder.Core.Commands.Types.UnitRankCommandHelper.Execute(em, entity);
+                }
+                GUI.enabled = true;
+            }
+            else
+            {
+                // Lv 5 — Glow Ability button.
+                GlowAbilityState glow = default;
+                if (em.HasComponent<GlowAbilityState>(entity))
+                    glow = em.GetComponentData<GlowAbilityState>(entity);
+
+                bool active = glow.ActiveRemaining > 0f;
+                bool ready = !active && glow.CooldownRemaining <= 0f;
+                GUI.enabled = ready;
+                string label = active
+                    ? $"Glow active ({glow.ActiveRemaining:F1}s)"
+                    : (ready ? "Glow Ability" : $"Glow ({glow.CooldownRemaining:F0}s)");
+                if (GUILayout.Button(label, GUILayout.Width(220)))
+                {
+                    TheWaningBorder.Core.Commands.Types.GlowAbilityCommandHelper.Execute(em, entity);
+                }
+                GUI.enabled = true;
+            }
+        }
+
+        private static string CostLabel(in TheWaningBorder.Core.Cost c)
+        {
+            if (c.Glow > 0)      return $"{c.Glow} Glow";
+            if (c.Veilsteel > 0) return $"{c.Veilsteel} Veilsteel";
+            if (c.Crystal > 0)   return $"{c.Crystal} Crystal";
+            if (c.Iron > 0)      return $"{c.Iron} Iron";
+            return $"{c.Supplies} Supplies";
         }
 
         // ═══════════════════════════════════════════════════════════════════════

--- a/Assets/Scripts/UI/Panels/SectAdoptionPanel.cs
+++ b/Assets/Scripts/UI/Panels/SectAdoptionPanel.cs
@@ -17,6 +17,7 @@
 using UnityEngine;
 using Unity.Entities;
 using TheWaningBorder.Economy;
+using TheWaningBorder.Systems.Sect;
 using TheWaningBorder.UI.Common;
 using EntityWorld = Unity.Entities.World;
 
@@ -120,9 +121,36 @@ namespace TheWaningBorder.UI.Panels
                 DrawLeverButton(em, faction, sectId, SectLeverKind.Building,    "B", sect.BuildingLevel);
                 DrawLeverButton(em, faction, sectId, SectLeverKind.Unit,        "U", sect.UnitLevel);
                 DrawLeverButton(em, faction, sectId, SectLeverKind.ActivePower, "A", sect.ActivePowerLevel);
+
+                // Fire button — only shown for sects with the Active Power
+                // lever bought. Casts the power at the temple's position; a
+                // future polish pass will add a target-cursor mode.
+                // (task-063 phase 5)
+                if (sect.ActivePowerLevel > 0)
+                {
+                    DrawFireButton(em, faction, sectId, temple);
+                }
             }
 
             GUILayout.EndHorizontal();
+        }
+
+        private static void DrawFireButton(
+            EntityManager em, Faction faction, string sectId, Entity temple)
+        {
+            float remaining = SectActivePowerHelper.CooldownRemaining(em, faction, sectId);
+            bool ready = remaining <= 0f;
+            GUI.enabled = ready;
+            string label = ready ? "Fire" : $"{(int)remaining}s";
+            if (GUILayout.Button(label, GUILayout.Width(64)))
+            {
+                if (em.HasComponent<Unity.Transforms.LocalTransform>(temple))
+                {
+                    var t = em.GetComponentData<Unity.Transforms.LocalTransform>(temple);
+                    SectActivePowerHelper.Fire(em, faction, sectId, t.Position);
+                }
+            }
+            GUI.enabled = true;
         }
 
         private static void DrawLeverButton(


### PR DESCRIPTION
## Summary
Promotes 6 squash-merged PRs from develop to main:

- **#253** task-063 phase 2d — 4 Lv I sect passives (War, Fortitude, Ruin, Reclamation)
- **#254** task-063 phase 2e — Antiquity + Silence Lv I passives (closes Lv I roster)
- **#255** task-063 phase 4 + Ash Lv I — Lv II/III scaling on all 12 sects + the missing 12th passive
- **#256** task-063 phase 3 — Feraldis blood pool layer (Age II+ gated)
- **#257** task-063 phase 5 — Building / Unit / Active-Power levers across all 12 sects
- **#258** audit fixes #1–#5 — unit Lv 1-5 rank system, Glow income from Elite crystal kills, Religion HUD top-center, 5s Default-stance pursuit timer, 'B' idle-builder cycle + smart-drag toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)