### PR TITLE
fix(nav): radius reach formula was too aggressive

### DIFF
--- a/Assets/Scripts/World/Terrain/PassabilityGrid.cs
+++ b/Assets/Scripts/World/Terrain/PassabilityGrid.cs
@@ -259,19 +259,30 @@ namespace TheWaningBorder.World.Terrain
         }
 
         /// <summary>
-        /// Radius-aware passability — true only if every cell within
-        /// <paramref name="radius"/> of <paramref name="worldPos"/> is passable.
+        /// Radius-aware passability — true only if every cell within the
+        /// agent's collision footprint of <paramref name="worldPos"/> is passable.
         /// Implements a Minkowski check at query time so callers don't need to
         /// pre-inflate the grid (which would trap units inside their own
-        /// building's footprint). Use this from MovementSystem / AStarPathfinder
-        /// to keep units off building edges. (Nav-clearance fix.)
+        /// building's footprint).
+        ///
+        /// Reach is computed as ceil((radius - cellSize/2) / cellSize) — i.e.
+        /// neighbours only need to be inspected when the agent's body actually
+        /// crosses cell boundaries. A unit standing in the centre of a 1m cell
+        /// with a 0.5m radius fits exactly inside that cell and reach is 0
+        /// (degenerates to centre-only IsPassable). Bigger units (siege,
+        /// battalion sizes) get the proper 3x3 / 5x5 sweep.
+        ///
+        /// Earlier the formula was naive ceil(radius / cellSize) which made
+        /// typical 0.5m units require all 8 neighbours to be passable — they
+        /// got stuck on every building edge during travel.
+        /// (Nav-clearance fix, recalibrated.)
         /// </summary>
         public bool IsPassableForRadius(float3 worldPos, float radius)
         {
             if (radius <= 0f) return IsPassable(worldPos);
-            // Inflate by ceil(radius / cellSize). For typical 0.5m radius +
-            // 1m cell size that's a single neighbor ring (3x3 sweep).
-            int reach = (int)math.ceil(radius / _cellSize);
+            int reach = (int)math.ceil((radius - _cellSize * 0.5f) / _cellSize);
+            if (reach < 0) reach = 0;
+            if (reach == 0) return IsPassable(worldPos);
             int2 c = WorldToCell(worldPos);
             // Treat the centre cell as a special case: if the unit is currently
             // standing inside its own building (BuildingBlocked), allow the


### PR DESCRIPTION
## Summary
The Minkowski reach in `IsPassableForRadius` used `ceil(radius / cellSize)`, which gives 1 even for typical 0.5m-radius units on a 1m cell grid. That made every cell adjacent to a building "blocked" for those units — they fit physically but the grid check refused them. Symptom after PR #274: units could leave their spawn (#274's escape hatch worked) but immediately got stuck on the next building edge they encountered en route.

**Fix:** correct formula is `ceil((radius - cellSize/2) / cellSize)`. A unit's body crosses cell boundaries only when its radius exceeds half a cell; below that threshold the unit fits inside its centre cell and no neighbour inspection is needed.

- 0.5m radius / 1m cell → reach = 0 (degenerates to centre-only IsPassable, matches pre-PR-272 behaviour for common units)
- Larger units (siege, future big units) still get the proper Minkowski sweep

The string-pull A* smoothing from PR #272 stays — that one was correct.

## Test plan
- [ ] Issue a long move past a building — unit walks straight past the wall (touches cosmetically, doesn't get stuck).
- [ ] Battalion of 12 marches past two adjacent buildings — no members get pinned on edges.
- [ ] First-command-from-spawn (PR #274's regression) still works — builder next to hall walks out.
- [ ] Trajectory smoothness from PR #272 still in effect — open-ground move shows a single straight segment, not a 45° staircase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)