### PR TITLE
refactor(core): split Crystal Curse off Faction.White into Faction.Curse

### DIFF
--- a/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
+++ b/Assets/Scripts/Bootstrap/CrystalNodeBootstrap.cs
@@ -123,11 +123,11 @@ namespace TheWaningBorder.Bootstrap
                 nodesSpawned++;
             }
 
-            // Initialize Faction.White crystal bank if it doesn't exist
-            if (!FactionEconomy.TryGetBank(em, Faction.White, out _))
+            // Initialize Faction.Curse crystal bank if it doesn't exist
+            if (!FactionEconomy.TryGetBank(em, Faction.Curse, out _))
             {
                 var bankEntity = em.CreateEntity(typeof(FactionTag), typeof(FactionResources));
-                em.SetComponentData(bankEntity, new FactionTag { Value = Faction.White });
+                em.SetComponentData(bankEntity, new FactionTag { Value = Faction.Curse });
                 em.SetComponentData(bankEntity, new FactionResources { Crystal = 100 * nodesSpawned });
             }
 

--- a/Assets/Scripts/Core/Components/CoreComponents.cs
+++ b/Assets/Scripts/Core/Components/CoreComponents.cs
@@ -16,7 +16,14 @@ public enum Faction : byte
     Purple = 4,
     Orange = 5,
     Teal = 6,
-    White = 7
+    White = 7,
+    /// <summary>
+    /// Crystal Curse — environmental hostile faction, hostile to all
+    /// player factions. NOT a player slot; falls outside the 0..7 player
+    /// color range so it's never picked up by lobby/AI slot iteration
+    /// (LobbyConfig.Slots and player-color tables are length 8).
+    /// </summary>
+    Curse = 8,
 }
 
 public static class Cultures

--- a/Assets/Scripts/Core/Settings/FactionColors.cs
+++ b/Assets/Scripts/Core/Settings/FactionColors.cs
@@ -119,6 +119,7 @@ public static class FactionColors
         }
         // Creature/neutral fallback
         if (f == Faction.White) return new Color(1f, 1f, 1f, 1f);
+        if (f == Faction.Curse) return new Color(0.6f, 0.85f, 0.95f, 1f); // icy cyan — crystal aesthetic
         return ColorPool[0];
     }
 

--- a/Assets/Scripts/Entities/Buildings/CrystalEnforcementNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalEnforcementNode.cs
@@ -16,7 +16,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalEnforcementNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -64,7 +64,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalEnforcementNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalMainNode.cs
@@ -10,14 +10,14 @@ namespace TheWaningBorder.Entities
     /// <summary>
     /// Crystal Main Node - the central hive of the Crystal Curse faction.
     /// Spawned at map start, spreads cursed ground, and controls crystal AI behavior.
