### PR TITLE
feat(nav): tiers B + C + D — radius-aware fields, BFME2 horde, context steering

### DIFF
--- a/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
+++ b/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
@@ -309,12 +309,18 @@ namespace TheWaningBorder.Systems.Movement
                         target = leaderPos + math.mul(formationRot, localOffset);
                     }
 
-                    // Check if the slot is reachable (passable terrain)
-                    bool slotBlocked = passGrid != null && !passGrid.IsPassable(target);
+                    // Tier C — BFME2 horde pathing.
+                    // Slot validity is radius-aware: a slot is invalid for a
+                    // member if its body would clip an obstacle there OR the
+                    // straight-line path from current pos to slot would clip
+                    // one along the way. Per-member radius lookup so siege
+                    // pieces and infantry get correct clearance.
+                    float memberRadiusForCheck = em.HasComponent<Radius>(_members[i])
+                        ? em.GetComponentData<Radius>(_members[i]).Value : 0.5f;
 
-                    // Check if the PATH from member to slot crosses impassable cells.
-                    // Even if the slot itself is passable (between trees), the member
-                    // may need to traverse through blocked cells to reach it.
+                    bool slotBlocked = passGrid != null
+                        && !passGrid.IsPassableForRadius(target, memberRadiusForCheck);
+
                     if (!slotBlocked && passGrid != null)
                     {
                         float3 toSlot = target - _memberPos[i];
@@ -322,18 +328,12 @@ namespace TheWaningBorder.Systems.Movement
                         float slotDist = math.length(toSlot);
                         if (slotDist > spacing)
                         {
-                            float3 slotDir = toSlot / slotDist;
-                            float cellSize = passGrid.CellSize;
-                            float checkDist = slotDist;
-                            for (float d = cellSize; d <= checkDist; d += cellSize)
-                            {
-                                float3 checkPos = _memberPos[i] + slotDir * d;
-                                if (!passGrid.IsPassable(checkPos))
-                                {
-                                    slotBlocked = true;
-                                    break;
-                                }
-                            }
+                            // Sampled geometric LOS — same code path StringPull
+                            // uses for A* simplification. Catches the case
+                            // where slot + current pos are both clear but
+                            // the line between them clips a building corner.
+                            if (!passGrid.HasClearLineOfSight(_memberPos[i], target, memberRadiusForCheck))
+                                slotBlocked = true;
                         }
                     }
 

