### PR TITLE
fix(nav): three navmesh PR compile errors

### DIFF
--- a/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
+++ b/Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
@@ -3,18 +3,23 @@
 // NavMeshManager for paths and writes the resulting corner list into
 // each unit's NavMeshWaypoint buffer.
 //
-// Runs only when GameSettings.UseNavMesh is on. Throttled to a small
-// number of path computations per tick so a wave of move orders doesn't
-// hitch — same pattern as AStarPathStore.
+// Throttled to a small number of path computations per tick so a wave
+// of move orders doesn't hitch — same pattern as AStarPathStore.
 //
 // Not Burst-compiled: NavMesh.CalculatePath is a managed API on the
 // main thread and returns a managed NavMeshPath. MovementSystem (Burst)
 // only reads the resulting NativeArray-style buffer afterwards.
 //
+// Uses a manual EntityQuery instead of Entities.ForEach because
+// the source generator rejects LocalTransform as a lambda parameter
+// type (DC0005). Manual iteration is fine — managed API anyway.
+//
 // Location: Assets/Scripts/Systems/Movement/NavMeshPathRequestSystem.cs
 
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
+using Unity.Transforms;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -24,16 +29,21 @@ namespace TheWaningBorder.Systems.Movement
     [UpdateBefore(typeof(MovementSystem))]
     public partial class NavMeshPathRequestSystem : SystemBase
     {
-        // Per-frame budget — match AStarPathStore's 20.
+        // Per-frame budget — match the legacy AStarPathStore's 20.
         private const int MaxRequestsPerFrame = 20;
         // If the goal moved less than this, don't bother repathing.
         private const float GoalChangeThreshold = 1.0f;
 
         private NavMeshPath _scratchPath;
+        private EntityQuery _unitQuery;
 
         protected override void OnCreate()
         {
             _scratchPath = new NavMeshPath();
+            _unitQuery = GetEntityQuery(
+                ComponentType.ReadOnly<UnitTag>(),
+                ComponentType.ReadWrite<DesiredDestination>(),
+                ComponentType.ReadOnly<LocalTransform>());
         }
 
         protected override void OnUpdate()
@@ -41,86 +51,86 @@ namespace TheWaningBorder.Systems.Movement
             var nmm = NavMeshManager.Instance;
             if (nmm == null || !nmm.IsBaked) return;
 
-            int requestsThisFrame = 0;
             var em = EntityManager;
+            using var entities = _unitQuery.ToEntityArray(Allocator.Temp);
 
-            // Pass 1: scan units with DesiredDestination, ensure the navmesh
-            // companion components exist (lazy stamp), and detect goal-change
-            // or first-time path needs.
-            Entities
-                .WithoutBurst()
-                .WithAll<UnitTag>()
-                .WithStructuralChanges()
-                .ForEach((Entity entity, ref DesiredDestination dd, in LocalTransform xf) =>
+            // Pass 1: lazy-stamp NavMeshPathfollowState + buffer, detect goal-change.
+            for (int i = 0; i < entities.Length; i++)
+            {
+                var entity = entities[i];
+                var dd = em.GetComponentData<DesiredDestination>(entity);
+                if (dd.Has == 0) continue;
+
+                if (!em.HasComponent<NavMeshPathfollowState>(entity))
                 {
-                    if (dd.Has == 0) return;
-
-                    if (!em.HasComponent<NavMeshPathfollowState>(entity))
+                    em.AddComponentData(entity, new NavMeshPathfollowState
                     {
-                        em.AddComponentData(entity, new NavMeshPathfollowState
-                        {
-                            LastRequestedGoal = dd.Position,
-                            CurrentWaypoint = 0,
-                            HasPath = 0,
-                            RequestPending = 1,
-                        });
-                        em.AddBuffer<NavMeshWaypoint>(entity);
-                    }
-                    else
-                    {
-                        var state = em.GetComponentData<NavMeshPathfollowState>(entity);
-                        if (math.distancesq(state.LastRequestedGoal, dd.Position)
-                                > GoalChangeThreshold * GoalChangeThreshold
-                            || state.HasPath == 0 && state.RequestPending == 0)
-                        {
-                            state.LastRequestedGoal = dd.Position;
-                            state.RequestPending = 1;
-                            em.SetComponentData(entity, state);
-                        }
-                    }
-                }).Run();
+                        LastRequestedGoal = dd.Position,
+                        CurrentWaypoint = 0,
+                        HasPath = 0,
+                        RequestPending = 1,
+                    });
+                    em.AddBuffer<NavMeshWaypoint>(entity);
+                    continue;
+                }
 
