### PR TITLE
feat(nav): BFME2-style on-arrival battalion formation alignment

### DIFF
--- a/Assets/Scripts/Core/Components/BattalionComponents.cs
+++ b/Assets/Scripts/Core/Components/BattalionComponents.cs
@@ -88,6 +88,20 @@ public struct DefaultStancePursuit : IComponentData
 }
 
 /// <summary>
+/// Per-leader latch for the BFME2-style on-arrival formation alignment.
+/// When a battalion's DesiredDestination.Has transitions from 1 → 0, the
+/// alignment pass in BattalionSyncSystem checks for overlap with another
+/// idle battalion and shifts this leader to a clear adjacent spot. Once
+/// shifted (or confirmed clear), AlignedSinceArrival flips to 1 and the
+/// pass skips this leader. Reset to 0 when a new move command lands
+/// (Has flips back to 1).
+/// </summary>
+public struct BattalionAlignmentState : IComponentData
+{
+    public byte AlignedSinceArrival;
+}
+
+/// <summary>
 /// Set on a unit when it takes damage. Records the attacking entity.
 /// Used by TargetingSystem to implement Defensive stance return-fire behavior.
 /// Cleared each frame by TargetingSystem after processing.

--- a/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
+++ b/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
@@ -149,6 +149,33 @@ namespace TheWaningBorder.Systems.Movement
             var ecbSingleton = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>();
             var ecb = ecbSingleton.CreateCommandBuffer(state.WorldUnmanaged);
 
+            // ── BFME2-style arrival alignment snapshot ──
+            // Snapshot every idle (DesiredDestination.Has==0) battalion leader
+            // up-front. The per-leader loop below uses this to detect overlap
+            // when its leader has just arrived, and shifts the new arrival's
+            // anchor to a clear adjacent spot. This is the BFME2 "snap to
+            // align" feel — dampening alone (PR #290) prevented the shake
+            // but left formations stacked on top of each other.
+            var alignSnaps = new NativeList<AlignmentSnap>(32, Allocator.Temp);
+            foreach (var (otherLeader, otherXf, otherEntity) in SystemAPI
+                .Query<RefRO<BattalionLeader>, RefRO<LocalTransform>>()
+                .WithAll<BattalionTag>()
+                .WithEntityAccess())
+            {
+                bool otherMoving = false;
+                if (em.HasComponent<DesiredDestination>(otherEntity))
+                    otherMoving = em.GetComponentData<DesiredDestination>(otherEntity).Has != 0;
+                if (otherMoving) continue;
+                var obl = otherLeader.ValueRO;
+                float r = math.max(obl.Columns, obl.Rows) * obl.Spacing * 0.5f;
+                alignSnaps.Add(new AlignmentSnap
+                {
+                    Entity = otherEntity,
+                    Position = otherXf.ValueRO.Position,
+                    Radius = r,
+                });
+            }
+
             foreach (var (leader, leaderXf, entity) in SystemAPI
                 .Query<RefRW<BattalionLeader>, RefRO<LocalTransform>>()
                 .WithAll<BattalionTag>()
@@ -200,6 +227,66 @@ namespace TheWaningBorder.Systems.Movement
                 {
                     formationRot = leaderRot;
                     leader.ValueRW.FormationRot = formationRot;
+                }
+
+                // ── BFME2-style arrival alignment ──
+                // On the first frame after a battalion arrives at its
+                // destination, check the snapshot for any other idle
+                // battalion whose formation footprint overlaps. If found,
+                // shift this leader's anchor away from the conflict so
+                // the two formations sit alongside instead of on top.
+                // Members re-target their slots automatically next frame
+                // because slot offsets are computed in leader-local space.
+                if (isMoving)
+                {
+                    if (em.HasComponent<BattalionAlignmentState>(entity))
+                        em.SetComponentData(entity, new BattalionAlignmentState { AlignedSinceArrival = 0 });
+                }
+                else
+                {
+                    bool aligned = em.HasComponent<BattalionAlignmentState>(entity)
+                        && em.GetComponentData<BattalionAlignmentState>(entity).AlignedSinceArrival != 0;
+                    if (!aligned)
+                    {
+                        float myRadius = math.max(cols, rows) * spacing * 0.5f;
+                        float3 shift = float3.zero;
+                        int conflictCount = 0;
+                        for (int s = 0; s < alignSnaps.Length; s++)
+                        {
+                            var snap = alignSnaps[s];
+                            if (snap.Entity == entity) continue;
+                            float3 diff = leaderPos - snap.Position;
+                            diff.y = 0f;
+                            float distSq = math.lengthsq(diff);
+                            float minDist = myRadius + snap.Radius;
+                            if (distSq < minDist * minDist && distSq > 0.0001f)
+                            {
+                                float dist = math.sqrt(distSq);
+                                float overlap = minDist - dist + 0.5f; // small buffer
+                                shift += (diff / dist) * overlap;
+                                conflictCount++;
+                            }
+                        }
+                        if (conflictCount > 0)
+                        {
+                            shift /= conflictCount;
+                            float3 newLeaderPos = leaderPos + shift;
+                            // Snap the shifted anchor onto the navmesh so
+                            // we don't land on a building / unreachable tile.
+                            var nmm = NavMeshManager.Instance;
+                            if (nmm != null)
+                                newLeaderPos = nmm.SnapToNavMesh(
+                                    new UnityEngine.Vector3(newLeaderPos.x, newLeaderPos.y, newLeaderPos.z), 5f);
+                            var newXf = LocalTransform.FromPositionRotationScale(
+                                newLeaderPos, leaderXf.ValueRO.Rotation, leaderXf.ValueRO.Scale);
+                            em.SetComponentData(entity, newXf);
+                            leaderPos = newLeaderPos;
+                        }
+                        if (em.HasComponent<BattalionAlignmentState>(entity))
+                            em.SetComponentData(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
+                        else
+                            em.AddComponentData(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
+                    }
                 }
 
                 // ── 1. Decide whether to run greedy reassignment ──
@@ -516,6 +603,25 @@ namespace TheWaningBorder.Systems.Movement
                         newPos, formationRot, memberXf.Scale));
                 }
             }
