### PR TITLE
fix(economy): wall enclosure income — correct rate to spec

### DIFF
--- a/Assets/Scripts/Economy/WallEnclosureIncomeSystem.cs
+++ b/Assets/Scripts/Economy/WallEnclosureIncomeSystem.cs
@@ -22,8 +22,16 @@ namespace TheWaningBorder.Economy
     public partial struct WallEnclosureIncomeSystem : ISystem
     {
         private const float UpdateInterval = 5f;
-        private const float IncomePerSquareUnit = 0.5f; // Supplies per square-unit per tick
-        private const float TickInterval = 10f;          // Income tick interval (seconds)
+        // Spec: 1 supply per minute per 20 units² of enclosed terrain.
+        // That's 1/20 = 0.05 supplies per minute per unit²,
+        // i.e. 0.05/60 ≈ 8.33e-4 per second.
+        // Income is applied via a SuppliesIncome.PerTick multiplied by
+        // ResourceTickSystem's tick (1 second), so the constant equals
+        // the per-second rate per unit²:  1 / (60 * 20) = 1/1200.
+        // Old value (0.5f) was 600× too high — yielded 30 supplies/min
+        // per unit² instead of 1 per 20 units².
+        private const float IncomePerSquareUnit = 1f / 1200f;
+        private const float TickInterval = 1f;  // Match ResourceTickSystem cadence
 
         private double _lastUpdateTime;
 


### PR DESCRIPTION
## Summary
User-reported: "Wall resource generation is broken. Should add 1 per minute per 20 units² of terrain inside the walls."

The audit confirmed:
- ✅ Shoelace area formula is correct (uses `math.abs()`, interior only).
- ✅ Closed-vs-open detection via graph cycle walk works.
- ❌ **Rate was 60× over spec.**

## Math
Spec: `1 supply / minute / 20 units²` = `1/1200` per `unit² · sec`.

Previous: `IncomePerSquareUnit = 0.5f` with `TickInterval = 10f` →
`0.5 × (60s / 10s) = 3 supplies / minute / unit²` = `60 / 20 units²`. **60× too high.**

Fixed: `IncomePerSquareUnit = 1f / 1200f`, `TickInterval = 1f`. A 200 units² enclosure now yields exactly 10 supplies/min.

## Re: "creates a new resource type"
Functionally a non-issue — the synthetic income entity routes through `ResourceTickSystem` which aggregates per-faction `SuppliesIncome` into the supplies bank. The supplies counter does reflect the boost. Folding the income directly into Hall's own `SuppliesIncome` is a follow-up cleanup; the rate is the actionable bug.

## Test plan
- [ ] Build a closed wall ring around 200 units² of terrain — supplies tick up at +10/min from the enclosure.
- [ ] Open a wall (destroy a segment) — income drops to base.
- [ ] Close it again — income returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)