-            // Pass 2: actually compute paths for entities flagged
-            // RequestPending. Throttled per frame.
-            Entities
-                .WithoutBurst()
-                .WithAll<UnitTag>()
-                .ForEach((Entity entity, ref NavMeshPathfollowState state,
-                    ref DynamicBuffer<NavMeshWaypoint> waypoints,
-                    in LocalTransform xf) =>
+                var state = em.GetComponentData<NavMeshPathfollowState>(entity);
+                if (math.distancesq(state.LastRequestedGoal, dd.Position)
+                        > GoalChangeThreshold * GoalChangeThreshold
+                    || (state.HasPath == 0 && state.RequestPending == 0))
                 {
-                    if (state.RequestPending == 0) return;
-                    if (requestsThisFrame >= MaxRequestsPerFrame) return;
+                    state.LastRequestedGoal = dd.Position;
+                    state.RequestPending = 1;
+                    em.SetComponentData(entity, state);
+                }
+            }
 
-                    requestsThisFrame++;
-                    state.RequestPending = 0;
+            // Pass 2: compute paths for entities flagged RequestPending.
+            // Throttled per frame.
+            int requestsThisFrame = 0;
+            for (int i = 0; i < entities.Length; i++)
+            {
+                if (requestsThisFrame >= MaxRequestsPerFrame) break;
+                var entity = entities[i];
+                if (!em.HasComponent<NavMeshPathfollowState>(entity)) continue;
 
-                    var fromW = new Vector3(xf.Position.x, xf.Position.y, xf.Position.z);
-                    var toW = new Vector3(state.LastRequestedGoal.x,
-                        state.LastRequestedGoal.y, state.LastRequestedGoal.z);
+                var state = em.GetComponentData<NavMeshPathfollowState>(entity);
+                if (state.RequestPending == 0) continue;
 
-                    bool ok = nmm.RequestPath(fromW, toW, _scratchPath);
-                    waypoints.Clear();
-                    if (!ok || _scratchPath.corners == null || _scratchPath.corners.Length == 0)
-                    {
-                        state.HasPath = 0;
-                        state.CurrentWaypoint = 0;
-                        return;
-                    }
+                requestsThisFrame++;
+                state.RequestPending = 0;
 
-                    // Skip the first corner (it's the unit's own position).
-                    var corners = _scratchPath.corners;
-                    int start = corners.Length > 1 ? 1 : 0;
-                    for (int i = start; i < corners.Length; i++)
-                    {
-                        waypoints.Add(new NavMeshWaypoint
-                        {
-                            Position = new float3(corners[i].x, corners[i].y, corners[i].z),
-                        });
-                    }
-                    state.HasPath = (byte)(waypoints.Length > 0 ? 1 : 0);
+                var xf = em.GetComponentData<LocalTransform>(entity);
+                var fromW = new Vector3(xf.Position.x, xf.Position.y, xf.Position.z);
+                var toW = new Vector3(state.LastRequestedGoal.x,
+                    state.LastRequestedGoal.y, state.LastRequestedGoal.z);
+
+                bool ok = nmm.RequestPath(fromW, toW, _scratchPath);
+                var waypoints = em.GetBuffer<NavMeshWaypoint>(entity);
+                waypoints.Clear();
+
+                if (!ok || _scratchPath.corners == null || _scratchPath.corners.Length == 0)
+                {
+                    state.HasPath = 0;
                     state.CurrentWaypoint = 0;
-                }).Run();
+                    em.SetComponentData(entity, state);
+                    continue;
+                }
+
+                // Skip the first corner (= unit's own position).
+                var corners = _scratchPath.corners;
+                int start = corners.Length > 1 ? 1 : 0;
+                for (int c = start; c < corners.Length; c++)
+                {
+                    waypoints.Add(new NavMeshWaypoint
+                    {
+                        Position = new float3(corners[c].x, corners[c].y, corners[c].z),
+                    });
+                }
+                state.HasPath = (byte)(waypoints.Length > 0 ? 1 : 0);
+                state.CurrentWaypoint = 0;
+                em.SetComponentData(entity, state);
+            }
         }
     }
 }

--- a/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
+++ b/Assets/Scripts/Systems/Work/PassabilityBuildingSync.cs
@@ -216,12 +216,10 @@ namespace TheWaningBorder.Systems.Work
 
             obstacleToRemove.Dispose();
 
-            // If anything changed, invalidate stale flow fields so units re-route
-            if (gridChanged)
-            {
-                var ffm = FlowFieldManager.Instance;
-                if (ffm != null) ffm.InvalidateAll();
-            }
+            // PR3 — flow-field invalidation removed. NavMeshManager re-bakes
+            // its navmesh when the building set changes via its own ECS sync.
+            // gridChanged is still tracked for future use but no longer dispatched.
+            _ = gridChanged;
         }
     }
 }


### PR DESCRIPTION
## Summary
Three compile errors in PR3:
- **DC0005 / CS0246** in `NavMeshPathRequestSystem.cs:54,90` — `Entities.ForEach` rejects `LocalTransform` as a lambda parameter type. Rewrote both passes with a manual `EntityQuery` + for-loop; `LocalTransform` fetched inside the loop via `EntityManager`. Cleaner anyway since the API is managed (NavMesh.CalculatePath is main-thread-only).
- **CS0103** in `PassabilityBuildingSync.cs:222` — missed a `FlowFieldManager.Instance` reference in PR3 cleanup. Replaced with the standard PR3 comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)