### PR TITLE
fix(nav): wall gates passable through the navmesh

### DIFF
--- a/Assets/Scripts/Systems/Movement/NavMeshManager.cs
+++ b/Assets/Scripts/Systems/Movement/NavMeshManager.cs
@@ -182,6 +182,14 @@ namespace TheWaningBorder.Systems.Movement
             for (int i = 0; i < entities.Length; i++)
             {
                 var e = entities[i];
+                // Wall gates are walk-through-able. Skip them from the
+                // navmesh stamp so units can path through ally gates.
+                // (The friend/foe gate logic in WallGatePassabilitySystem
+                // is gameplay, not pathing — combat handles enemies on
+                // contact. A per-faction navmesh layer would let us close
+                // the gate for enemies cleanly; that's a future tile-set
+                // extension.)
+                if (em.HasComponent<WallGateTag>(e)) continue;
                 var t = em.GetComponentData<LocalTransform>(e);
                 Vector2 sz;
                 if (em.HasComponent<BuildingSize>(e))


### PR DESCRIPTION
## Summary
`NavMeshManager.SyncBuildings` stamped every `BuildingTag` entity as a Box source, including wall gates. Gates became impassable to all units even though `WallGatePassabilitySystem` is supposed to manage the friend/foe filter via the unit-vs-building separation push.

**Fix:** skip `WallGateTag` entities from the navmesh stamp. Gates are walkable at the navmesh layer for everyone; combat resolves enemies on contact.

## Future
Per-faction navmesh layers would close gates for enemies at the nav layer. That's a tile-set extension worth doing if/when the AI starts trying to send siege through enemy gates.

## Test plan
- [ ] Build a wall + gate, send a battalion through — they path through cleanly.
- [ ] Build a wall + gate at the edge of the map — units can still navigate around walls without trying to go through the now-passable gate (navmesh routes through gate when it's the shortest path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)