### PR TITLE
feat(nav) navmesh PR2: units consume navmesh paths (UseNavMesh defaults ON)

### DIFF
--- a/Assets/Scripts/Core/Components/NavMeshComponents.cs
+++ b/Assets/Scripts/Core/Components/NavMeshComponents.cs
@@ -1,0 +1,37 @@
+// NavMeshComponents.cs
+// ECS components for the navmesh-based pathing path (Tier-4 / Option B,
+// PR2). Units that have these store the waypoint corridor returned by
+// NavMesh.CalculatePath; MovementSystem walks the corridor instead of
+// reading a flow-field direction.
+//
+// Lives in global namespace per the project's ECS convention.
+//
+// Location: Assets/Scripts/Core/Components/NavMeshComponents.cs
+
+using Unity.Entities;
+using Unity.Mathematics;
+
+/// <summary>
+/// Per-unit navmesh path state. Companion to a DynamicBuffer&lt;NavMeshWaypoint&gt;
+/// that holds the actual corner positions.
+///
+/// LastRequestedGoal lets the request system detect that the unit's
+/// DesiredDestination has moved and we need a fresh path. CurrentWaypoint
+/// is incremented by MovementSystem as the unit walks the corridor.
+/// </summary>
+public struct NavMeshPathfollowState : IComponentData
+{
+    public float3 LastRequestedGoal;
+    public int CurrentWaypoint;
+    public byte HasPath;          // 1 = waypoint buffer is valid
+    public byte RequestPending;   // 1 = waiting for the request system to fill the buffer
+}
+
+/// <summary>
+/// One corner of a NavMesh-computed path. Buffer is rewritten in place
+/// by NavMeshPathRequestSystem each time a fresh path is computed.
+/// </summary>
+public struct NavMeshWaypoint : IBufferElementData
+{
+    public float3 Position;
+}

--- a/Assets/Scripts/Core/Components/NavMeshComponents.cs.meta
+++ b/Assets/Scripts/Core/Components/NavMeshComponents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b4c8a2f3d5e1729e7c9b3d4a8f5e167

--- a/Assets/Scripts/Core/Settings/GameSettings.cs
+++ b/Assets/Scripts/Core/Settings/GameSettings.cs
@@ -144,11 +144,11 @@ public static class GameSettings
     /// <summary>
     /// Tier-4 navmesh migration toggle. When ON, units route via Unity's
     /// runtime-built navmesh (NavMeshManager) instead of the grid-based
-    /// flow field / A* stack. Default OFF until the navmesh consumer
-    /// (PR2) lands. Once enabled the legacy stack stops being consulted
-    /// and can be deleted (PR3).
+    /// flow field / A* stack. Default ON as of PR2 (navmesh consumer
+    /// landed). The flow-field / A* / passability-grid code is still
+    /// present but no longer consulted by movement; PR3 deletes it.
     /// </summary>
-    public static bool UseNavMesh = false;
+    public static bool UseNavMesh = true;
 
     // ==================== Multiplayer Settings ====================
 

--- a/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
+++ b/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
@@ -141,7 +141,12 @@ namespace TheWaningBorder.Systems.Movement
         {
             var em = state.EntityManager;
             float dt = SystemAPI.Time.DeltaTime;
-            var passGrid = PassabilityGrid.Instance;
+            // PR2 — when UseNavMesh is on, the navmesh routes the leader and
+            // (transitively) the formation away from buildings; the grid
+            // becomes a stale parallel source of truth that disagrees at cell
+            // boundaries. Treat passGrid as null here so per-member slot
+            // validity / next-step checks just trust the navmesh path.
+            var passGrid = GameSettings.UseNavMesh ? null : PassabilityGrid.Instance;
 
             var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
             var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);

--- a/Assets/Scripts/Systems/Movement/MovementSystem.cs
+++ b/Assets/Scripts/Systems/Movement/MovementSystem.cs
@@ -361,7 +361,47 @@ namespace TheWaningBorder.Systems.Movement
                 float3 dir = to / math.max(1e-5f, dist);
 
                 // === PATHFINDING DIRECTION ===
