### PR TITLE
fix(sect): Unit lever zeroed HP/Damage on single-axis sect specs

### DIFF
--- a/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
+++ b/Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs
@@ -126,8 +126,15 @@ namespace TheWaningBorder.Systems.Sect
         private static void ApplyDelta(EntityManager em, Entity entity,
             in SectUnitLeverSpec spec, float scalar)
         {
+            // SectUnitLeverSpec uses the default(0) value for "unset" multipliers.
+            // Skip both 0 (unset) and 1 (no-op) for HP / Damage so a sect that
+            // only sets one axis doesn't accidentally zero the other on every
+            // matching unit. (Previously: HpMultiplier=0 sect → unit HP × 0.)
+
             // HP — multiplicative on Max + Value.
-            if (math.abs(spec.HpMultiplier - 1f) > 0.001f && em.HasComponent<Health>(entity))
+            if (spec.HpMultiplier > 0.001f
+                && math.abs(spec.HpMultiplier - 1f) > 0.001f
+                && em.HasComponent<Health>(entity))
             {
                 var hp = em.GetComponentData<Health>(entity);
                 float diff = 1f + (spec.HpMultiplier - 1f) * scalar;
@@ -149,7 +156,9 @@ namespace TheWaningBorder.Systems.Sect
             }
 
             // Damage — multiplicative on Damage component.
-            if (math.abs(spec.DamageMultiplier - 1f) > 0.001f && em.HasComponent<Damage>(entity))
+            if (spec.DamageMultiplier > 0.001f
+                && math.abs(spec.DamageMultiplier - 1f) > 0.001f
+                && em.HasComponent<Damage>(entity))
             {
                 var dmg = em.GetComponentData<Damage>(entity);
                 float diff = 1f + (spec.DamageMultiplier - 1f) * scalar;


### PR DESCRIPTION
## Summary
`SectUnitLeverSpec` uses `0` as the C# default for unset multipliers, but `SectUnitLeverSystem.ApplyDelta` treated any value ≠ 1 as a real multiplier. So for a sect spec like Renewal `{ HpMultiplier = 1.05f }`, the code applied `DamageMultiplier = 0` to every matching unit on adoption — multiplying their Damage (or HP, depending on which axis was unset) by zero. Sects whose Unit lever set damage but left HP at 0 zeroed unit `Max/Value`, killing them instantly.

**Fix:** skip multiplier application when the value is `< 0.001` (treat as unset) in addition to the existing "near 1.0" no-op skip. Same guard on both HpMultiplier and DamageMultiplier paths in [SectUnitLeverSystem.ApplyDelta](Assets/Scripts/Systems/Sect/SectUnitLeverSystem.cs).

## Recovery note
Units already stamped with `SectUnitLeverApplied` at the buggy level will keep their zeroed stats — the diff system won't re-apply. New units trained after this lands will be unaffected; existing broken units must die and be retrained (or start a new game).

## Test plan
- [ ] Adopt a sect whose Unit lever sets only HP (e.g. Renewal) — newly trained units should retain their normal Damage value.
- [ ] Adopt a sect whose Unit lever sets only damage (e.g. War, Antiquity) — newly trained units should retain their normal Max HP and not die instantly.
- [ ] Adopt Fortitude (sets ArmorBonus only on Melee class) — Melee units should gain the armor bump without losing HP/damage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)