### PR TITLE
fix(nav): three real bugs causing units to clip building corners

### DIFF
--- a/Assets/Scripts/Systems/Movement/AStarPathfinder.cs
+++ b/Assets/Scripts/Systems/Movement/AStarPathfinder.cs
@@ -67,28 +67,34 @@ namespace TheWaningBorder.Systems.Movement
         /// <summary>
         /// Find a path from start to goal using A*.
         /// Returns a list of world-space waypoints (cell centers), or null if unreachable.
-        /// Convenience overload — defaults to a 1-cell radius inflation so pathing
-        /// keeps a one-cell clearance from blocked cells (kills "stuck on edge").
+        /// Convenience overload — assumes the typical 0.5m unit radius for the
+        /// string-pull LOS check. Callers with bigger units should pass agentRadius.
         /// </summary>
         public static List<float3> FindPath(float3 startWorld, float3 goalWorld, PassabilityGrid grid)
-            => FindPath(startWorld, goalWorld, grid, agentRadiusCells: 1);
+            => FindPath(startWorld, goalWorld, grid, agentRadius: 0.5f);
 
         /// <summary>
-        /// Find a path with a configurable agent-radius inflation (in cells).
-        /// Inflation = N requires every traversed cell to have an N-cell ring of
-        /// passable neighbours (Minkowski sum of obstacles by agent footprint).
+        /// Find a path with a configurable agent radius (world units).
+        /// Inflation in cells = ceil((agentRadius - cellSize/2) / cellSize),
+        /// requiring every traversed cell to have an N-cell ring of passable
+        /// neighbours (Minkowski sum of obstacles by agent footprint).
         /// If no path is found at the requested inflation, falls back to 0
         /// inflation so units already wedged in tight spots can still escape.
+        /// String-pull post-process uses the geometric, sampled LOS so it
+        /// won't drop a waypoint whose shortcut clips a building corner.
         /// (Nav-clearance fix.)
         /// </summary>
         public static List<float3> FindPath(float3 startWorld, float3 goalWorld,
-            PassabilityGrid grid, int agentRadiusCells)
+            PassabilityGrid grid, float agentRadius)
         {
+            int agentRadiusCells = grid != null
+                ? math.max(0, (int)math.ceil((agentRadius - grid.CellSize * 0.5f) / grid.CellSize))
+                : 0;
             var path = FindPathInternal(startWorld, goalWorld, grid, agentRadiusCells);
             if (path == null && agentRadiusCells > 0)
                 path = FindPathInternal(startWorld, goalWorld, grid, 0);
             if (path != null && path.Count >= 3)
-                StringPull(path, grid, agentRadiusCells);
+                StringPull(path, grid, agentRadius);
             return path;
         }
 
@@ -285,19 +291,19 @@ namespace TheWaningBorder.Systems.Movement
 
         /// <summary>
         /// String-pulling smoothing pass — drops any waypoint whose
-        /// predecessor and successor have a clear line-of-sight in the grid
-        /// (Bresenham scan). This converts the 8-direction grid output into
-        /// any-angle straight-line segments where the obstacle field allows
-        /// it, killing the 45° staircase look without requiring a navmesh
-        /// or theta*. Operates in place. (Funnel-style smoothing.)
+        /// predecessor and successor have a clear, radius-aware line of sight.
+        /// Uses the sampled geometric LOS so it correctly rejects shortcuts
+        /// that clip a building corner (which a Bresenham-on-cells scan would
+        /// miss when the line passes through the corner of a blocked cell).
+        /// Operates in place.
         /// </summary>
