### PR TITLE
release: develop → main (audit follow-up)

### DIFF
--- a/Assets/Scripts/Core/Components/UnitComponents.cs
+++ b/Assets/Scripts/Core/Components/UnitComponents.cs
@@ -67,6 +67,20 @@ public struct GlowAbilityState : IComponentData
     public float CooldownRemaining; // Seconds until castable again (0 = ready)
 }
 
+/// <summary>
+/// Pickup entity dropped when a Lv 2+ veteran unit dies. Carries the
+/// cumulative resources the unit consumed during its rank-ups. Any unit
+/// of any faction that walks within <see cref="PickupRadius"/> credits
+/// the pile to its faction and destroys the pile. Self-despawns after
+/// <see cref="Lifetime"/> seconds if not collected.
+/// </summary>
+public struct UpgradePile : IComponentData
+{
+    public TheWaningBorder.Core.Cost Drop;
+    public float Lifetime;
+    public float PickupRadius;
+}
+
 // ==================== Unit Type Tags ====================
 
 /// <summary>Marks a unit as capable of constructing buildings.</summary>

--- a/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/MeleeCombatSystem.cs
@@ -203,8 +203,14 @@ namespace TheWaningBorder.Systems.Combat
                         // Fix #226: last-damager tracking routed through shared helper
                         CombatDamageHelper.TrackLastDamager(em, ecb, entity, tgt.Value, elapsed);
 
-                        // Reset cooldown (sect attack-speed multiplier removed in Phase 1).
-                        cd.Timer = cd.Cooldown;
+                        // Reset cooldown. Glow Ability (Lv 5 active window)
+                        // shortens the cooldown by 30% per the design spec.
+                        // (audit follow-up — was deferred in PR #258.)
+                        float cdMult = 1f;
+                        if (em.HasComponent<GlowAbilityState>(entity)
+                            && em.GetComponentData<GlowAbilityState>(entity).ActiveRemaining > 0f)
+                            cdMult = 1f / 1.30f;
+                        cd.Timer = cd.Cooldown * cdMult;
                     }
                 }
                 else

--- a/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/RangedCombatSystem.cs
@@ -323,12 +323,16 @@ namespace TheWaningBorder.Systems.Combat
                                 isAOE, aoeRadius, spawnYOffset);
                         }
 
-                        // Reset state — use unit's configured cooldown
+                        // Reset state — use unit's configured cooldown.
+                        // Glow Ability (Lv 5 active window) shortens by 30%
+                        // per the design spec. (audit follow-up)
                         float cooldownValue = 1.5f;
                         if (em.HasComponent<AttackCooldown>(entity))
                             cooldownValue = em.GetComponentData<AttackCooldown>(entity).Cooldown;
+                        if (em.HasComponent<GlowAbilityState>(entity)
+                            && em.GetComponentData<GlowAbilityState>(entity).ActiveRemaining > 0f)
+                            cooldownValue *= (1f / 1.30f);
 
-                        // task-063 phase 1: sect AttackSpeed multiplier gone — baseline 1.0×.
                         archer.CooldownTimer = cooldownValue;
                         archer.AimTimer = 0;
                         archer.IsFiring = 0;

--- a/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
+++ b/Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
@@ -1,12 +1,13 @@
 // UnitRankDeathEffectsSystem.cs
-// On-death AOE for Lv 4+ veteran units. Mirrors PillageSystem's death-event
-// hook (runs before DeathSystem with WithNone<DeathAnimationState>).
+// On-death AOE for Lv 4+ veteran units AND drop-pile spawn for Lv 2+
+// veterans. Mirrors PillageSystem's death-event hook.
 //
 // Lv 4: small magical explosion, AOE damage to nearby enemies.
-// Lv 5: medium explosion, more damage + push-back (sets DesiredDestination
-//       on nearby enemies away from the death position).
+// Lv 5: medium explosion, more damage + push-back.
+// Lv 2+: drops cumulative consumed resources at 50%, as a pickup any
+//        faction can collect (UpgradePile entity, audit follow-up).
 //
-// Audit fix #1.
+// Audit fix #1 + follow-up.
 //
 // Location: Assets/Scripts/Systems/Combat/UnitRankDeathEffectsSystem.cs
 
