### PR TITLE
feat(building): per-culture building upgrades - foundation, UI, AI (PR 1/3)

### DIFF
--- a/Assets/Scripts/AI/Managers/AIBuildingUpgradeSystem.cs
+++ b/Assets/Scripts/AI/Managers/AIBuildingUpgradeSystem.cs
@@ -1,0 +1,200 @@
+// AIBuildingUpgradeSystem.cs
+// Culture-agnostic AI driver for the building upgrade system.
+//
+// Each AI brain that's Era >= 2 with a non-None culture picks ONE
+// upgradeable building per tick (slowest cadence so it doesn't dominate
+// the build queue) and tries UpgradeBuildingCommandHelper.Execute on it.
+// Priority: Hall first (multi-target unlock + train speed), then Barracks
+// (training + arrow attack at L3), then Hut (pop scaling).
+//
+// Reserves a small buffer of resources before upgrading so upgrades
+// don't bankrupt the AI mid-rush. Reserves are loose — if the AI
+// genuinely can't afford it, the command helper rejects gracefully.
+//
+// Location: Assets/Scripts/AI/Managers/AIBuildingUpgradeSystem.cs
+
+using Unity.Collections;
+using Unity.Entities;
+using TheWaningBorder.Core.Commands.Types;
+using TheWaningBorder.Core.Settings;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.AI
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    [UpdateAfter(typeof(SimpleAISystem))]
+    public partial struct AIBuildingUpgradeSystem : ISystem
+    {
+        // Slow strategic loop. Upgrades take 20-45s to complete; checking
+        // every 6 s is plenty of cadence and keeps query churn low.
+        private const float ThinkInterval = 6f;
+
+        // Reserve buffer the AI keeps untouched before queueing an upgrade —
+        // upgrades are expensive and we don't want them to starve military /
+        // research lines.
+        private const int ReserveSupplies = 200;
+        private const int ReserveIron     = 50;
+        private const int ReserveCrystal  = 20;
+
+        // Priority order — cheapest, highest-impact first. Hall gives the
+        // largest combat + train benefits per click; Barracks gains an
+        // attack at L3; Huts are pop scaling.
+        private static readonly string[] PriorityOrder = { "Hall", "Barracks", "Hut" };
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<AIBrain>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            if (GameSettings.IsMultiplayer && !GameSettings.IsHost()) return;
+            float time = (float)SystemAPI.Time.ElapsedTime;
+            var em = state.EntityManager;
+
+            // Snapshot brains — we make structural changes (BuildingUpgrading
+            // gets added) so we can't iterate via SystemAPI.Query.
+            var brainQuery = em.CreateEntityQuery(ComponentType.ReadOnly<AIBrain>());
+            using var brainEntities = brainQuery.ToEntityArray(Allocator.Temp);
+
+            for (int b = 0; b < brainEntities.Length; b++)
+            {
+                var brainEntity = brainEntities[b];
+                if (!em.Exists(brainEntity)) continue;
+                var brain = em.GetComponentData<AIBrain>(brainEntity);
+                if (brain.IsActive == 0) continue;
+
+                Faction faction = brain.Owner;
+
+                // Per-brain throttle.
+                if (em.HasComponent<AIBuildingUpgradeTickState>(brainEntity))
+                {
+                    var tick = em.GetComponentData<AIBuildingUpgradeTickState>(brainEntity);
+                    if (time < tick.NextThinkTime) continue;
+                    tick.NextThinkTime = time + ThinkInterval;
+                    em.SetComponentData(brainEntity, tick);
+                }
+                else
+                {
+                    em.AddComponentData(brainEntity, new AIBuildingUpgradeTickState
+                    {
+                        NextThinkTime = time + ThinkInterval,
+                    });
+                    continue; // skip first tick
+                }
+
+                // Era 2+ + culture picked? UpgradeBuildingCommandHelper does
+                // the same gate but rejecting at this layer cuts query cost.
+                if (!FactionEconomy.TryGetBank(em, faction, out var bank)) continue;
+                if (!em.HasComponent<FactionEra>(bank)) continue;
+                if (em.GetComponentData<FactionEra>(bank).Value < 2) continue;
+                if (!HasCulture(em, faction)) continue;
+
+                // Reserve check — keep some resources for non-upgrade use.
+                if (!FactionEconomy.TryGetResources(em, faction, out var res)) continue;
+                if (res.Supplies < ReserveSupplies) continue;
+                if (res.Iron     < ReserveIron)     continue;
+                if (res.Crystal  < ReserveCrystal)  continue;
+
+                // Walk the priority order; first eligible building gets the upgrade.
+                TryUpgradeOne(em, faction);
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // HELPERS
+        // ──────────────────────────────────────────────────────────────────
+
+        private static bool HasCulture(EntityManager em, Faction faction)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<HallTag>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<FactionProgress>());
+            using var ents = query.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < ents.Length; i++)
+            {
+                if (em.GetComponentData<FactionTag>(ents[i]).Value != faction) continue;
+                if (em.GetComponentData<FactionProgress>(ents[i]).Culture != Cultures.None) return true;
+            }
+            return false;
+        }
+
+        private static void TryUpgradeOne(EntityManager em, Faction faction)
+        {
+            for (int p = 0; p < PriorityOrder.Length; p++)
+            {
+                if (TryUpgradeBuildingType(em, faction, PriorityOrder[p])) return;
+            }
+        }
+
+        /// <summary>
+        /// Find the LOWEST-LEVEL building of the given type owned by the
+        /// faction. Lowest level = highest marginal benefit per upgrade
+        /// click (uncultured Hall → L1 unlocks the multi-target chain).
+        /// Returns true if the upgrade was queued.
+        /// </summary>
+        private static bool TryUpgradeBuildingType(EntityManager em, Faction faction, string buildingId)
+        {
+            EntityQuery query;
+            switch (buildingId)
+            {
+                case "Hall":
+                    query = em.CreateEntityQuery(
+                        ComponentType.ReadOnly<HallTag>(),
+                        ComponentType.ReadOnly<BuildingUpgradeable>(),
+                        ComponentType.ReadOnly<FactionTag>());
+                    break;
+                case "Barracks":
+                    query = em.CreateEntityQuery(
+                        ComponentType.ReadOnly<BarracksTag>(),
+                        ComponentType.ReadOnly<BuildingUpgradeable>(),
+                        ComponentType.ReadOnly<FactionTag>());
+                    break;
+                case "Hut":
+                    query = em.CreateEntityQuery(
+                        ComponentType.ReadOnly<HutTag>(),
+                        ComponentType.ReadOnly<BuildingUpgradeable>(),
+                        ComponentType.ReadOnly<FactionTag>());
+                    break;
+                default:
+                    return false;
+            }
+
+            using var ents = query.ToEntityArray(Allocator.Temp);
+
+            Entity best = Entity.Null;
+            int bestLevel = int.MaxValue;
+            for (int i = 0; i < ents.Length; i++)
+            {
+                if (em.GetComponentData<FactionTag>(ents[i]).Value != faction) continue;
+                if (em.HasComponent<UnderConstruction>(ents[i])) continue;
+                if (em.HasComponent<BuildingUpgrading>(ents[i])) continue;
+
+                byte lvl = em.HasComponent<BuildingUpgradeState>(ents[i])
+                    ? em.GetComponentData<BuildingUpgradeState>(ents[i]).Level : (byte)0;
+                if (lvl >= BuildingUpgradeConfig.MaxLevel) continue;
+
+                if (lvl < bestLevel) { bestLevel = lvl; best = ents[i]; }
+            }
+            if (best == Entity.Null) return false;
+
+            var result = UpgradeBuildingCommandHelper.Execute(em, best);
+            if (result == UpgradeBuildingResult.Ok)
+            {
+                AILogger.Log(faction, "BUILDING",
+                    $"Upgrading {buildingId} to L{bestLevel + 1}");
+                return true;
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Per-brain tick throttle for the building upgrade loop.
+    /// </summary>
+    public struct AIBuildingUpgradeTickState : IComponentData
+    {
+        public float NextThinkTime;
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/UpgradeBuildingCommand.cs
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UpgradeBuildingCommand.cs
@@ -1,0 +1,144 @@
+// File: Assets/Scripts/Core/Commands/CommandTypes/UpgradeBuildingCommand.cs
+// Issues a building upgrade. Validates the request, captures base stats
+// the first time the building is upgraded, deducts cost, and stamps
+// BuildingUpgrading. The actual stat application happens later, when
+// BuildingUpgradeSystem ticks the timer down to zero — same pattern as
+// UnderConstruction → BuildingConstructionSystem.
+
+using Unity.Entities;
+using TheWaningBorder.Core.Settings;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Core.Commands.Types
+{
+    public static class UpgradeBuildingCommandHelper
+    {
+        /// <summary>
+        /// Try to start an upgrade on <paramref name="building"/>. Returns a
+        /// result code so callers (UI, AI) can show the appropriate
+        /// feedback. Captures base stats on first call so the upgrade
+        /// system can recompute idempotently.
+        /// </summary>
+        public static UpgradeBuildingResult Execute(EntityManager em, Entity building)
+        {
+            if (!em.Exists(building)) return UpgradeBuildingResult.NotUpgradeable;
+            if (!em.HasComponent<BuildingUpgradeable>(building)) return UpgradeBuildingResult.NotUpgradeable;
+            if (em.HasComponent<UnderConstruction>(building)) return UpgradeBuildingResult.UnderConstruction;
+            if (em.HasComponent<BuildingUpgrading>(building)) return UpgradeBuildingResult.AlreadyUpgrading;
+
+            // Identify the building type via PresentationId — same lookup the
+            // factory uses, so we don't need a parallel string registry.
+            string buildingId = ResolveBuildingId(em, building);
+            if (string.IsNullOrEmpty(buildingId)) return UpgradeBuildingResult.NotUpgradeable;
+
+            // Determine current level (default 0 if no state component yet).
+            byte currentLevel = 0;
+            if (em.HasComponent<BuildingUpgradeState>(building))
+                currentLevel = em.GetComponentData<BuildingUpgradeState>(building).Level;
+
+            if (currentLevel >= BuildingUpgradeConfig.MaxLevel)
+                return UpgradeBuildingResult.AlreadyMaxLevel;
+
+            // Owner culture: read from the Hall's FactionProgress (any culture
+            // unlocks upgrades for that faction's buildings — even non-Hall ones).
+            if (!em.HasComponent<FactionTag>(building)) return UpgradeBuildingResult.NoCulture;
+            var faction = em.GetComponentData<FactionTag>(building).Value;
+            if (!FactionHasCulture(em, faction)) return UpgradeBuildingResult.NoCulture;
+
+            byte targetLevel = (byte)(currentLevel + 1);
+
+            // Cost lookup + spend.
+            if (!BuildingUpgradeConfig.TryGetCost(buildingId, targetLevel, out var cost))
+                return UpgradeBuildingResult.NotUpgradeable;
+            if (!FactionEconomy.CanAfford(em, faction, cost)) return UpgradeBuildingResult.CannotAfford;
+            if (!FactionEconomy.Spend(em, faction, cost)) return UpgradeBuildingResult.CannotAfford;
+
+            // Capture base stats once. After this they NEVER change — the
+            // upgrade system always recomputes scaled values from base, so
+            // re-applying a level (save/load, frame race) can't double-bump.
+            if (!em.HasComponent<BuildingUpgradeState>(building))
+            {
+                int baseHp = em.HasComponent<Health>(building)
+                    ? em.GetComponentData<Health>(building).Max : 0;
+                float baseAtkCd = em.HasComponent<BuildingRangedAttack>(building)
+                    ? em.GetComponentData<BuildingRangedAttack>(building).Cooldown : 0f;
+                int basePop = em.HasComponent<PopulationProvider>(building)
+                    ? em.GetComponentData<PopulationProvider>(building).Amount : 0;
+
+                em.AddComponentData(building, new BuildingUpgradeState
+                {
+                    Level                  = 0,
+                    BaseHpMax              = baseHp,
+                    BaseAttackCooldown     = baseAtkCd,
+                    BasePopulationProvider = basePop,
+                });
+            }
+
+            // Stamp the in-progress timer.
+            em.AddComponentData(building, new BuildingUpgrading
+            {
+                Progress    = 0f,
+                Total       = BuildingUpgradeConfig.UpgradeDuration[targetLevel],
+                TargetLevel = targetLevel,
+            });
+
+            return UpgradeBuildingResult.Ok;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // HELPERS
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Map building entity -> upgrade-system-known id ("Hall" / "Barracks"
+        /// / "Hut"). Uses the marker tag components rather than presentation
+        /// id so the lookup keeps working through any future re-skinning.
+        /// </summary>
+        private static string ResolveBuildingId(EntityManager em, Entity e)
+        {
+            if (em.HasComponent<HallTag>(e))     return "Hall";
+            if (em.HasComponent<BarracksTag>(e)) return "Barracks";
+            if (em.HasComponent<HutTag>(e))      return "Hut";
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Faction has picked a culture iff its Hall carries FactionProgress.Culture
+        /// other than Cultures.None. Reading from the Hall avoids a separate
+        /// per-faction lookup table.
+        /// </summary>
+        private static bool FactionHasCulture(EntityManager em, Faction faction)
+        {
+            var query = em.CreateEntityQuery(
+                ComponentType.ReadOnly<HallTag>(),
+                ComponentType.ReadOnly<FactionTag>(),
+                ComponentType.ReadOnly<FactionProgress>());
+            using var ents = query.ToEntityArray(Unity.Collections.Allocator.Temp);
+            for (int i = 0; i < ents.Length; i++)
+            {
+                if (em.GetComponentData<FactionTag>(ents[i]).Value != faction) continue;
+                if (em.GetComponentData<FactionProgress>(ents[i]).Culture != Cultures.None) return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Return the next level's cost (or default if no further levels).
+        /// UI uses this to render "Upgrade — 200s 50i 15c" labels.
+        /// </summary>
+        public static bool TryGetNextCost(EntityManager em, Entity building, out Cost cost, out byte nextLevel)
+        {
+            cost = default;
+            nextLevel = 0;
+            if (!em.Exists(building) || !em.HasComponent<BuildingUpgradeable>(building)) return false;
+
+            byte current = em.HasComponent<BuildingUpgradeState>(building)
+                ? em.GetComponentData<BuildingUpgradeState>(building).Level : (byte)0;
+            if (current >= BuildingUpgradeConfig.MaxLevel) return false;
+
+            nextLevel = (byte)(current + 1);
+            string id = ResolveBuildingId(em, building);
+            return BuildingUpgradeConfig.TryGetCost(id, nextLevel, out cost);
+        }
+    }
+}

--- a/Assets/Scripts/Core/Commands/CommandTypes/UpgradeBuildingCommand.cs.meta
+++ b/Assets/Scripts/Core/Commands/CommandTypes/UpgradeBuildingCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 761869223d099654fa623b1c33062b2f

--- a/Assets/Scripts/Core/Components/BuildingUpgradeComponents.cs
+++ b/Assets/Scripts/Core/Components/BuildingUpgradeComponents.cs
@@ -1,0 +1,83 @@
+// File: Assets/Scripts/Core/Components/BuildingUpgradeComponents.cs
+// Components for the per-culture building upgrade system.
+//
+// Player flow: pick a culture (age-up), then click an Upgrade button on
+// the building portrait. Each upgrade level costs more, takes longer, and
+// applies cumulative stat bonuses (HP, training speed, attack rate) plus
+// a few per-building specials (Hall multi-target, Barracks gains attack
+// at lvl 3, House gains pop). Visual swap to the matching prefab is
+// handled in a follow-up PR.
+//
+// Levels run 0..3. 0 = uncultured (base stats). 1..3 = cultured tiers.
+// Components live in the global namespace to match the rest of
+// Core/Components/*.cs (BuildingComponents, CoreComponents, etc.).
+
+using Unity.Entities;
+
+/// <summary>
+/// Marker — this building type is upgradeable. Stamped at creation
+/// time on Hall, Barracks, Hut. Buildings without this tag never show
+/// an upgrade button and are skipped by the upgrade system.
+/// </summary>
+public struct BuildingUpgradeable : IComponentData { }
+
+/// <summary>
+/// Current upgrade level + captured base stats so re-applying a level
+/// always recomputes from base (idempotent — no double-bumping if a
+/// frame races or save/load replays the level).
+///
+/// Lazy-stamped by UpgradeBuildingCommandHelper.Execute on first
+/// upgrade attempt; absent on uncultured (lvl 0) buildings until then.
+/// </summary>
+public struct BuildingUpgradeState : IComponentData
+{
+    /// <summary>Current applied level (0..3). Bumped after BuildingUpgrading completes.</summary>
+    public byte Level;
+
+    /// <summary>Base Health.Max captured at first upgrade. Used to recompute scaled HP.</summary>
+    public int BaseHpMax;
+
+    /// <summary>
+    /// Base BuildingRangedAttack.Cooldown captured at first upgrade. 0 if the
+    /// building had no ranged attack at base (e.g. Barracks — gains attack
+    /// at lvl 3, so the system stamps a fresh cooldown at that point).
+    /// </summary>
+    public float BaseAttackCooldown;
+
+    /// <summary>
+    /// Base PopulationProvider.Amount captured at first upgrade. 0 if the
+    /// building wasn't a pop provider (e.g. Barracks). Used by Hut's
+    /// +5 pop per level rule.
+    /// </summary>
+    public int BasePopulationProvider;
+}
+
+/// <summary>
+/// Active upgrade in progress. Functions like UnderConstruction —
+/// blocks training and attack while ticking, and the upgrade system
+/// removes it when Progress >= Total and applies the level.
+///
+/// Time scales per level — higher levels cost more elapsed time.
+/// </summary>
+public struct BuildingUpgrading : IComponentData
+{
+    public float Progress;
+    public float Total;
+    public byte TargetLevel;
+}
+
+/// <summary>
+/// Result codes from UpgradeBuildingCommandHelper.Execute. Surfaced
+/// in AILogger output and (eventually) UI feedback. Lets the UI tell
+/// the player WHY a click didn't take.
+/// </summary>
+public enum UpgradeBuildingResult : byte
+{
+    Ok = 0,
+    NotUpgradeable,
+    AlreadyMaxLevel,
+    NoCulture,
+    AlreadyUpgrading,
+    UnderConstruction,
+    CannotAfford,
+}

--- a/Assets/Scripts/Core/Components/BuildingUpgradeComponents.cs.meta
+++ b/Assets/Scripts/Core/Components/BuildingUpgradeComponents.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 554bc3eda83c42441ac08c7c47f63e8d

--- a/Assets/Scripts/Core/Settings/BuildingUpgradeConfig.cs
+++ b/Assets/Scripts/Core/Settings/BuildingUpgradeConfig.cs
@@ -1,0 +1,126 @@
+// File: Assets/Scripts/Core/Settings/BuildingUpgradeConfig.cs
+// Static tables for the building upgrade system: per-level cost,
+// duration, and stat multipliers. Single source of truth — both the
+// command helper (cost check / spend) and the upgrade system (apply
+// stats) read from here.
+//
+// Stats are absolute over base, NOT cumulative. e.g., a Hall at lvl 2
+// has 1.15x base HP (not 1.10 * 1.15). This matches the spec phrasing
+// "Hall_al_2 (increase HP by 15%)" — single bump from uncultured base.
+
+using TheWaningBorder.Core;
+
+namespace TheWaningBorder.Core.Settings
+{
+    /// <summary>
+    /// Per-level configuration for the building upgrade system.
+    /// </summary>
+    public static class BuildingUpgradeConfig
+    {
+        public const byte MaxLevel = 3;
+
+        // ──────────────────────────────────────────────────────────────────
+        // STAT MULTIPLIERS (level 0..3 — index 0 = base, 1..3 = cultured)
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>HP multiplier vs base (1.0 = no change).</summary>
+        public static readonly float[] HpMultiplier = { 1.00f, 1.10f, 1.15f, 1.20f };
+
+        /// <summary>
+        /// Train-time multiplier vs base (lower = faster).
+        /// "Train speed +15%" means 15% MORE units per minute, so
+        /// trainTime *= 1 / 1.15 = 0.870.
+        /// </summary>
+        public static readonly float[] TrainTimeMultiplier = { 1.00f, 1f / 1.15f, 1f / 1.25f, 1f / 1.40f };
+
+        /// <summary>
+        /// Attack-cooldown multiplier vs base (lower = faster).
+        /// "Attack rate +10%" means 10% more shots per second, so
+        /// cooldown *= 1 / 1.10 = 0.909.
+        /// </summary>
+        public static readonly float[] AttackCooldownMultiplier = { 1.00f, 1f / 1.10f, 1f / 1.15f, 1f / 1.20f };
+
+        /// <summary>Hall multi-target count per level (1 / 1 / 2 / 4).</summary>
+        public static readonly int[] HallMaxTargets = { 1, 1, 2, 4 };
+
+        /// <summary>Hut +pop per level past base (0 / 5 / 10 / 15).</summary>
+        public static readonly int[] HutBonusPop = { 0, 5, 10, 15 };
+
+        // ──────────────────────────────────────────────────────────────────
+        // UPGRADE DURATIONS (seconds; index 1..3 corresponds to TARGET level)
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Time spent in BuildingUpgrading before stats apply. Index =
+        /// TARGET level. Index 0 unused (no upgrade to lvl 0).
+        /// </summary>
+        public static readonly float[] UpgradeDuration = { 0f, 20f, 30f, 45f };
+
+        // ──────────────────────────────────────────────────────────────────
+        // COSTS (per buildingId, per TARGET level)
+        // ──────────────────────────────────────────────────────────────────
+        //
+        // No glow for buildings (per spec). Costs scale roughly 2x per tier
+        // and add a higher-tier resource at each step (iron at L1, +crystal
+        // at L2/L3, +veilsteel at L3 for the Hall as the apex sink).
+
+        /// <summary>
+        /// Lookup cost for a given building type + target level. Returns
+        /// false if the combination isn't recognized.
+        /// </summary>
+        public static bool TryGetCost(string buildingId, byte targetLevel, out Cost cost)
+        {
+            cost = default;
+            if (targetLevel < 1 || targetLevel > MaxLevel) return false;
+
+            switch (buildingId)
+            {
+                case "Hall":
+                    cost = targetLevel switch
+                    {
+                        1 => new Cost { Supplies = 100, Iron = 25 },
+                        2 => new Cost { Supplies = 200, Iron = 50, Crystal = 15 },
+                        3 => new Cost { Supplies = 400, Iron = 100, Crystal = 40, Veilsteel = 5 },
+                        _ => default,
+                    };
+                    return true;
+                case "Barracks":
+                    cost = targetLevel switch
+                    {
+                        1 => new Cost { Supplies = 80, Iron = 20 },
+                        2 => new Cost { Supplies = 160, Iron = 40, Crystal = 10 },
+                        3 => new Cost { Supplies = 320, Iron = 80, Crystal = 30 },
+                        _ => default,
+                    };
+                    return true;
+                case "Hut":
+                    cost = targetLevel switch
+                    {
+                        1 => new Cost { Supplies = 60, Iron = 10 },
+                        2 => new Cost { Supplies = 120, Iron = 25, Crystal = 5 },
+                        3 => new Cost { Supplies = 240, Iron = 50, Crystal = 15 },
+                        _ => default,
+                    };
+                    return true;
+            }
+            return false;
+        }
+
+        // ──────────────────────────────────────────────────────────────────
+        // CULTURE CODE (for prefab lookups in PR-2 — kept here so all
+        // upgrade-related strings live in one place).
+        // ──────────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Two-letter culture code used in prefab filenames (al / ru / fe).
+        /// Returns empty string for None.
+        /// </summary>
+        public static string CultureCode(byte culture) => culture switch
+        {
+            Cultures.Alanthor => "al",
+            Cultures.Runai    => "ru",
+            Cultures.Feraldis => "fe",
+            _                 => string.Empty,
+        };
+    }
+}

--- a/Assets/Scripts/Core/Settings/BuildingUpgradeConfig.cs.meta
+++ b/Assets/Scripts/Core/Settings/BuildingUpgradeConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5515ef3e08c49124795b13b32cf5cb49

--- a/Assets/Scripts/Entities/Buildings/Barracks.cs
+++ b/Assets/Scripts/Entities/Buildings/Barracks.cs
@@ -68,6 +68,7 @@ namespace TheWaningBorder.Entities
 
             // Combat type tags
             em.AddComponentData(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            em.AddComponent<BuildingUpgradeable>(entity);
 
             return entity;
         }
@@ -113,6 +114,7 @@ namespace TheWaningBorder.Entities
 
             // Combat type tags
             ecb.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            ecb.AddComponent<BuildingUpgradeable>(entity);
 
             return entity;
         }

--- a/Assets/Scripts/Entities/Buildings/Hall.cs
+++ b/Assets/Scripts/Entities/Buildings/Hall.cs
@@ -59,6 +59,7 @@ namespace TheWaningBorder.Entities
             // Training queue buffer + rally point + ranged attack
             creator.AddBuffer<TrainQueueItem>(entity);
             creator.AddComponent<HallTag>(entity);
+            creator.AddComponent<BuildingUpgradeable>(entity);
             creator.AddComponent(entity, new RallyPoint { Position = position + new float3(5f, 0, 5f), Has = 1 });
             creator.AddComponent(entity, new BuildingRangedAttack
             {

--- a/Assets/Scripts/Entities/Buildings/Hut.cs
+++ b/Assets/Scripts/Entities/Buildings/Hut.cs
@@ -54,6 +54,7 @@ namespace TheWaningBorder.Entities
 
             // Combat type tags
             creator.AddComponent(entity, new ArmorTypeData { Value = ArmorType.StructureHuman });
+            creator.AddComponent<BuildingUpgradeable>(entity);
 
             return entity;
         }

--- a/Assets/Scripts/Systems/Buildings/BuildingUpgradeSystem.cs
+++ b/Assets/Scripts/Systems/Buildings/BuildingUpgradeSystem.cs
@@ -1,0 +1,155 @@
+// File: Assets/Scripts/Systems/Buildings/BuildingUpgradeSystem.cs
+// Ticks BuildingUpgrading on every upgradeable building. When Progress
+// >= Total, bump BuildingUpgradeState.Level and recompute scaled stats
+// from BASE values (NOT current — that way any reapply is idempotent).
+//
+// Per-building specials:
+//   - Hall: BuildingRangedAttack.MaxTargets follows BuildingUpgradeConfig.HallMaxTargets[level].
+//   - Barracks: gains BuildingRangedAttack at level 3 (component is added
+//       fresh — base cooldown captured here, not in command helper, since
+//       Barracks has no attack at level 0).
+//   - Hut: PopulationProvider.Amount = base + HutBonusPop[level].
+//
+// BuildingUpgrading is removed at completion. Training systems +
+// BuildingCombatSystem are gated WithNone<BuildingUpgrading> so the
+// building goes briefly inert during the upgrade.
+
+using Unity.Entities;
+using TheWaningBorder.Core.Settings;
+using TheWaningBorder.Economy;
+
+namespace TheWaningBorder.Systems.Buildings
+{
+    [UpdateInGroup(typeof(SimulationSystemGroup))]
+    public partial struct BuildingUpgradeSystem : ISystem
+    {
+        // Barracks — when it gains its first attack at level 3, use these.
+        // Mirrors Hall's stats from Hall.cs (Range 20, Damage 12, Cooldown 2.5s).
+        // Barracks is closer to a watchtower than a keep — same range/cooldown,
+        // slightly lower damage so it's not a strict Hall upgrade.
+        private const float BarracksAttackRange    = 18f;
+        private const int   BarracksAttackDamage   = 8;
+        private const float BarracksAttackCooldown = 2.5f;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BuildingUpgrading>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            float dt = SystemAPI.Time.DeltaTime;
+            var em = state.EntityManager;
+
+            // Snapshot — applying the level is a structural change for
+            // Barracks (adds BuildingRangedAttack), so we mustn't iterate
+            // SystemAPI.Query while doing it.
+            var query = em.CreateEntityQuery(ComponentType.ReadWrite<BuildingUpgrading>());
+            using var ents = query.ToEntityArray(Unity.Collections.Allocator.Temp);
+
+            for (int i = 0; i < ents.Length; i++)
+            {
+                var e = ents[i];
+                if (!em.Exists(e)) continue;
+
+                var up = em.GetComponentData<BuildingUpgrading>(e);
+                up.Progress += dt;
+
+                if (up.Progress < up.Total)
+                {
+                    em.SetComponentData(e, up);
+                    continue;
+                }
+
+                // ── Apply level ────────────────────────────────────────
+                ApplyLevel(em, e, up.TargetLevel);
+                em.RemoveComponent<BuildingUpgrading>(e);
+            }
+        }
+
+        /// <summary>
+        /// Set BuildingUpgradeState.Level = <paramref name="level"/> and
+        /// recompute scaled stats from BASE values. Always idempotent —
+        /// calling with the same level twice produces the same result.
+        /// </summary>
+        public static void ApplyLevel(EntityManager em, Entity building, byte level)
+        {
+            if (!em.HasComponent<BuildingUpgradeState>(building)) return;
+
+            var ups = em.GetComponentData<BuildingUpgradeState>(building);
+            ups.Level = level;
+            em.SetComponentData(building, ups);
+
+            // Health: scale Max from base, scale current proportionally so
+            // the visual HP bar stays at the same percentage. (Mid-combat
+            // upgrades don't suddenly heal or kill the building.)
+            if (em.HasComponent<Health>(building) && ups.BaseHpMax > 0)
+            {
+                int newMax = (int)(ups.BaseHpMax * BuildingUpgradeConfig.HpMultiplier[level]);
+                var hp = em.GetComponentData<Health>(building);
+                float pct = hp.Max > 0 ? (float)hp.Value / hp.Max : 1f;
+                hp.Max = newMax;
+                hp.Value = Unity.Mathematics.math.clamp((int)(newMax * pct), 0, newMax);
+                em.SetComponentData(building, hp);
+            }
+
+            // Attack: cooldown scales by AttackCooldownMultiplier. Hall +
+            // Barracks-at-lvl-3 also pull from HallMaxTargets where applicable.
+            ApplyAttackChanges(em, building, level, ups.BaseAttackCooldown);
+
+            // Hut: +5 pop per level.
+            if (em.HasComponent<HutTag>(building) && em.HasComponent<PopulationProvider>(building))
+            {
+                var pp = em.GetComponentData<PopulationProvider>(building);
+                pp.Amount = ups.BasePopulationProvider + BuildingUpgradeConfig.HutBonusPop[level];
+                em.SetComponentData(building, pp);
+            }
+        }
+
+        private static void ApplyAttackChanges(EntityManager em, Entity building,
+            byte level, float baseAttackCooldown)
+        {
+            bool isHall     = em.HasComponent<HallTag>(building);
+            bool isBarracks = em.HasComponent<BarracksTag>(building);
+
+            if (isHall && em.HasComponent<BuildingRangedAttack>(building))
+            {
+                // Already attacks — scale cooldown, set MaxTargets per level.
+                var atk = em.GetComponentData<BuildingRangedAttack>(building);
+                atk.Cooldown = baseAttackCooldown * BuildingUpgradeConfig.AttackCooldownMultiplier[level];
+                atk.MaxTargets = BuildingUpgradeConfig.HallMaxTargets[level];
+                em.SetComponentData(building, atk);
+            }
+            else if (isBarracks && level >= 3)
+            {
+                // Gain ranged attack on first arrival at lvl 3. Idempotent
+                // because we set the same fields whether component is new or old.
+                if (!em.HasComponent<BuildingRangedAttack>(building))
+                {
+                    em.AddComponentData(building, new BuildingRangedAttack
+                    {
+                        Range      = BarracksAttackRange,
+                        Damage     = BarracksAttackDamage,
+                        Cooldown   = BarracksAttackCooldown,
+                        Timer      = 0f,
+                        MaxTargets = 1,
+                    });
+                    // Barracks is normally not a damager — give it the standard
+                    // ranged damage type so the projectile path treats arrows correctly.
+                    if (!em.HasComponent<DamageTypeData>(building))
+                        em.AddComponentData(building, new DamageTypeData { Value = DamageType.Ranged });
+                }
+                else
+                {
+                    var atk = em.GetComponentData<BuildingRangedAttack>(building);
+                    atk.Range      = BarracksAttackRange;
+                    atk.Damage     = BarracksAttackDamage;
+                    atk.Cooldown   = BarracksAttackCooldown;
+                    atk.MaxTargets = 1;
+                    em.SetComponentData(building, atk);
+                }
+            }
+            // Hut + Barracks below lvl 3 — no attack changes.
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Buildings/BuildingUpgradeSystem.cs.meta
+++ b/Assets/Scripts/Systems/Buildings/BuildingUpgradeSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 680db0186b9610846960651b665ef926

--- a/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
+++ b/Assets/Scripts/Systems/Combat/BuildingCombatSystem.cs
@@ -44,7 +44,7 @@ namespace TheWaningBorder.Systems.Combat
             foreach (var (transform, attack, faction, entity) in SystemAPI
                 .Query<RefRO<LocalTransform>, RefRW<BuildingRangedAttack>, RefRO<FactionTag>>()
                 .WithAll<BuildingTag>()
-                .WithNone<UnderConstruction>()
+                .WithNone<UnderConstruction, BuildingUpgrading>()
                 .WithEntityAccess())
             {
                 // Tick cooldown

--- a/Assets/Scripts/Systems/Training/TrainingSystem.cs
+++ b/Assets/Scripts/Systems/Training/TrainingSystem.cs
@@ -64,6 +64,7 @@ namespace TheWaningBorder.Systems.Training
             foreach (var (ts, entity) in SystemAPI
                          .Query<RefRW<TrainingState>>()
                          .WithNone<UnderConstruction, BatchTrainingTag, AgeUpState>()
+                         .WithNone<BuildingUpgrading>()
                          .WithEntityAccess())
             {
                 var queue = state.EntityManager.GetBuffer<TrainQueueItem>(entity);
@@ -100,6 +101,15 @@ namespace TheWaningBorder.Systems.Training
                             SectConfig.War, SectLeverKind.Passive);
                         if (warLevel > 0)
                             trainingTime *= WarSectCostHelper.TrainTimeMultiplierFor(warLevel);
+                    }
+
+                    // Building upgrade: cultured Hall/Barracks train faster.
+                    // Multiplier is 1.0 at lvl 0 and shrinks per level.
+                    if (state.EntityManager.HasComponent<BuildingUpgradeState>(entity))
+                    {
+                        byte upLevel = state.EntityManager.GetComponentData<BuildingUpgradeState>(entity).Level;
+                        trainingTime *= TheWaningBorder.Core.Settings.BuildingUpgradeConfig
+                            .TrainTimeMultiplier[upLevel];
                     }
 
                     ts.ValueRW.Busy = 1;

--- a/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
+++ b/Assets/Scripts/UI/Panels/EntityInfoPanel.cs
@@ -9,6 +9,7 @@ using TWB_Input = TheWaningBorder.Input;
 using TheWaningBorder.UI;
 using TheWaningBorder.UI.Common;
 using TheWaningBorder.UI.HUD;
+using TheWaningBorder.Core.Commands.Types;
 
 namespace TheWaningBorder.UI.Panels
 {
@@ -158,6 +159,11 @@ namespace TheWaningBorder.UI.Panels
 
             GUILayout.EndVertical();
             GUILayout.EndHorizontal();
+
+            // Upgrade button — appears next to the portrait area for any
+            // upgradeable building owned by the local player whose faction
+            // has picked a culture. Click triggers UpgradeBuildingCommandHelper.
+            DrawUpgradeButton();
 
             GUILayout.Space(10);
 
@@ -887,5 +893,99 @@ namespace TheWaningBorder.UI.Panels
             );
             return screenRect.Contains(mousePos);
         }
+
+        // ──────────────────────────────────────────────────────────────────
+        // BUILDING UPGRADE BUTTON
+        // ──────────────────────────────────────────────────────────────────
+
+        // Brief feedback line shown under the upgrade button — reflects the
+        // last command result so the player understands why a click stuck
+        // (or didn't). Clears after BuildingUpgradeFeedbackTimeout seconds.
+        private string _upgradeFeedback;
+        private float _upgradeFeedbackUntil;
+        private const float BuildingUpgradeFeedbackTimeout = 3f;
+
+        private void DrawUpgradeButton()
+        {
+            var entity = UnifiedUIManager.GetFirstSelectedEntity();
+            var em = UnifiedUIManager.GetEntityManager();
+            if (entity == Entity.Null || em.Equals(default(EntityManager))) return;
+            if (!em.Exists(entity)) return;
+            if (!em.HasComponent<BuildingUpgradeable>(entity)) return;
+
+            // Local-player only — no upgrade button on enemy buildings.
+            if (!em.HasComponent<FactionTag>(entity)) return;
+            var fac = em.GetComponentData<FactionTag>(entity).Value;
+            if (fac != GameSettings.LocalPlayerFaction) return;
+
+            // Already at max?
+            byte currentLevel = em.HasComponent<BuildingUpgradeState>(entity)
+                ? em.GetComponentData<BuildingUpgradeState>(entity).Level : (byte)0;
+            bool atMax = currentLevel >= TheWaningBorder.Core.Settings.BuildingUpgradeConfig.MaxLevel;
+
+            // In progress?
+            bool upgrading = em.HasComponent<BuildingUpgrading>(entity);
+
+            GUILayout.Space(6);
+            GUILayout.BeginHorizontal();
+
+            if (upgrading)
+            {
+                var ub = em.GetComponentData<BuildingUpgrading>(entity);
+                float pct = ub.Total > 0f ? Mathf.Clamp01(ub.Progress / ub.Total) : 0f;
+                GUILayout.Label($"Upgrading to L{ub.TargetLevel}... {(int)(pct * 100f)}%",
+                    Styles.Label);
+            }
+            else if (atMax)
+            {
+                GUILayout.Label($"Lvl {currentLevel} (max)", Styles.Label);
+            }
+            else if (UpgradeBuildingCommandHelper.TryGetNextCost(em, entity,
+                out var cost, out byte nextLevel))
+            {
+                string costLabel = FormatCost(cost);
+                bool clicked = GUILayout.Button($"Upgrade to L{nextLevel} — {costLabel}");
+                if (clicked)
+                {
+                    var result = UpgradeBuildingCommandHelper.Execute(em, entity);
+                    _upgradeFeedback = FeedbackFor(result);
+                    _upgradeFeedbackUntil = Time.realtimeSinceStartup + BuildingUpgradeFeedbackTimeout;
+                }
+            }
+
+            GUILayout.EndHorizontal();
+
+            if (!string.IsNullOrEmpty(_upgradeFeedback)
+                && Time.realtimeSinceStartup < _upgradeFeedbackUntil)
+            {
+                GUILayout.Label(_upgradeFeedback, Styles.SmallLabel);
+            }
+        }
+
+        private static string FormatCost(TheWaningBorder.Core.Cost c)
+        {
+            // Compact inline display: "100s 25i" or "200s 50i 15c". Skip
+            // zeros so the button label stays short.
+            var sb = new System.Text.StringBuilder(24);
+            if (c.Supplies > 0)  sb.Append(c.Supplies).Append("s ");
+            if (c.Iron > 0)      sb.Append(c.Iron).Append("i ");
+            if (c.Crystal > 0)   sb.Append(c.Crystal).Append("c ");
+            if (c.Veilsteel > 0) sb.Append(c.Veilsteel).Append("v ");
+            if (c.Glow > 0)      sb.Append(c.Glow).Append("g ");
+            if (sb.Length == 0)  return "free";
+            return sb.ToString().TrimEnd();
+        }
+
+        private static string FeedbackFor(UpgradeBuildingResult r) => r switch
+        {
+            UpgradeBuildingResult.Ok                 => "Upgrade started.",
+            UpgradeBuildingResult.NotUpgradeable     => "Cannot upgrade this building.",
+            UpgradeBuildingResult.AlreadyMaxLevel    => "Already at max level.",
+            UpgradeBuildingResult.NoCulture          => "Pick a culture (age up) first.",
+            UpgradeBuildingResult.AlreadyUpgrading   => "Already upgrading.",
+            UpgradeBuildingResult.UnderConstruction  => "Finish construction first.",
+            UpgradeBuildingResult.CannotAfford       => "Not enough resources.",
+            _                                        => string.Empty,
+        };
     }
 }


### PR DESCRIPTION
PR 1 of 3 for the building upgrade system. Adds the data model, command helper, ticking system, UI button on the entity portrait, training-time hookup, and a generic AI driver. No prefab swaps yet (PR 2). Combat works for Hall (already had BuildingRangedAttack) and Barracks gains attack at L3 via the upgrade system.

## Spec (3 levels per culture, no glow for buildings)
- Hall: HP/train/attack-rate scale; multi-target 1/2/4 at L1/2/3.
- Barracks: HP/train scale; gains arrow attack at L3.
- Hut: HP/train scale; +5 pop per level.

## Cost table
- Hall L1: 100s/25i; L2: 200s/50i/15c; L3: 400s/100i/40c/5v.
- Barracks/Hut scale similarly. Glow excluded per spec.

## Test plan
- [ ] Place Hall, age up, pick culture; click Upgrade L1; confirm HP rises 10%, train speed up 15%, cooldown shorter.
- [ ] Upgrade Hall L2/3; confirm BuildingRangedAttack.MaxTargets = 2/4.
- [ ] Upgrade Barracks to L3; confirm it starts shooting arrows.
- [ ] Upgrade Hut L1/2/3; confirm pop max increases by 5/10/15.
- [ ] Confirm AI faction queues upgrades after age-up.

?? Generated with Claude Code