-        private static void StringPull(List<float3> path, PassabilityGrid grid, int agentRadiusCells)
+        private static void StringPull(List<float3> path, PassabilityGrid grid, float agentRadius)
         {
             if (path == null || path.Count < 3) return;
             int i = 0;
             while (i < path.Count - 2)
             {
-                if (HasLineOfSight(path[i], path[i + 2], grid, agentRadiusCells))
+                if (grid.HasClearLineOfSight(path[i], path[i + 2], agentRadius))
                 {
                     path.RemoveAt(i + 1);
                     if (i > 0) i--; // re-test the prior segment, the new neighbour might be reachable too
@@ -306,35 +312,6 @@ namespace TheWaningBorder.Systems.Movement
                 {
                     i++;
                 }
-            }
-        }
-
-        /// <summary>
-        /// Bresenham-style cell sweep between two world positions; returns true
-        /// only when every traversed cell satisfies the radius-aware passability
-        /// check. Used by <see cref="StringPull"/>.
-        /// </summary>
-        private static bool HasLineOfSight(float3 a, float3 b, PassabilityGrid grid, int agentRadiusCells)
-        {
-            int2 c0 = grid.WorldToCell(a);
-            int2 c1 = grid.WorldToCell(b);
-            int dx = math.abs(c1.x - c0.x);
-            int dy = math.abs(c1.y - c0.y);
-            int sx = c0.x < c1.x ? 1 : -1;
-            int sy = c0.y < c1.y ? 1 : -1;
-            int err = dx - dy;
-            int x = c0.x;
-            int y = c0.y;
-            while (true)
-            {
-                bool ok = agentRadiusCells <= 0
-                    ? grid.IsPassable(new int2(x, y))
-                    : grid.IsCellPassableForRadius(new int2(x, y), agentRadiusCells);
-                if (!ok) return false;
-                if (x == c1.x && y == c1.y) return true;
-                int e2 = 2 * err;
-                if (e2 > -dy) { err -= dy; x += sx; }
-                if (e2 <  dx) { err += dx; y += sy; }
             }
         }
 

--- a/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
+++ b/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
@@ -109,9 +109,18 @@ namespace TheWaningBorder.Systems.Work
             {
                 if (!currentBuildings.ContainsKey(kvp.Key))
                 {
+                    // Missing braces here meant the circular UnblockBuilding ran
+                    // unconditionally — fine for unblock, but a real bug at the
+                    // matching block site below. Adding braces both places to
+                    // make the intent explicit.
                     if (kvp.Value.HasSize == 1)
+                    {
                         grid.UnblockBuildingRect(kvp.Value.Position, kvp.Value.Size);
+                    }
+                    else
+                    {
                         grid.UnblockBuilding(kvp.Value.Position, kvp.Value.Radius);
+                    }
                     toRemove.Add(kvp.Key);
                 }
             }
@@ -127,9 +136,23 @@ namespace TheWaningBorder.Systems.Work
             {
                 if (!_knownBuildings.ContainsKey(kvp.Key))
                 {
+                    // BUG FIX: missing braces here meant `BlockBuilding` (a
+                    // CIRCULAR stamp) was called for EVERY building regardless
+                    // of HasSize, so every rect-footprint building also got an
+                    // overlapping circle. The circle's radius is derived from
+                    // BuildingSize so it can extend WELL beyond the rect's
+                    // footprint, jamming pathing around buildings the player
+                    // can't see is "fat". Use the rect for sized buildings,
+                    // fall back to circle only for legacy buildings without
+                    // a BuildingSize component.
                     if (kvp.Value.HasSize == 1)
+                    {
                         grid.BlockBuildingRect(kvp.Value.Position, kvp.Value.Size);
+                    }
+                    else
+                    {
                         grid.BlockBuilding(kvp.Value.Position, kvp.Value.Radius);
+                    }
                     _knownBuildings.Add(kvp.Key, kvp.Value);
                     newBuildingsAdded = true;
                 }

--- a/Assets/Scripts/World/Terrain/PassabilityGrid.cs
+++ b/Assets/Scripts/World/Terrain/PassabilityGrid.cs
@@ -259,50 +259,84 @@ namespace TheWaningBorder.World.Terrain
         }
 
         /// <summary>
-        /// Radius-aware passability — true only if every cell within the
-        /// agent's collision footprint of <paramref name="worldPos"/> is passable.
-        /// Implements a Minkowski check at query time so callers don't need to
-        /// pre-inflate the grid (which would trap units inside their own
-        /// building's footprint).
+        /// Geometric radius-aware passability — true only if every cell whose
+        /// rectangle is within <paramref name="radius"/> world units of
+        /// <paramref name="worldPos"/> is passable (Minkowski sum of obstacles
+        /// with the agent disk).
         ///
-        /// Reach is computed as ceil((radius - cellSize/2) / cellSize) — i.e.
-        /// neighbours only need to be inspected when the agent's body actually
-        /// crosses cell boundaries. A unit standing in the centre of a 1m cell
-        /// with a 0.5m radius fits exactly inside that cell and reach is 0
-        /// (degenerates to centre-only IsPassable). Bigger units (siege,
-        /// battalion sizes) get the proper 3x3 / 5x5 sweep.
+        /// The centre cell is treated leniently: BuildingBlocked is OK at the
+        /// centre so units can leave their own building's footprint. Surrounding
+        /// cells must be Passable.
         ///
-        /// Earlier the formula was naive ceil(radius / cellSize) which made
-        /// typical 0.5m units require all 8 neighbours to be passable — they
-        /// got stuck on every building edge during travel.
-        /// (Nav-clearance fix, recalibrated.)
+        /// Iterates the AABB enclosing the agent disk and computes the
+        /// point-to-rectangle distance for each candidate cell — this catches
+        /// the case where the agent's centre is at one cell's centre but its
+        /// body still penetrates an adjacent blocked cell (e.g. 0.5m unit at
+        /// world (2.0, 0.0) with a building at cell (1, 0) — body extends
+        /// to x=1.5, z=-0.5, overlapping the building corner).
+        /// (Nav-clearance fix, geometric pass.)
         /// </summary>
         public bool IsPassableForRadius(float3 worldPos, float radius)
         {
             if (radius <= 0f) return IsPassable(worldPos);
-            int reach = (int)math.ceil((radius - _cellSize * 0.5f) / _cellSize);
-            if (reach < 0) reach = 0;
-            if (reach == 0) return IsPassable(worldPos);
-            int2 c = WorldToCell(worldPos);
-            // Treat the centre cell as a special case: if the unit is currently
-            // standing inside its own building (BuildingBlocked), allow the
-            // check to pass — only refuse when the surrounding ring is blocked
-            // by something the unit collided into.
-            byte centreVal = (c.x < 0 || c.x >= _width || c.y < 0 || c.y >= _height)
-                ? TerrainBlocked
-                : _cells[c.y * _width + c.x];
-            bool centreOk = centreVal == Passable || centreVal == BuildingBlocked;
-            if (!centreOk) return false;
-            for (int dy = -reach; dy <= reach; dy++)
+            int2 centreCell = WorldToCell(worldPos);
+            int2 minCell = WorldToCell(new float3(worldPos.x - radius, 0f, worldPos.z - radius));
+            int2 maxCell = WorldToCell(new float3(worldPos.x + radius, 0f, worldPos.z + radius));
+            float r2 = radius * radius;
+            for (int y = minCell.y; y <= maxCell.y; y++)
             {
-                for (int dx = -reach; dx <= reach; dx++)
+                for (int x = minCell.x; x <= maxCell.x; x++)
                 {
-                    if (dx == 0 && dy == 0) continue;
-                    int x = c.x + dx;
-                    int y = c.y + dy;
-                    if (x < 0 || x >= _width || y < 0 || y >= _height) return false;
-                    if (_cells[y * _width + x] != Passable) return false;
+                    // Distance from worldPos to the cell rectangle.
+                    float cellMinX = _origin.x + x * _cellSize;
+                    float cellMaxX = cellMinX + _cellSize;
+                    float cellMinZ = _origin.z + y * _cellSize;
+                    float cellMaxZ = cellMinZ + _cellSize;
+                    float dx = math.max(0f, math.max(cellMinX - worldPos.x, worldPos.x - cellMaxX));
+                    float dz = math.max(0f, math.max(cellMinZ - worldPos.z, worldPos.z - cellMaxZ));
+                    if (dx * dx + dz * dz >= r2) continue; // body just touches or doesn't reach
+
+                    byte v;
+                    if (x < 0 || x >= _width || y < 0 || y >= _height)
+                        v = TerrainBlocked;
+                    else
+                        v = _cells[y * _width + x];
+
+                    bool isCentre = (x == centreCell.x && y == centreCell.y);
+                    if (isCentre)
+                    {
+                        if (v != Passable && v != BuildingBlocked) return false;
+                    }
+                    else
+                    {
+                        if (v != Passable) return false;
+                    }
                 }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Sampled radius-aware line-of-sight between two world positions. Used
+        /// by AStarPathfinder.StringPull to verify a "shortcut" between two
+        /// waypoints is actually traversable by an agent of the given radius.
+        ///
+        /// Bresenham-on-cells is not enough: the centres of cells the line
+        /// passes through can all be Passable while the actual world-space
+        /// segment clips a building corner geometrically. Here we sample at
+        /// half-cell intervals and run the geometric IsPassableForRadius at
+        /// each sample.
+        /// </summary>
+        public bool HasClearLineOfSight(float3 a, float3 b, float radius)
+        {
+            float dist = math.distance(new float2(a.x, a.z), new float2(b.x, b.z));
+            // Sample at half-cell intervals (capped at 64 samples for sanity).
+            int samples = (int)math.clamp(math.ceil(dist / (_cellSize * 0.5f)), 2f, 64f);
+            for (int i = 0; i <= samples; i++)
+            {
+                float t = (float)i / samples;
+                float3 p = math.lerp(a, b, t);
+                if (!IsPassableForRadius(p, radius)) return false;
             }
             return true;
         }


### PR DESCRIPTION
## Summary
Three compounding bugs producing the user-reported symptom: unit at (0,0), building at (1..2, -1..1), goal (3,0) — unit walks to corner (1,1) then heads straight to (3,0), clipping the wall.

### Bug #1 — `PassabilityBuildingSync` double-stamp (missing braces)
```csharp
if (kvp.Value.HasSize == 1)
    grid.BlockBuildingRect(...);
    grid.BlockBuilding(...);  // ← runs unconditionally, no else
```
Every building with a `BuildingSize` was getting BOTH a rect footprint AND a circular block on top. The circle's radius is derived from `BuildingSize` so it can extend well beyond the rect, making blocked areas larger than designers intended. Same brace bug in the unblock path. Same C# trap as the SelectionSystem one we fixed earlier.

### Bug #2 — `IsPassableForRadius` was non-geometric
The previous `reach = ceil((r - cellSize/2) / cellSize)` formula gave reach=0 for typical 0.5m units on a 1m grid → the check degenerated to a single centre-cell test. Missed the case where the agent crosses cell boundaries during diagonal motion and its body extends into an adjacent blocked cell. Replaced with a proper Minkowski sweep: iterate the AABB enclosing the agent disk, compute point-to-rect distance per candidate cell, refuse if any blocked cell falls inside the disk (centre cell exempt for own-building escape). Tangent (`>= r²`) counts as no overlap.

### Bug #3 — `HasLineOfSight` was Bresenham-on-cells only
String-pull dropped any waypoint whose neighbours had a clear Bresenham LOS. But Bresenham only inspects the centres of cells the line crosses — it misses the case where the world-space line grazes a corner of a blocked cell. The line from cell (1,1) to cell (3,0) passes through cells whose centres are passable, but the agent's body clips a building corner mid-traversal. New `PassabilityGrid.HasClearLineOfSight` samples the segment at half-cell world intervals and runs the geometric `IsPassableForRadius` at each sample. `AStarPathfinder.FindPath` now takes `agentRadius` in world units.

`MovementSystem` and `BattalionSyncSystem` already call `IsPassableForRadius` so they pick up the geometric upgrade automatically.

## Test plan
- [ ] User's exact case: unit at (0,0), building (1..2, -1..1), move to (3,0) — unit takes a curved path around the building, no clipping.
- [ ] Move past a tight 2×2 building — path bends cleanly, no corner-cut shortcut.
- [ ] Spawn-adjacent regression: builder next to hall still walks out (PR #274's escape still works since the centre cell exempt keeps that path open).
- [ ] Battalion of 12 marches around two adjacent buildings — no member snags on any corner.
- [ ] Standalone open-ground move — path is a single straight segment (string-pull still merges in clear space).

🤖 Generated with [Claude Code](https://claude.com/claude-code)