-    /// Uses Faction.White so existing targeting treats it as enemy to all players.
+    /// Uses Faction.Curse so existing targeting treats it as enemy to all players.
     /// </summary>
     public static class CrystalMainNode
     {
         /// <summary>
         /// Create CrystalMainNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -90,7 +90,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalMainNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalResourceNode.cs
@@ -16,7 +16,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalResourceNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -66,7 +66,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalResourceNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Buildings/CrystalRestorationNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalRestorationNode.cs
@@ -16,7 +16,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalRestorationNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -63,7 +63,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalRestorationNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Buildings/CrystalSuppressionNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalSuppressionNode.cs
@@ -16,7 +16,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalSuppressionNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -64,7 +64,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalSuppressionNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Buildings/CrystalTurretNode.cs
+++ b/Assets/Scripts/Entities/Buildings/CrystalTurretNode.cs
@@ -17,7 +17,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalTurretNode using EntityManager.
         /// </summary>
-        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityManager em, float3 position, Faction faction = Faction.Curse)
         {
             var entity = em.CreateEntity(
                 typeof(PresentationId),
@@ -67,7 +67,7 @@ namespace TheWaningBorder.Entities
         /// <summary>
         /// Create CrystalTurretNode using EntityCommandBuffer for deferred creation.
         /// </summary>
-        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.White)
+        public static Entity Create(EntityCommandBuffer ecb, float3 position, Faction faction = Faction.Curse)
         {
             var entity = ecb.CreateEntity();
 

--- a/Assets/Scripts/Entities/Units/Crystalling.cs
+++ b/Assets/Scripts/Entities/Units/Crystalling.cs
@@ -8,7 +8,7 @@ namespace TheWaningBorder.Entities
 {
     /// <summary>
     /// Crystalling unit - fast, weak melee crystal swarm unit.
-    /// Cheap crystal-cost melee infantry for the Crystal faction (Faction.White).
+    /// Cheap crystal-cost melee infantry for the Crystal faction (Faction.Curse).
     /// No population cost - crystal faction uses crystal resource economy.
     /// </summary>
     public static class Crystalling

--- a/Assets/Scripts/Presentation/PresentationSpawnSystem.cs
+++ b/Assets/Scripts/Presentation/PresentationSpawnSystem.cs
@@ -865,6 +865,7 @@ public partial class PresentationSpawnSystem : MonoBehaviour
             Faction.Orange => new Color(1f, 0.6f, 0.2f),
             Faction.Teal => new Color(0.2f, 0.8f, 0.8f),
             Faction.White => new Color(0.9f, 0.9f, 0.9f),
+            Faction.Curse => new Color(0.6f, 0.85f, 0.95f), // icy cyan — crystal aesthetic
             _ => Color.gray
         };
     }

--- a/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
+++ b/Assets/Scripts/Systems/Creatures/CrystalSpreadSystem.cs
@@ -203,7 +203,7 @@ namespace TheWaningBorder.Systems.Creatures
                     ecb.AddComponent(groundEntity, LocalTransform.FromPosition(groundPos));
                     ecb.AddComponent(groundEntity, new PresentationId { Id = CursedGroundPresentationId });
                     ecb.AddComponent(groundEntity, new Radius { Value = TileRadius });
-                    ecb.AddComponent(groundEntity, new FactionTag { Value = Faction.White });
+                    ecb.AddComponent(groundEntity, new FactionTag { Value = Faction.Curse });
                     ecb.AddComponent(groundEntity, new CursedGroundDPS
                     {
                         DamagePerSecond = BaseDPS,

--- a/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalAISystem.cs
@@ -136,7 +136,7 @@ namespace TheWaningBorder.Systems.Crystal
             var em = EntityManager;
 
             // Get crystal bank balance
-            if (!FactionEconomy.TryGetResources(em, Faction.White, out var resources))
+            if (!FactionEconomy.TryGetResources(em, Faction.Curse, out var resources))
                 return;
 
             int crystalBank = resources.Crystal;
@@ -171,7 +171,7 @@ namespace TheWaningBorder.Systems.Crystal
                 float territoryRadius = crystalNodes[n].SpreadRadius; // Fixed territory radius
 
                 // Refresh bank balance
-                if (FactionEconomy.TryGetResources(em, Faction.White, out resources))
+                if (FactionEconomy.TryGetResources(em, Faction.Curse, out resources))
                     crystalBank = resources.Crystal;
 
                 // Drive AI phase from elapsed game time
@@ -199,12 +199,12 @@ namespace TheWaningBorder.Systems.Crystal
                                 if (spawnPos.x != float.MinValue)
                                 {
                                     string unitName = ts.TrainingUnitType switch { 1 => "Crystalling", 2 => "Veilstinger", 3 => "Godsplinter", _ => "?" };
-                                    AILogger.Log(Faction.White, "TRAINING", $"Spawned {unitName} at ({spawnPos.x:F0},{spawnPos.z:F0}), bank:{crystalBank}, pop:{crystalUnitCount + 1}/{MaxCrystalUnits}");
+                                    AILogger.Log(Faction.Curse, "TRAINING", $"Spawned {unitName} at ({spawnPos.x:F0},{spawnPos.z:F0}), bank:{crystalBank}, pop:{crystalUnitCount + 1}/{MaxCrystalUnits}");
                                     switch (ts.TrainingUnitType)
                                     {
-                                        case 1: Crystalling.Create(em, spawnPos, Faction.White); break;
-                                        case 2: Veilstinger.Create(em, spawnPos, Faction.White); break;
-                                        case 3: Godsplinter.Create(em, spawnPos, Faction.White); break;
+                                        case 1: Crystalling.Create(em, spawnPos, Faction.Curse); break;
+                                        case 2: Veilstinger.Create(em, spawnPos, Faction.Curse); break;
+                                        case 3: Godsplinter.Create(em, spawnPos, Faction.Curse); break;
                                     }
                                     crystalUnitCount++;
                                 }
@@ -303,7 +303,7 @@ namespace TheWaningBorder.Systems.Crystal
 
             if (resourceCount < MaxResourceNodesPerMain && crystalBank >= ResourceNodeCost)
             {
-                if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: ResourceNodeCost)))
+                if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: ResourceNodeCost)))
                 {
                     created = CrystalResourceNode.Create(em, buildPos);
                     crystalBank -= ResourceNodeCost;
@@ -311,7 +311,7 @@ namespace TheWaningBorder.Systems.Crystal
             }
             else if (turretCount < MaxTurretNodesPerMain && crystalBank >= TurretNodeCost)
             {
-                if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: TurretNodeCost)))
+                if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: TurretNodeCost)))
                 {
                     created = CrystalTurretNode.Create(em, buildPos);
                     crystalBank -= TurretNodeCost;
@@ -319,7 +319,7 @@ namespace TheWaningBorder.Systems.Crystal
             }
             else if (restorationCount < MaxRestorationNodesPerMain && crystalBank >= RestorationNodeCost && ai.Phase >= 1)
             {
-                if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: RestorationNodeCost)))
+                if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: RestorationNodeCost)))
                 {
                     created = CrystalRestorationNode.Create(em, buildPos);
                     crystalBank -= RestorationNodeCost;
@@ -327,7 +327,7 @@ namespace TheWaningBorder.Systems.Crystal
             }
             else if (enforcementCount < MaxEnforcementNodesPerMain && crystalBank >= EnforcementNodeCost && ai.Phase >= 1)
             {
-                if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: EnforcementNodeCost)))
+                if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: EnforcementNodeCost)))
                 {
                     created = CrystalEnforcementNode.Create(em, buildPos);
                     crystalBank -= EnforcementNodeCost;
@@ -335,7 +335,7 @@ namespace TheWaningBorder.Systems.Crystal
             }
             else if (suppressionCount < MaxSuppressionNodesPerMain && crystalBank >= SuppressionNodeCost && ai.Phase >= 2)
             {
-                if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: SuppressionNodeCost)))
+                if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: SuppressionNodeCost)))
                 {
                     created = CrystalSuppressionNode.Create(em, buildPos);
                     crystalBank -= SuppressionNodeCost;
@@ -376,7 +376,7 @@ namespace TheWaningBorder.Systems.Crystal
 
             if (unitType == 0) return;
 
-            if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: cost)))
+            if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: cost)))
             {
                 crystalBank -= cost;
                 em.SetComponentData(nodeEntity, new CrystalTrainingState
@@ -447,7 +447,7 @@ namespace TheWaningBorder.Systems.Crystal
 
             for (int i = 0; i < intruders.Length; i++)
             {
-                if (intruderFactions[i].Value == Faction.White) continue;
+                if (intruderFactions[i].Value == Faction.Curse) continue;
                 float dist = math.distance(nodePos, intruderTransforms[i].Position);
                 if (dist <= spreadRadius && dist < closestDist)
                 {
@@ -540,7 +540,7 @@ namespace TheWaningBorder.Systems.Crystal
                 RescueStrandedUnits(em, nodeTransforms, ref random);
                 wave.WaveTimer = wave.WaveInterval;
                 wave.WaveNumber++;
-                AILogger.Log(Faction.White, "WAVE",
+                AILogger.Log(Faction.Curse, "WAVE",
                     $"Pursuit wave #{wave.WaveNumber}: {reassigned} units retargeted (interval {wave.WaveInterval:F0}s)");
             }
 
@@ -576,7 +576,7 @@ namespace TheWaningBorder.Systems.Crystal
             {
                 for (int i = 0; i < bEnts.Length; i++)
                 {
-                    if (bFactions[i].Value == Faction.White) continue;
+                    if (bFactions[i].Value == Faction.Curse) continue;
                     if (bHealth[i].Value <= 0) continue;
                     targets.Add(bTransforms[i].Position);
                 }
@@ -595,7 +595,7 @@ namespace TheWaningBorder.Systems.Crystal
             {
                 for (int i = 0; i < uEnts.Length; i++)
                 {
-                    if (uFactions[i].Value == Faction.White) continue;
+                    if (uFactions[i].Value == Faction.Curse) continue;
                     if (uHealth[i].Value <= 0) continue;
                     targets.Add(uTransforms[i].Position);
                 }
@@ -694,7 +694,7 @@ namespace TheWaningBorder.Systems.Crystal
                 rescued++;
             }
             if (rescued > 0)
-                AILogger.Log(Faction.White, "RESCUE", $"Recalled {rescued} stranded units to nearest main node");
+                AILogger.Log(Faction.Curse, "RESCUE", $"Recalled {rescued} stranded units to nearest main node");
         }
 
         /// <summary>Try to seed a new main curse node. Returns true on creation.</summary>
@@ -740,7 +740,7 @@ namespace TheWaningBorder.Systems.Crystal
 
             if (!found) return false;
 
-            if (FactionEconomy.Spend(em, Faction.White, Cost.Of(crystal: ExpansionCost)))
+            if (FactionEconomy.Spend(em, Faction.Curse, Cost.Of(crystal: ExpansionCost)))
             {
                 CrystalMainNode.Create(em, expandPos);
                 crystalBank -= ExpansionCost;

--- a/Assets/Scripts/Systems/Crystal/CrystalExtinctionSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalExtinctionSystem.cs
@@ -121,7 +121,7 @@ namespace TheWaningBorder.Systems.Crystal
             var playerPositions = new NativeList<float3>(Allocator.Temp);
             for (int i = 0; i < hallFactions.Length; i++)
             {
-                if (hallFactions[i].Value != Faction.White)
+                if (hallFactions[i].Value != Faction.Curse)
                     playerPositions.Add(hallTransforms[i].Position);
             }
 
@@ -160,7 +160,7 @@ namespace TheWaningBorder.Systems.Crystal
                 CrystalMainNode.Create(em, candidate);
 
                 // Give small crystal bank boost
-                FactionEconomy.Add(em, Faction.White, Cost.Of(crystal: 100));
+                FactionEconomy.Add(em, Faction.Curse, Cost.Of(crystal: 100));
 
                 playerPositions.Dispose();
                 return;

--- a/Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
@@ -1,6 +1,6 @@
 // File: Assets/Scripts/Systems/Crystal/CrystalIncomeSystem.cs
 // Crystal income system: generates Crystal resources based on cursed ground coverage.
-// Income is credited to Faction.White's resource bank every second.
+// Income is credited to Faction.Curse's resource bank every second.
 
 using Unity.Entities;
 using Unity.Mathematics;
@@ -48,8 +48,8 @@ namespace TheWaningBorder.Systems.Crystal
 
             if (income <= 0) return;
 
-            // Credit to Faction.White bank
-            FactionEconomy.Add(em, Faction.White, new Cost { Crystal = income });
+            // Credit to Faction.Curse bank
+            FactionEconomy.Add(em, Faction.Curse, new Cost { Crystal = income });
         }
     }
 }

--- a/Assets/Scripts/Systems/Crystal/SuppressionNodeSystem.cs
+++ b/Assets/Scripts/Systems/Crystal/SuppressionNodeSystem.cs
@@ -54,8 +54,8 @@ namespace TheWaningBorder.Systems.Crystal
                 .WithAll<UnitTag>()
                 .WithEntityAccess())
             {
-                // Only debuff non-White (non-crystal) faction units
-                if (faction.ValueRO.Value == Faction.White) continue;
+                // Only debuff non-Curse (player) faction units
+                if (faction.ValueRO.Value == Faction.Curse) continue;
 
                 float3 unitPos = unitTransform.ValueRO.Position;
 

--- a/Assets/Scripts/UI/Common/UIHelpers.cs
+++ b/Assets/Scripts/UI/Common/UIHelpers.cs
@@ -213,6 +213,7 @@ namespace TheWaningBorder.UI.Common
                 Faction.Orange => new Color(1f, 0.6f, 0.2f),
                 Faction.Teal => new Color(0.2f, 0.8f, 0.8f),
                 Faction.White => new Color(0.9f, 0.9f, 0.9f),
+                Faction.Curse => new Color(0.6f, 0.85f, 0.95f), // icy cyan — crystal aesthetic
                 _ => Color.gray
             };
         }