@@ -31,11 +32,11 @@ namespace TheWaningBorder.Systems.Combat
         {
             var em = state.EntityManager;
 
-            // Snapshot dead Lv 4+ units before applying AOE so the iteration
-            // doesn't see effects we cause.
-            var explosions = new NativeList<float3>(Allocator.Temp);
-            var explosionFactions = new NativeList<Faction>(Allocator.Temp);
-            var explosionRanks = new NativeList<byte>(Allocator.Temp);
+            // Snapshot dead veterans before applying effects so iteration
+            // doesn't see entities we spawn.
+            var deadPositions = new NativeList<float3>(Allocator.Temp);
+            var deadFactions  = new NativeList<Faction>(Allocator.Temp);
+            var deadRanks     = new NativeList<byte>(Allocator.Temp);
 
             foreach (var (health, transform, faction, rank) in SystemAPI
                 .Query<RefRO<Health>, RefRO<LocalTransform>, RefRO<FactionTag>, RefRO<UnitRank>>()
@@ -43,21 +44,63 @@ namespace TheWaningBorder.Systems.Combat
                 .WithNone<DeathAnimationState>())
             {
                 if (health.ValueRO.Value > 0) continue;
-                if (rank.ValueRO.Value < 4) continue;
+                if (rank.ValueRO.Value < 2) continue;
 
-                explosions.Add(transform.ValueRO.Position);
-                explosionFactions.Add(faction.ValueRO.Value);
-                explosionRanks.Add(rank.ValueRO.Value);
+                deadPositions.Add(transform.ValueRO.Position);
+                deadFactions.Add(faction.ValueRO.Value);
+                deadRanks.Add(rank.ValueRO.Value);
             }
 
-            for (int i = 0; i < explosions.Length; i++)
+            for (int i = 0; i < deadPositions.Length; i++)
             {
-                ApplyExplosion(em, explosions[i], explosionFactions[i], explosionRanks[i]);
+                if (deadRanks[i] >= 4)
+                    ApplyExplosion(em, deadPositions[i], deadFactions[i], deadRanks[i]);
+                SpawnUpgradePile(em, deadPositions[i], deadRanks[i]);
             }
 
-            explosions.Dispose();
-            explosionFactions.Dispose();
-            explosionRanks.Dispose();
+            deadPositions.Dispose();
+            deadFactions.Dispose();
+            deadRanks.Dispose();
+        }
+
+        /// <summary>
+        /// Spawns an UpgradePile entity at the death position carrying 50% of
+        /// the cumulative resources the unit paid for its rank-ups. Lv 2 drops
+        /// half the Lv-2 cost, Lv 3 drops half of (Lv2 + Lv3), and so on.
+        /// (Audit follow-up — drop-pile-on-death.)
+        /// </summary>
+        private static void SpawnUpgradePile(EntityManager em, float3 pos, byte rank)
+        {
+            // Sum costs for ranks 2..rank.
+            var drop = new TheWaningBorder.Core.Cost();
+            for (byte r = 2; r <= rank; r++)
+            {
+                var c = UnitRankConfig.CostFor(r);
+                drop.Supplies  += c.Supplies;
+                drop.Iron      += c.Iron;
+                drop.Crystal   += c.Crystal;
+                drop.Veilsteel += c.Veilsteel;
+                drop.Glow      += c.Glow;
+            }
+            // 50% recovery rate.
+            drop.Supplies  /= 2;
+            drop.Iron      /= 2;
+            drop.Crystal   /= 2;
+            drop.Veilsteel /= 2;
+            drop.Glow      /= 2;
+
+            // Skip if nothing to drop (shouldn't happen at Lv 2+ but guard anyway).
+            if (drop.Supplies + drop.Iron + drop.Crystal + drop.Veilsteel + drop.Glow == 0) return;
+
+            var pile = em.CreateEntity(typeof(UpgradePile), typeof(LocalTransform));
+            em.SetComponentData(pile, new UpgradePile
+            {
+                Drop = drop,
+                Lifetime = 60f,       // 1 minute to collect before despawn
+                PickupRadius = 1.5f,
+            });
+            em.SetComponentData(pile, LocalTransform.FromPositionRotationScale(
+                pos, quaternion.identity, 1f));
         }
 
         private static void ApplyExplosion(EntityManager em, float3 center, Faction owner, byte rank)