-                if (!useFlowFields && astarStore != null && em.HasComponent<AStarPathIndex>(entity))
+                bool useNavMesh = GameSettings.UseNavMesh;
+                if (useNavMesh && em.HasComponent<NavMeshPathfollowState>(entity)
+                    && em.HasBuffer<NavMeshWaypoint>(entity))
+                {
+                    // Navmesh waypoint following (Tier-4 / Option B). Path is
+                    // computed by NavMeshPathRequestSystem; we only walk it here.
+                    var nmState = em.GetComponentData<NavMeshPathfollowState>(entity);
+                    if (nmState.HasPath != 0)
+                    {
+                        var waypoints = em.GetBuffer<NavMeshWaypoint>(entity);
+                        if (nmState.CurrentWaypoint < waypoints.Length)
+                        {
+                            var wp = waypoints[nmState.CurrentWaypoint].Position;
+                            float3 toWp = wp - pos;
+                            toWp.y = 0f;
+                            float wpDist = math.length(toWp);
+
+                            if (wpDist < StopDistance * 2f)
+                            {
+                                nmState.CurrentWaypoint++;
+                                ecb.SetComponent(entity, nmState);
+                                if (nmState.CurrentWaypoint < waypoints.Length)
+                                {
+                                    var wp2 = waypoints[nmState.CurrentWaypoint].Position;
+                                    toWp = wp2 - pos;
+                                    toWp.y = 0f;
+                                    wpDist = math.length(toWp);
+                                }
+                                // else: corridor exhausted; fall through to direct-line
+                                // toward goal (DesiredDestination arrival check will stop).
+                            }
+
+                            if (wpDist > 1e-4f)
+                                dir = toWp / wpDist;
+                        }
+                    }
+                    // No HasPath yet (request pending) — keep direct-line dir as
+                    // a placeholder; first frame after the request resolves the
+                    // unit will pick up the corridor.
+                }
+                else if (!useFlowFields && astarStore != null && em.HasComponent<AStarPathIndex>(entity))
                 {
                     // A* waypoint following
                     var pathIdx = em.GetComponentData<AStarPathIndex>(entity);
@@ -489,7 +529,13 @@ namespace TheWaningBorder.Systems.Movement
                 bool blocked = false;
                 var passGrid = PassabilityGrid.Instance;
                 int2 nextCell = default;
-                if (passGrid != null)
+                // PR2 — when UseNavMesh is on, the navmesh path is the source
+                // of truth for obstacle avoidance. Skip the grid-based radius
+                // check entirely (the grid still exists for non-pathing
+                // queries like wall-enclosure detection until PR3 deletes it).
+                // Otherwise grid + navmesh disagree at cell boundaries and
+                // units get rejected mid-corridor.
+                if (passGrid != null && !GameSettings.UseNavMesh)
                 {
                     nextCell = passGrid.WorldToCell(nextPos);
                     float radius = em.HasComponent<Radius>(entity)

--- a/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
+++ b/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
@@ -1,0 +1,127 @@
+// NavMeshPathRequestSystem.cs
+// PR2 of the navmesh migration. Per-unit driver that queries the
+// NavMeshManager for paths and writes the resulting corner list into
+// each unit's NavMeshWaypoint buffer.
+//
+// Runs only when GameSettings.UseNavMesh is on. Throttled to a small
+// number of path computations per tick so a wave of move orders doesn't
+// hitch — same pattern as AStarPathStore.
+//
+// Not Burst-compiled: NavMesh.CalculatePath is a managed API on the
+// main thread and returns a managed NavMeshPath. MovementSystem (Burst)
+// only reads the resulting NativeArray-style buffer afterwards.
+//
+// Location: Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
+
+using Unity.Entities;
+using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace TheWaningBorder.Systems.Movement
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateBefore(typeof(MovementSystem))]
+    public partial class NavMeshPathRequestSystem : SystemBase
+    {
+        // Per-frame budget — match AStarPathStore's 20.
+        private const int MaxRequestsPerFrame = 20;
+        // If the goal moved less than this, don't bother repathing.
+        private const float GoalChangeThreshold = 1.0f;
+
+        private NavMeshPath _scratchPath;
+
+        protected override void OnCreate()
+        {
+            _scratchPath = new NavMeshPath();
+        }
+
+        protected override void OnUpdate()
+        {
+            if (!GameSettings.UseNavMesh) return;
+            var nmm = NavMeshManager.Instance;
+            if (nmm == null || !nmm.IsBaked) return;
+
+            int requestsThisFrame = 0;
+            var em = EntityManager;
+
+            // Pass 1: scan units with DesiredDestination, ensure the navmesh
+            // companion components exist (lazy stamp), and detect goal-change
+            // or first-time path needs.
+            Entities
+                .WithoutBurst()
+                .WithAll<UnitTag>()
+                .WithStructuralChanges()
+                .ForEach((Entity entity, ref DesiredDestination dd, in LocalTransform xf) =>
+                {
+                    if (dd.Has == 0) return;
+
+                    if (!em.HasComponent<NavMeshPathfollowState>(entity))
+                    {
+                        em.AddComponentData(entity, new NavMeshPathfollowState
+                        {
+                            LastRequestedGoal = dd.Position,
+                            CurrentWaypoint = 0,
+                            HasPath = 0,
+                            RequestPending = 1,
+                        });
+                        em.AddBuffer<NavMeshWaypoint>(entity);
+                    }
+                    else
+                    {
+                        var state = em.GetComponentData<NavMeshPathfollowState>(entity);
+                        if (math.distancesq(state.LastRequestedGoal, dd.Position)
+                                > GoalChangeThreshold * GoalChangeThreshold
+                            || state.HasPath == 0 && state.RequestPending == 0)
+                        {
+                            state.LastRequestedGoal = dd.Position;
+                            state.RequestPending = 1;
+                            em.SetComponentData(entity, state);
+                        }
+                    }
+                }).Run();
+
+            // Pass 2: actually compute paths for entities flagged
+            // RequestPending. Throttled per frame.
+            Entities
+                .WithoutBurst()
+                .WithAll<UnitTag>()
+                .ForEach((Entity entity, ref NavMeshPathfollowState state,
+                    ref DynamicBuffer<NavMeshWaypoint> waypoints,
+                    in LocalTransform xf) =>
+                {
+                    if (state.RequestPending == 0) return;
+                    if (requestsThisFrame >= MaxRequestsPerFrame) return;
+
+                    requestsThisFrame++;
+                    state.RequestPending = 0;
+
+                    var fromW = new Vector3(xf.Position.x, xf.Position.y, xf.Position.z);
+                    var toW = new Vector3(state.LastRequestedGoal.x,
+                        state.LastRequestedGoal.y, state.LastRequestedGoal.z);
+
+                    bool ok = nmm.RequestPath(fromW, toW, _scratchPath);
+                    waypoints.Clear();
+                    if (!ok || _scratchPath.corners == null || _scratchPath.corners.Length == 0)
+                    {
+                        state.HasPath = 0;
+                        state.CurrentWaypoint = 0;
+                        return;
+                    }
+
+                    // Skip the first corner (it's the unit's own position).
+                    var corners = _scratchPath.corners;
+                    int start = corners.Length > 1 ? 1 : 0;
+                    for (int i = start; i < corners.Length; i++)
+                    {
+                        waypoints.Add(new NavMeshWaypoint
+                        {
+                            Position = new float3(corners[i].x, corners[i].y, corners[i].z),
+                        });
+                    }
+                    state.HasPath = (byte)(waypoints.Length > 0 ? 1 : 0);
+                    state.CurrentWaypoint = 0;
+                }).Run();
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs.meta
+++ b/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f8a2e6b3c1d5917e8a7c4b9d2e3f586


### PR DESCRIPTION
## Summary
Tier-4 navmesh migration **step 2 of 3**. Wires units to the NavMeshManager foundation from PR1. `UseNavMesh` is now ON by default — pathing routes through Unity's runtime navmesh.

## What landed

### `NavMeshComponents.cs` (new, global namespace)
- `NavMeshPathfollowState` — per-unit nav corridor state (current waypoint, last requested goal, has-path / pending flags).
- `NavMeshWaypoint` — `IBufferElementData` holding one corner of the path.

### `NavMeshPathRequestSystem` (new, managed `SystemBase`, runs before `MovementSystem`)
- Each tick: finds units with `DesiredDestination`, lazily stamps the components. Detects goal changes > 1 m and re-requests.
- Throttled to 20 path computations per frame (matches `AStarPathStore`).
- Wraps `NavMesh.SamplePosition` + `CalculatePath` via `NavMeshManager.RequestPath`. Skips the first corner (= unit's own position).

### `MovementSystem`
- New navmesh branch in the path-direction selector — consumes `NavMeshWaypoint` buffer when `UseNavMesh` is on. Walks to current waypoint, advances on arrival within `StopDistance * 2`.
- Per-frame radius passability check gated off when `UseNavMesh` is on. Otherwise grid + navmesh disagree at cell boundaries and units get rejected mid-corridor by the (now-stale) grid view.

### `BattalionSyncSystem`
- Treats `passGrid` as null when `UseNavMesh` is on. Slot-validity / next-step checks just trust the navmesh path. Members still steer toward slots in leader-local space; the leader's path through the formation is navmesh-routed.

### `GameSettings.UseNavMesh = true`
Default flipped.

## What's still here (until PR3)
Flow field BFS, A*, PassabilityGrid, PassabilityBuildingSync — all running but no longer consulted by movement. PR3 deletes the dead code.

## Test plan
- [ ] User's exact corner-clip case: unit at (0,0), 1×2 building at (1..2, -1..1), move to (3,0) — unit takes a smooth navmesh-curved path around the building.
- [ ] Battalion of 12 marches between buildings — clean navmesh route, no edge-snagging.
- [ ] Spawn-adjacent: builder next to hall walks out (NavMesh.SamplePosition snaps the start to the nearest valid navmesh point).
- [ ] Place a building mid-game — within 0.5 s the navmesh re-bakes and units route around the new obstacle.
- [ ] Long path past several buildings — straight, smooth.

## Rollback
`UseNavMesh = false` in GameSettings reverts to the legacy stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)