--- a/Assets/Scripts/UI/HUD/CrystalDebugPanel.cs
+++ b/Assets/Scripts/UI/HUD/CrystalDebugPanel.cs
@@ -95,7 +95,7 @@ namespace TheWaningBorder.UI.HUD
             InitQueries(em);
 
             // Crystal bank
-            if (FactionEconomy.TryGetResources(em, Faction.White, out var res))
+            if (FactionEconomy.TryGetResources(em, Faction.Curse, out var res))
                 _crystalBank = res.Crystal;
 
             // Count main nodes first (needed for income calc)

--- a/Assets/Scripts/UI/HUD/PostGameStatsUI.cs
+++ b/Assets/Scripts/UI/HUD/PostGameStatsUI.cs
@@ -524,6 +524,7 @@ namespace TheWaningBorder.UI.HUD
                 Faction.Orange => new Color(1f, 0.6f, 0.2f),
                 Faction.Teal => new Color(0.2f, 0.8f, 0.8f),
                 Faction.White => new Color(0.9f, 0.9f, 0.9f),
+                Faction.Curse => new Color(0.6f, 0.85f, 0.95f), // icy cyan — crystal aesthetic
                 _ => Color.gray
             };
         }


### PR DESCRIPTION
Faction.White was double-booked as both player slot 7 (real lobby color) and the Crystal Curse tag. A real player picking white shared FactionTag with curse units, breaking friend/foe checks, income, and tints.

Adds Faction.Curse = 8 (outside the 0..7 player slot range so LobbyConfig.Slots / color tables of length 8 keep working). All curse entities, banks, ground tiles, and curse AI logic now use Faction.Curse. Player-color sites keep Faction.White. The four faction-to-color switches get an explicit Curse case (icy cyan).

?? Generated with Claude Code