### PR TITLE
fix(nav): BattalionAlignmentState add must go through ECB

### DIFF
--- a/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
+++ b/Assets/Scripts/Systems/Movement/BattalionSyncSystem.cs
@@ -282,10 +282,13 @@ namespace TheWaningBorder.Systems.Movement
                             em.SetComponentData(entity, newXf);
                             leaderPos = newLeaderPos;
                         }
+                        // ECB for the structural Add — direct EntityManager
+                        // calls would trip the iteration-vs-structural-change
+                        // safety check.
                         if (em.HasComponent<BattalionAlignmentState>(entity))
-                            em.SetComponentData(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
+                            ecb.SetComponent(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
                         else
-                            em.AddComponentData(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
+                            ecb.AddComponent(entity, new BattalionAlignmentState { AlignedSinceArrival = 1 });
                     }
                 }
 


### PR DESCRIPTION
## Summary
PR #292's alignment block called `em.AddComponentData` directly inside the `SystemAPI.Query` foreach. Adding a new component is a structural change and trips Unity's iteration-vs-structural-change safety check, throwing `InvalidOperationException` at runtime.

**Fix:** route the Add (and the matching Set, for consistency) through the existing `EntityCommandBuffer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)