--- a/Assets/Scripts/Systems/Movement/ContextSteer.cs
+++ b/Assets/Scripts/Systems/Movement/ContextSteer.cs
@@ -1,0 +1,86 @@
+// ContextSteer.cs
+// Tier D — context-steering local avoidance helper.
+//
+// When a unit's desired movement direction is blocked by the radius-aware
+// passability check, this samples a small fan of alternative directions
+// around the desired heading and returns the most-aligned one that the
+// unit's body can actually traverse. This converts the existing "perpendicular
+// nudge" stuck recovery (Tier 2 in MovementSystem) into a smoother,
+// monotonically-improving direction selection.
+//
+// Inspired by Andrew Fray's "Context Behaviours Know How to Share" (Game AI
+// Pro 2013, GDC 2018). We only score by (alignment * passability) — no
+// danger map, no neighbour repulsion — because the global flow field
+// (Tier B, radius-aware) already handles obstacle avoidance at the macro
+// scale, and UnitSeparationSystem handles ally-vs-ally separation
+// post-step. This helper exists purely to refine the "I want to go this
+// way but a wall is in front of me" case.
+//
+// Location: Assets/Scripts/Systems/Movement/ContextSteer.cs
+
+using Unity.Mathematics;
+using TheWaningBorder.World.Terrain;
+
+namespace TheWaningBorder.Systems.Movement
+{
+    public static class ContextSteer
+    {
+        // Candidate offsets in radians from the desired direction. Symmetric
+        // around 0, ordered nearest-first so ties go to "go more or less the
+        // way I wanted." The 0 entry is intentionally absent — caller has
+        // already determined that direction is blocked.
+        private static readonly float[] CandidateOffsets =
+        {
+             0.3927f, -0.3927f, // +/- 22.5°
+             0.7854f, -0.7854f, // +/- 45°
+             1.1781f, -1.1781f, // +/- 67.5°
+             1.5708f, -1.5708f, // +/- 90°
+        };
+
+        /// <summary>
+        /// Try to find a passable steering direction near <paramref name="desiredDir"/>
+        /// when the unit's body would clip an obstacle on the desired step.
+        ///
+        /// Returns true and sets <paramref name="steeredDir"/> to the best
+        /// candidate direction (highest alignment with desired) whose
+        /// projected next-position passes the radius-aware passability check.
+        /// Returns false if every candidate is blocked — in that case the
+        /// caller should fall through to the existing stuck-escalation
+        /// (perpendicular nudge / spiral escape / cancel order).
+        ///
+        /// <paramref name="desiredDir"/> must be normalised. <paramref name="step"/>
+        /// is the per-frame movement magnitude. <paramref name="position"/>
+        /// is the unit's current world position. <paramref name="radius"/>
+        /// is its collision radius for the Minkowski check.
+        /// </summary>
+        public static bool TrySteerAround(
+            float3 position,
+            float3 desiredDir,
+            float step,
+            float radius,
+            PassabilityGrid grid,
+            out float3 steeredDir)
+        {
+            steeredDir = desiredDir;
+            if (grid == null) return false;
+
+            // 2D heading (XZ plane); preserve y from the input direction.
+            float baseAngle = math.atan2(desiredDir.x, desiredDir.z);
+
+            // The candidate list is already ordered nearest-first, so the
+            // first match is the best.
+            for (int i = 0; i < CandidateOffsets.Length; i++)
+            {
+                float angle = baseAngle + CandidateOffsets[i];
+                float3 candidate = new float3(math.sin(angle), 0f, math.cos(angle));
+                float3 candidatePos = position + candidate * step;
+                if (!grid.IsPassableForRadius(candidatePos, radius)) continue;
+
+                steeredDir = candidate;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Movement/ContextSteer.cs.meta
+++ b/Assets/Scripts/Systems/Movement/ContextSteer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a3b8c2e6d4f5917e5b8c3d1a7f4e296

--- a/Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs
+++ b/Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs
@@ -38,6 +38,70 @@ namespace TheWaningBorder.Systems.Movement
         /// <summary>Sentinel value for unreachable / unvisited cells.</summary>
         private const ushort Unreachable = ushort.MaxValue;
 
+        /// <summary>
+        /// Internal-only cell value used by the inflation pre-pass to mark
+        /// Passable cells that have at least one blocked 1-cell neighbour.
+        /// The BFS treats these as blocked (Cells != 0). Distinct from
+        /// PassabilityGrid.BuildingBlocked / TerrainBlocked / ObstacleBlocked
+        /// so debug tooling can tell them apart if it inspects the BFS copy.
+        /// </summary>
+        private const byte InflatedClearance = 4;
+
+        /// <summary>
+        /// Mark Passable cells adjacent to any blocked cell as InflatedClearance.
+        /// One-cell Chebyshev kernel — sufficient for typical 0.5m units on a
+        /// 1m grid. The destination cell is restored to Passable so BFS can
+        /// seed it even when the goal sits next to a building. Operates in
+        /// place on the BFS's private cells copy.
+        /// </summary>
+        private static void InflateForAgentRadius(NativeArray<byte> cells, int width, int height, int destinationIndex)
+        {
+            // Pre-compute a snapshot of which cells were originally blocked, so
+            // we don't cascade the inflation (each pass would inflate the
+            // previous inflation's ring, propagating the obstacle outward
+            // forever).
+            var originallyBlocked = new NativeArray<byte>(cells.Length, Allocator.Temp);
+            for (int i = 0; i < cells.Length; i++)
+                originallyBlocked[i] = (byte)(cells[i] != 0 ? 1 : 0);
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    int idx = y * width + x;
+                    if (cells[idx] != 0) continue; // already blocked, leave alone
+
+                    bool adjacentBlocked = false;
+                    for (int dy = -1; dy <= 1 && !adjacentBlocked; dy++)
+                    {
+                        int ny = y + dy;
+                        if (ny < 0 || ny >= height) continue;
+                        for (int dx = -1; dx <= 1; dx++)
+                        {
+                            if (dx == 0 && dy == 0) continue;
+                            int nx = x + dx;
+                            if (nx < 0 || nx >= width) continue;
+                            if (originallyBlocked[ny * width + nx] != 0)
+                            {
+                                adjacentBlocked = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (adjacentBlocked) cells[idx] = InflatedClearance;
+                }
+            }
+
+            // Preserve destination — BFS bails if Cells[DestinationIndex] != 0.
+            if (destinationIndex >= 0 && destinationIndex < cells.Length
+                && originallyBlocked[destinationIndex] == 0)
+            {
+                cells[destinationIndex] = 0;
+            }
+
+            originallyBlocked.Dispose();
+        }
+
         // =====================================================================
         // PUBLIC API
         // =====================================================================
@@ -125,6 +189,18 @@ namespace TheWaningBorder.Systems.Movement
             // dispose (existing code already does this).
             var passabilityCopy = new NativeArray<byte>(passabilityCells.Length, Allocator.Persistent);
             passabilityCopy.CopyFrom(passabilityCells);
+
+            // Tier B (nav rework): radius-aware inflation pre-pass. Mark every
+            // Passable cell that has at least one blocked 1-cell neighbour as
+            // InflatedClearance — the BFS treats it as blocked, so the flow
+            // field naturally routes 1 cell away from buildings instead of
+            // squeezing through corner-touching cells the unit's body can't
+            // physically traverse. The destination cell is preserved so BFS
+            // can seed even when the goal sits next to a building. Units that
+            // happen to spawn inside the inflated ring fall back to direct-line
+            // via the existing FlowFieldLookup 5x5 Gaussian which finds a
+            // non-zero neighbour direction.
+            InflateForAgentRadius(passabilityCopy, gridWidth, gridHeight, destinationIndex);
 
             // Allocate BFS queue
             var bfsQueue = new NativeQueue<int>(Allocator.Persistent);

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -499,6 +499,26 @@ namespace TheWaningBorder.Systems.Movement
                     bool nextOk = currentlyClear
                         ? passGrid.IsPassableForRadius(nextPos, radius)
                         : passGrid.IsPassable(nextCell);
+
+                    // Tier D — context steering. If the desired step is
+                    // blocked, sample a fan of alternative directions around
+                    // the desired heading and take the most-aligned one that
+                    // clears. Avoids the abrupt "Tier 2 perpendicular nudge"
+                    // dance and gives the unit a smooth detour around minor
+                    // obstacles. Only kicks in for units that aren't currently
+                    // wedged (currentlyClear == true) — wedged units still
+                    // use the existing escape hatch (centre-only fallback).
+                    if (!nextOk && currentlyClear && radius > 0f)
+                    {
+                        if (ContextSteer.TrySteerAround(pos, smoothedDir, step, radius, passGrid, out var steeredDir))
+                        {
+                            smoothedDir = steeredDir;
+                            nextPos = pos + smoothedDir * step;
+                            nextCell = passGrid.WorldToCell(nextPos);
+                            nextOk = true;
+                        }
+                    }
+
                     if (!nextOk) blocked = true;
                 }
 


### PR DESCRIPTION
## Summary
Three coordinated nav tiers from the deep-dive plan. Each is a separate commit so you can roll back individually.

### Tier B — radius-aware flow field BFS
[FlowFieldGenerator.cs](Assets/Scripts/Systems/Movement/FlowFieldGenerator.cs)
- New `InflateForAgentRadius` pre-pass: marks every Passable cell that has a blocked 1-cell neighbour as `InflatedClearance` (internal sentinel != 0 so the BFS treats it as blocked).
- One-cell Chebyshev kernel — sufficient for typical 0.5m units on a 1m grid.
- Destination cell is preserved so BFS still seeds even when the goal sits next to a building.
- Fixes the *root cause* the deep-dive flagged: flow field was point-agent-only, generating directions that pointed into edge cells the unit's body couldn't traverse. Now the field naturally routes 1 cell away from buildings.
- Units in the inflated ring (e.g. spawned next to a hall) fall back to direct-line via FlowFieldLookup's existing 5×5 Gaussian neighbour sample.
- Cost: O(N) inflation per BFS schedule on the main thread before the worker job. Negligible at typical grid sizes.

### Tier C — BFME2 horde pathing (radius-aware slot validity)
[BattalionSyncSystem.cs](Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs)
- Slot validity check now uses `passGrid.IsPassableForRadius(slot, memberRadius)` — per-member radius so siege pieces and infantry get correct clearance.
- Slot-path raycast replaced with `passGrid.HasClearLineOfSight(memberPos, slot, radius)` — same sampled geometric LOS as A* string-pull. Catches the case where slot + member are both clear but the line between them clips a building corner.
- Net effect: members fall back to follow-leader-via-flow-field when slots are unreachable, leader's flow field is now safe (Tier B), so the BFME2 'horde paths, members steer to slots' pattern works correctly without per-member point-passability false negatives.

### Tier D — context steering on blocked step
[ContextSteer.cs](Assets/Scripts/Systems/Movement/ContextSteer.cs) (new) + [MovementSystem.cs](Assets/Scripts/Systems/Movement/MovementSystem.cs)
- New `ContextSteer.TrySteerAround` samples a fan of alternative directions (±22.5°, ±45°, ±67.5°, ±90°) ordered nearest-first; returns the most-aligned candidate whose projected next-position clears the radius-aware check.
- Wired into MovementSystem at the per-frame radius-rejection site, gated on the unit being currently clear (wedged units still use the existing escape hatch).
- Replaces the abrupt Tier 2 perpendicular nudge with a smooth detour. The stuck counter is reset on successful steering so small obstacles no longer escalate.
- Inspired by Andrew Fray's context steering (Game AI Pro 2013) but pared down — only scoring by `alignment × passability` because Tier B handles macro-scale routing and UnitSeparationSystem handles ally-separation.

## Test plan
- [ ] User's exact scenario: unit at (0,0), 1×2 building at (1..2, -1..1), move to (3,0) — unit takes a smooth curved path around the building, no clipping.
- [ ] Battalion of 12 marches between two buildings — members find slots, fall back to follow-leader cleanly when slot is blocked, no edge-snagging.
- [ ] Spawn-adjacent regression: builder next to hall walks out (the inflation traps no one because of the lenient centre + Gaussian fallback).
- [ ] Open-ground move — single straight segment (string-pull from #278 still in effect).
- [ ] Clusters of buildings — units approach, route around, group at goal without piling on edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)