### PR TITLE
fix(world): crystal curse not spawning

### DIFF
--- a/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
@@ -144,6 +144,22 @@ namespace TheWaningBorder.Bootstrap
                 });
             }
 
+            // Initialize extinction state singleton so CrystalExtinctionSystem
+            // gets to run. Without this, RequireForUpdate<CrystalExtinctionState>
+            // permanently parks the system and the curse can't recover after
+            // the player wipes its initial nodes.
+            var extQuery = em.CreateEntityQuery(ComponentType.ReadOnly<CrystalExtinctionState>());
+            if (extQuery.IsEmpty)
+            {
+                var extEntity = em.CreateEntity(typeof(CrystalExtinctionState));
+                em.SetComponentData(extEntity, new CrystalExtinctionState
+                {
+                    IsExtinct = 0,
+                    RespawnTimer = 0f,
+                    HasEverExisted = 1,
+                });
+            }
+
             // Starter near-patch is spawned by CrystalPatchBootstrap (which always
             // runs, with or without the curse). This file used to spawn its own
             // 5×320=1600-crystal starter patch, doubling up with CrystalPatchBootstrap

--- a/Assets/Scripts/Bootstrap/SpawnDelayHelper.cs
+++ b/Assets/Scripts/Bootstrap/SpawnDelayHelper.cs
@@ -43,10 +43,11 @@ namespace TheWaningBorder.Bootstrap
                     IronDepositBootstrap.SpawnIronDeposits();
                     // Mineable crystal patches always spawn (1 near each player
                     // + scattered) so AI/players can age up without hunting
-                    // Crystallings first. Curse main nodes are still gated on
-                    // CrystalCurseEnabled and skipped on flat test maps.
+                    // Crystallings first. Curse main nodes respect only their
+                    // own toggle now — FlatTestMap previously double-gated and
+                    // silently disabled the curse in dev builds.
                     CrystalPatchBootstrap.SpawnCrystalPatches();
-                    if (GameSettings.CrystalCurseEnabled && !GameSettings.FlatTestMap)
+                    if (GameSettings.CrystalCurseEnabled)
                         CrystalNodeBootstrap.SpawnCrystalNodes();
                     FocusCameraOnHall();
                     LoadingScreen.NotifyReady();
@@ -64,7 +65,7 @@ namespace TheWaningBorder.Bootstrap
                 ObstacleBootstrap.SpawnObstacles();
             IronDepositBootstrap.SpawnIronDeposits();
             CrystalPatchBootstrap.SpawnCrystalPatches();
-            if (!GameSettings.FlatTestMap)
+            if (GameSettings.CrystalCurseEnabled)
                 CrystalNodeBootstrap.SpawnCrystalNodes();
             FocusCameraOnHall();
             LoadingScreen.NotifyReady();


### PR DESCRIPTION
Fixes Crystal Curse silently disabled. Two compounding bugs:

1. SpawnDelayHelper double-gated CrystalNodeBootstrap with !FlatTestMap on top of CrystalCurseEnabled. FlatTestMap defaults true so the curse never spawned. Both gates now respect only CrystalCurseEnabled.

2. CrystalExtinctionState singleton was never created. CrystalExtinctionSystem has RequireForUpdate so without the singleton the system was permanently parked - meaning once player wiped initial nodes the curse could never respawn. Now seeded alongside CrystalWaveState.

?? Generated with Claude Code