### PR TITLE
release: develop → main (nav spawn-adjacent hotfix)

### DIFF
--- a/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
+++ b/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
@@ -525,21 +525,31 @@ namespace TheWaningBorder.Systems.Movement
                         newPos = memberXf.Position + dir * step;
 
                         // Radius-aware passability: don't walk where the
-                        // member's body would overlap an obstacle.
-                        if (passGrid != null && !passGrid.IsPassableForRadius(newPos, memberRadius))
+                        // member's body would overlap an obstacle. Same escape
+                        // hatch as MovementSystem — if the member already
+                        // fails the radius check (spawned adjacent to a
+                        // building, etc.) fall back to the centre-cell check
+                        // so they can walk out of the tight spot.
+                        if (passGrid != null)
                         {
-                            // Blocked — try to path toward leader using flow field instead.
-                            // Earlier missing braces (line ~516) made this fall through to
-                            // `newPos = memberXf.Position` unconditionally, so the
-                            // alt-direction probe was always discarded and stuck members
-                            // never used the formation-member fallback. (task-053 F-2 / MB-2)
-                            float3 ffDir = FlowFieldMovementHelper.GetDirection(
-                                memberXf.Position, leaderPos, dir, dist);
-                            float3 altPos = memberXf.Position + ffDir * step;
-                            if (passGrid.IsPassableForRadius(altPos, memberRadius))
-                                newPos = altPos;
-                            else
-                                newPos = memberXf.Position; // truly stuck, don't move
+                            bool currentlyClear = memberRadius <= 0f
+                                || passGrid.IsPassableForRadius(memberXf.Position, memberRadius);
+                            bool nextOk = currentlyClear
+                                ? passGrid.IsPassableForRadius(newPos, memberRadius)
+                                : passGrid.IsPassable(newPos);
+                            if (!nextOk)
+                            {
+                                float3 ffDir = FlowFieldMovementHelper.GetDirection(
+                                    memberXf.Position, leaderPos, dir, dist);
+                                float3 altPos = memberXf.Position + ffDir * step;
+                                bool altOk = currentlyClear
+                                    ? passGrid.IsPassableForRadius(altPos, memberRadius)
+                                    : passGrid.IsPassable(altPos);
+                                if (altOk)
+                                    newPos = altPos;
+                                else
+                                    newPos = memberXf.Position; // truly stuck, don't move
+                            }
                         }
                     }
 

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -478,11 +478,14 @@ namespace TheWaningBorder.Systems.Movement
                 float step = math.min(speed * dt, dist);
                 float3 nextPos = pos + smoothedDir * step;
 
-                // === PASSABILITY CHECK (radius-aware Minkowski) ===
+                // === PASSABILITY CHECK (radius-aware Minkowski with escape) ===
                 // Test the unit's collision footprint, not just its centre cell.
-                // This is the fix for "stuck on every building edge" — without
-                // it, the unit's centre can occupy a passable cell while its
-                // body overlaps a neighbouring blocked cell.
+                // BUT: only enforce the radius check if the unit's current
+                // position already passes it. Otherwise units that spawn
+                // directly adjacent to a building (e.g. builder next to its
+                // hall) would refuse every step — their starting cell already
+                // fails the 3x3 sweep so no neighbour can pass either. Falling
+                // back to the centre-only check lets them walk out.
                 bool blocked = false;
                 var passGrid = PassabilityGrid.Instance;
                 int2 nextCell = default;
@@ -491,8 +494,12 @@ namespace TheWaningBorder.Systems.Movement
                     nextCell = passGrid.WorldToCell(nextPos);
                     float radius = em.HasComponent<Radius>(entity)
                         ? em.GetComponentData<Radius>(entity).Value : 0f;
-                    if (!passGrid.IsPassableForRadius(nextPos, radius))
-                        blocked = true;
+                    bool currentlyClear = radius <= 0f
+                        || passGrid.IsPassableForRadius(pos, radius);
+                    bool nextOk = currentlyClear
+                        ? passGrid.IsPassableForRadius(nextPos, radius)
+                        : passGrid.IsPassable(nextCell);
+                    if (!nextOk) blocked = true;
                 }
 
                 // === SLOPE CHECK with terrain height caching ===


### PR DESCRIPTION
Promotes PR #274 — fixes regression where units spawned adjacent to a building couldn't issue their first move command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)