--- a/Assets/Scripts/Systems/Economy/UpgradePilePickupSystem.cs
+++ b/Assets/Scripts/Systems/Economy/UpgradePilePickupSystem.cs
@@ -1,0 +1,89 @@
+// UpgradePilePickupSystem.cs
+// Picks up Lv2+ veteran death drops. Each tick:
+//   1. Decrement Lifetime; destroy expired piles.
+//   2. For each pile, find the nearest UnitTag entity within PickupRadius.
+//      The first faction to walk over the pile collects the full drop.
+//
+// This is the "any player can gather these" half of the unit upgrade
+// drop spec. Mirrors the auto-pickup pattern rather than miner-required
+// gathering — keeps the UX low-friction for accidental veteran kills.
+//
+// Audit follow-up.
+//
+// Location: Assets/Scripts/Systems/Economy/UpgradePilePickupSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Economy
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct UpgradePilePickupSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<UpgradePile>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var em = state.EntityManager;
+            float dt = SystemAPI.Time.DeltaTime;
+
+            // Snapshot pile entities to avoid mutating the iteration set.
+            var pilesToProcess = new NativeList<Entity>(Allocator.Temp);
+            foreach (var (pile, entity) in SystemAPI
+                .Query<RefRW<UpgradePile>>()
+                .WithEntityAccess())
+            {
+                pile.ValueRW.Lifetime -= dt;
+                if (pile.ValueRO.Lifetime <= 0f)
+                {
+                    em.DestroyEntity(entity);
+                    continue;
+                }
+                pilesToProcess.Add(entity);
+            }
+
+            for (int i = 0; i < pilesToProcess.Length; i++)
+            {
+                var pile = pilesToProcess[i];
+                if (!em.Exists(pile)) continue;
+                TryPickup(em, pile);
+            }
+
+            pilesToProcess.Dispose();
+        }
+
+        private static void TryPickup(EntityManager em, Entity pile)
+        {
+            var pileData = em.GetComponentData<UpgradePile>(pile);
+            var pilePos = em.GetComponentData<LocalTransform>(pile).Position;
+            float r2 = pileData.PickupRadius * pileData.PickupRadius;
+
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadOnly<LocalTransform>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<Health>());
+            using var entities = query.ToEntityArray(Allocator.Temp);
+
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var e = entities[i];
+                if (em.GetComponentData<Health>(e).Value <= 0) continue;
+                var p = em.GetComponentData<LocalTransform>(e).Position;
+                float dx = p.x - pilePos.x, dz = p.z - pilePos.z;
+                if (dx * dx + dz * dz > r2) continue;
+
+                var faction = em.GetComponentData<FactionTag>(e).Value;
+                FactionEconomy.Add(em, faction, pileData.Drop);
+                em.DestroyEntity(pile);
+                return;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Economy/UpgradePilePickupSystem.cs.meta
+++ b/Assets/Scripts/Systems/Economy/UpgradePilePickupSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9c1b3e8a4d2f5916e7d4c3b1a8f5e273

--- a/Assets/Scripts/Systems/Work/SelfDestructSystem.cs
+++ b/Assets/Scripts/Systems/Work/SelfDestructSystem.cs
@@ -61,13 +61,17 @@ namespace TheWaningBorder.Systems.Work
                     string buildingId = GetBuildingId(em, entity);
                     if (buildingId != null && BuildCosts.TryGet(buildingId, out var cost))
                     {
-                        // Refund 80% of construction cost
+                        // Refund 80% of construction cost. Salvage bonus: any
+                        // Veilsteel consumed yields 10% of that as Glow on top
+                        // of the standard refund — the spec's "salvaging" lane
+                        // for Glow income. (audit follow-up)
+                        int glowSalvage = (int)(cost.Veilsteel * 0.10f);
                         var refund = Cost.Of(
                             supplies: (int)(cost.Supplies * RefundMultiplier),
                             iron: (int)(cost.Iron * RefundMultiplier),
                             crystal: (int)(cost.Crystal * RefundMultiplier),
                             veilsteel: (int)(cost.Veilsteel * RefundMultiplier),
-                            glow: (int)(cost.Glow * RefundMultiplier)
+                            glow: (int)(cost.Glow * RefundMultiplier) + glowSalvage
                         );
 
                         FactionEconomy.Add(em, faction, refund);


### PR DESCRIPTION
## Summary
Promotes PR #260 (audit-fix follow-up) to main:
- Drop-pile-on-death (Lv 2+ veterans drop half-cost pickup pile)
- Glow Ability +30% attack rate (cooldown plumbing in Melee + Ranged)
- Salvage Glow path (10% of veilsteel-cost on building self-destruct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)