+
+            alignSnaps.Dispose();
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // BFME2 ALIGNMENT SUPPORT
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// One snapshot row used by the alignment pass — an idle leader's
+        /// world position + formation radius. Filled at the top of OnUpdate
+        /// before the per-leader iteration so each leader can scan its
+        /// peers without nested SystemAPI queries.
+        /// </summary>
+        private struct AlignmentSnap
+        {
+            public Entity Entity;
+            public float3 Position;
+            public float Radius;
         }
     }
 }


### PR DESCRIPTION
## Summary
Companion to PR #290's anti-shake. PR #290 suppressed the oscillation; you observed two battalions could now fully overlap and just sit on each other. BFME2 prevents that by snapping the new arrival's anchor to a clear adjacent spot. This PR ports the behavior.

## Implementation

### `BattalionAlignmentState` (new, 1-byte latch on the leader)
- Reset to 0 when `DesiredDestination.Has` flips to 1 (new move command).
- Set to 1 after the alignment pass runs once.
- Gates "do this exactly once per arrival."

### `BattalionSyncSystem.OnUpdate`
- **Snapshot pass** at the top: collects every idle leader's `(Entity, Position, FormationRadius)` into a `NativeList<AlignmentSnap>`.
- **Per-leader pass** (existing): when `isMoving == false` and `AlignedSinceArrival == 0`:
  - Scans the snapshot for any other idle leader whose formation overlaps.
  - Accumulates a push-away vector across all conflicts.
  - Applies the average shift to this leader's `LocalTransform`.
  - `NavMesh.SamplePosition`-snaps the result (5 m search) so we don't land on a building.
- Members re-target slots automatically next frame — slot offsets are in leader-local space.

## Edge cases handled
- Leader-to-self skip in the snapshot scan.
- Zero-distance overlap guarded (would NaN the divide).
- NavMesh snap covers building / wall conflicts.

## Limitations (acceptable for first cut, matches BFME2)
- Triggers once per arrival. If the player drops another battalion on top of a settled one, only the new arrival moves; the existing one stays put.
- Greedy single-pass shift. If 3+ leaders pile up, alignment is per-arrival, not iterated to global optimum.

## Test plan
- [ ] Order a battalion to a spot occupied by an idle battalion — new arrival pulls up alongside instead of stacking.
- [ ] Order three battalions to roughly the same spot in sequence — they fan out (each new arrival aligns past the previous).
- [ ] Order a battalion next to a wall such that the natural alignment shift would put it inside the wall — snap pulls it back to the navmesh.
- [ ] Issue a move command on an aligned battalion — `AlignedSinceArrival` resets to 0, so the next arrival re-aligns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)